### PR TITLE
Expiration extension for parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <maven.jar.version>2.4</maven.jar.version>
         <maven.compiler.version>3.1</maven.compiler.version>
 
-        <jdk.version>1.6</jdk.version>
+        <jdk.version>1.7</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <buildNumber>${user.name}-${maven.build.timestamp}</buildNumber>
 

--- a/src/main/java/io/jsonwebtoken/JwtParser.java
+++ b/src/main/java/io/jsonwebtoken/JwtParser.java
@@ -234,7 +234,16 @@ public interface JwtParser {
      * @return the parser for method chaining.
      * @since 0.7.0
      */
-    JwtParser setExpirationExtension(long expirationExtension);
+    JwtParser setExpirationExtensionMillis(long expirationExtensionMillis);
+    
+    /**
+     * Time skew for premature and expiration timeout. 
+     * 
+     * @param driftTimeMillis time skew in milliseconds
+     * @return the parser for method chaining.
+     * @since 0.7.0
+     */
+    JwtParser setDriftTimeMillis(long driftTimeMillis);
 
     /**
      * Returns {@code true} if the specified JWT compact string represents a signed JWT (aka a 'JWS'), {@code false}

--- a/src/main/java/io/jsonwebtoken/JwtParser.java
+++ b/src/main/java/io/jsonwebtoken/JwtParser.java
@@ -228,6 +228,15 @@ public interface JwtParser {
     JwtParser setCompressionCodecResolver(CompressionCodecResolver compressionCodecResolver);
 
     /**
+     * In some cases you need to accept a token even after it is expired.
+     * 
+     * @param expirationExtension in milliseconds
+     * @return the parser for method chaining.
+     * @since 0.7.0
+     */
+    JwtParser setExpirationExtension(long expirationExtension);
+
+    /**
      * Returns {@code true} if the specified JWT compact string represents a signed JWT (aka a 'JWS'), {@code false}
      * otherwise.
      * <p>

--- a/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
@@ -190,6 +190,32 @@ class JwtParserTest {
             assertTrue e.getMessage().startsWith('JWT must not be accepted before ')
         }
     }
+    
+    @Test
+    void testParseWithExtendedExpirationJwt() {
+    
+        Date exp = new Date(System.currentTimeMillis() - 1000)
+
+        String compact = Jwts.builder().setSubject('Joe').setExpiration(exp).compact()
+
+		Jwts.parser().setExpirationExtension(2000).parse(compact)
+
+    }
+    
+    @Test
+    void testParseWithExtendedExpirationButStillExpiredJwt() {
+    
+    	Date exp = new Date(System.currentTimeMillis() - 2000)
+
+        String compact = Jwts.builder().setSubject('Joe').setExpiration(exp).compact()
+
+        try {
+            Jwts.parser().setExpirationExtension(1000).parse(compact)
+            fail()
+        } catch (ExpiredJwtException e) {
+            assertTrue e.getMessage().startsWith('JWT expired at ')
+        }     
+    }
 
     // ========================================================================
     // parsePlaintextJwt tests

--- a/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
@@ -194,27 +194,84 @@ class JwtParserTest {
     @Test
     void testParseWithExtendedExpirationJwt() {
     
-        Date exp = new Date(System.currentTimeMillis() - 1000)
+        Date exp = new Date(System.currentTimeMillis() - 10000)
 
         String compact = Jwts.builder().setSubject('Joe').setExpiration(exp).compact()
 
-		Jwts.parser().setExpirationExtension(2000).parse(compact)
+		Jwts.parser().setExpirationExtensionMillis(20000).parse(compact)
 
     }
     
     @Test
     void testParseWithExtendedExpirationButStillExpiredJwt() {
     
-    	Date exp = new Date(System.currentTimeMillis() - 2000)
+    	Date exp = new Date(System.currentTimeMillis() - 20000)
 
         String compact = Jwts.builder().setSubject('Joe').setExpiration(exp).compact()
 
         try {
-            Jwts.parser().setExpirationExtension(1000).parse(compact)
+            Jwts.parser().setExpirationExtensionMillis(10000).parse(compact)
             fail()
         } catch (ExpiredJwtException e) {
             assertTrue e.getMessage().startsWith('JWT expired at ')
         }     
+    }
+    
+    @Test
+    void testParseWithDriftTimeJwt() {
+    
+        Date exp = new Date(System.currentTimeMillis() - 3000)
+
+        String compact = Jwts.builder().setSubject('Joe').setExpiration(exp).compact()
+
+		Jwts.parser().setDriftTimeMillis(10000).parse(compact)
+    
+        exp = new Date(System.currentTimeMillis() + 3000)
+
+        compact = Jwts.builder().setSubject('Joe').setNotBefore(exp).compact()
+
+		Jwts.parser().setDriftTimeMillis(10000).parse(compact)
+    }
+    
+    @Test
+    void testParseWithDriftTimeButStillExpiredJwt() {
+    
+    	Date exp = new Date(System.currentTimeMillis() - 20000)
+
+        String compact = Jwts.builder().setSubject('Joe').setExpiration(exp).compact()
+
+        try {
+            Jwts.parser().setDriftTimeMillis(10000).parse(compact)
+            fail()
+        } catch (ExpiredJwtException e) {
+            assertTrue e.getMessage().startsWith('JWT expired at ')
+        }     
+    }
+    
+    @Test
+    void testParseWithDriftTimeButStillPrematureJwt() {
+    
+    	Date exp = new Date(System.currentTimeMillis() + 20000)
+
+        String compact = Jwts.builder().setSubject('Joe').setNotBefore(exp).compact()
+
+        try {
+            Jwts.parser().setDriftTimeMillis(10000).parse(compact)
+            fail()
+        } catch (PrematureJwtException e) {
+            assertTrue e.getMessage().startsWith('JWT must not be accepted before ')
+        }     
+    }
+    
+    @Test
+    void testParseWithDriftTimeAndExpirationExtensionJwt() {
+    
+        Date exp = new Date(System.currentTimeMillis() - 30000)
+		Date notBefore = new Date(System.currentTimeMillis() + 3000)
+		
+        String compact = Jwts.builder().setSubject('Joe').setExpiration(exp).setNotBefore(notBefore).compact()
+
+		Jwts.parser().setDriftTimeMillis(10000).setExpirationExtensionMillis(50000).parse(compact)
     }
 
     // ========================================================================


### PR DESCRIPTION
In some cases I need to accept even expired token.
I've added a setting to the parser:
```
Jwts.parser().setExpirationExtension(2000).parse(compact)
```
which would extend the expiration time by the provided value (in milliseconds).

If you like the feature and accept the pull request, it would help us continue to use the official release instead of our fork.

Thank you,
Eugene

