### PR TITLE
add osgi support via maven-bundle-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,9 @@
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
+                        <manifestFile>
+                            ${project.build.outputDirectory}/META-INF/MANIFEST.MF
+                        </manifestFile>
                     </archive>
                 </configuration>
             </plugin>
@@ -263,6 +266,21 @@
                     <arguments>-Psonatype-oss-release -Pdocs -Psign</arguments>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.5</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
I have tested jjwt as bundle in Equinox Kepler SR1 and it is completely okay! Bundle is resolved:

    59      RESOLVED    io.jsonwebtoken.jjwt_0.5.0.SNAPSHOT

This code:

    byte[] key = new byte[64];
    new SecureRandom().nextBytes(key);
    
    String compact = Jwts.builder().setSubject("Joe").signWith(SignatureAlgorithm.HS256, key).compact();
    
    if (Jwts.parser().setSigningKey(key).parseClaimsJws(compact).getBody().getSubject().equals("Joe")) {
        System.out.println("Jjwt is okay");
    }

And it prints as expected:

    Jjwt is okay

In continue of https://github.com/jwtk/jjwt/issues/19