### PR TITLE
Add ignoreExpiry(), ignoreNotBefore() and ignoreSignature() to JwtPa…

### DIFF
--- a/src/main/java/io/jsonwebtoken/JwtParser.java
+++ b/src/main/java/io/jsonwebtoken/JwtParser.java
@@ -28,6 +28,36 @@ public interface JwtParser {
     public static final char SEPARATOR_CHAR = '.';
 
     /**
+     * Do not validate the {@code exp} claim when parsing the JWT.
+     * <p>
+     * <p>Note that this circumvents security features of JWT.</p>
+     *
+     * @return the parser for method chaining.
+     * @see ExpiredJwtException
+     */
+    JwtParser ignoreExpiry();
+
+    /**
+     * Do not validate the {@code nbf} claim when parsing the JWT.
+     * <p>
+     * <p>Note that this circumvents security features of JWT.</p>
+
+     * @return the parser for method chaining.
+     * @see PrematureJwtException
+     */
+    JwtParser ignoreNotBefore();
+
+    /**
+     * Do not validate the JWS digital signature.
+     * <p>
+     * <p>Note that this circumvents security features of JWT and JWS.</p>
+     *
+     * @return the parser for method chaining.
+     * @see SignatureException
+     */
+    JwtParser ignoreSignature();
+
+    /**
      * Ensures that the specified {@code jti} exists in the parsed JWT.  If missing or if the parsed
      * value does not equal the specified value, an exception will be thrown indicating that the
      * JWT is invalid and may not be used.

--- a/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -69,6 +69,33 @@ public class DefaultJwtParser implements JwtParser {
 
     Claims expectedClaims = new DefaultClaims();
 
+    private boolean ignoreExpiry = false;
+
+    private boolean ignoreNotBefore = false;
+
+    private boolean ignoreSignature = false;
+
+    @Override
+    public JwtParser ignoreExpiry() {
+        ignoreExpiry = true;
+
+        return this;
+    }
+
+    @Override
+    public JwtParser ignoreNotBefore() {
+        ignoreNotBefore = true;
+
+        return this;
+    }
+
+    @Override
+    public JwtParser ignoreSignature() {
+        ignoreSignature = true;
+
+        return this;
+    }
+
     @Override
     public JwtParser requireIssuedAt(Date issuedAt) {
         expectedClaims.setIssuedAt(issuedAt);
@@ -265,7 +292,7 @@ public class DefaultJwtParser implements JwtParser {
         }
 
         // =============== Signature =================
-        if (base64UrlEncodedDigest != null) { //it is signed - validate the signature
+        if (base64UrlEncodedDigest != null && !ignoreSignature) { //it is signed - validate the signature
 
             JwsHeader jwsHeader = (JwsHeader) header;
 
@@ -352,7 +379,7 @@ public class DefaultJwtParser implements JwtParser {
             //https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-30#section-4.1.4
             //token MUST NOT be accepted on or after any specified exp time:
             Date exp = claims.getExpiration();
-            if (exp != null) {
+            if (exp != null && !ignoreExpiry) {
 
                 now = new Date();
 
@@ -369,7 +396,7 @@ public class DefaultJwtParser implements JwtParser {
             //https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-30#section-4.1.5
             //token MUST NOT be accepted before any specified nbf time:
             Date nbf = claims.getNotBefore();
-            if (nbf != null) {
+            if (nbf != null && !ignoreNotBefore) {
 
                 if (now == null) {
                     now = new Date();

--- a/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
@@ -125,6 +125,23 @@ class JwtParserTest {
     }
 
     @Test
+    void testParseWithIgnoreInvalidSignature() {
+
+        String header = '{"alg":"HS256"}'
+
+        String payload = '{"subject":"Joe"}'
+
+        String badSig = ";aklsjdf;kajsd;fkjas;dklfj"
+
+        String bad = TextCodec.BASE64.encode(header) + '.' +
+                TextCodec.BASE64.encode(payload) + '.' +
+                TextCodec.BASE64.encode(badSig)
+
+        Jwts.parser().setSigningKey(randomKey()).ignoreSignature().parse(bad)
+
+    }
+
+    @Test
     void testParsePlaintextJwsWithIncorrectAlg() {
 
         String header = '{"alg":"none"}'
@@ -177,6 +194,17 @@ class JwtParserTest {
     }
 
     @Test
+    void testParseWithIgnoreExpiredJwt() {
+
+        Date exp = new Date(System.currentTimeMillis() - 1000)
+
+        String compact = Jwts.builder().setSubject('Joe').setExpiration(exp).compact()
+
+        Jwts.parser().ignoreExpiry().parse(compact)
+
+    }
+
+    @Test
     void testParseWithPrematureJwt() {
 
         Date nbf = new Date(System.currentTimeMillis() + 100000)
@@ -189,6 +217,17 @@ class JwtParserTest {
         } catch (PrematureJwtException e) {
             assertTrue e.getMessage().startsWith('JWT must not be accepted before ')
         }
+    }
+
+    @Test
+    void testParseWithIgnorePrematureJwt() {
+
+        Date nbf = new Date(System.currentTimeMillis() + 100000)
+
+        String compact = Jwts.builder().setSubject('Joe').setNotBefore(nbf).compact()
+
+        Jwts.parser().ignoreNotBefore().parse(compact)
+
     }
 
     // ========================================================================


### PR DESCRIPTION
Add ignoreExpiry(), ignoreNotBefore() and ignoreSignature() to JwtParser to skip validations when parsing JWT.

I need to parse some information out of the token, but I'm not too concerned about the validity of the token.

In particular, I'm extracting the subject for logging and the token will either already be validated (I don't have the key) and I would still like to log the username (subject) in case of any errors, even if it can't be trusted.
