### PR TITLE
#61: Add support for clock skew to JwtParser for exp and nbf claims

### DIFF
--- a/src/main/java/io/jsonwebtoken/JwtParser.java
+++ b/src/main/java/io/jsonwebtoken/JwtParser.java
@@ -137,6 +137,16 @@ public interface JwtParser {
     JwtParser setClock(Clock clock);
 
     /**
+     * Sets the amount of clock skew in seconds to tolerate when verifying the local time against the {@code exp}
+     * and {@code nbf} claims.
+     *
+     * @param seconds
+     * @return the parser for method chaining.
+     * @since 0.7.0
+     */
+    JwtParser setAllowedClockSkewInSeconds(int seconds);
+
+    /**
      * Sets the signing key used to verify any discovered JWS digital signature.  If the specified JWT string is not
      * a JWS (no signature), this key is not used.
      * <p>

--- a/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
@@ -193,6 +193,58 @@ class JwtParserTest {
         }
     }
 
+    @Test
+    void testParseWithExpiredJwtWithinAllowedClockSkew() {
+        Date exp = new Date(System.currentTimeMillis() - 3000)
+
+        String subject = 'Joe'
+        String compact = Jwts.builder().setSubject(subject).setExpiration(exp).compact()
+
+        Jwt<Header,Claims> jwt = Jwts.parser().setAllowedClockSkewInSeconds(10).parse(compact)
+
+        assertEquals jwt.getBody().getSubject(), subject
+    }
+
+    @Test
+    void testParseWithExpiredJwtNotWithinAllowedClockSkew() {
+        Date exp = new Date(System.currentTimeMillis() - 3000)
+
+        String compact = Jwts.builder().setSubject('Joe').setExpiration(exp).compact()
+
+        try {
+            Jwts.parser().setAllowedClockSkewInSeconds(1).parse(compact)
+            fail()
+        } catch (ExpiredJwtException e) {
+            assertTrue e.getMessage().startsWith('JWT expired at ')
+        }
+    }
+
+    @Test
+    void testParseWithPrematureJwtWithinAllowedClockSkew() {
+        Date exp = new Date(System.currentTimeMillis() + 3000)
+
+        String subject = 'Joe'
+        String compact = Jwts.builder().setSubject(subject).setNotBefore(exp).compact()
+
+        Jwt<Header,Claims> jwt = Jwts.parser().setAllowedClockSkewInSeconds(10).parse(compact)
+
+        assertEquals jwt.getBody().getSubject(), subject
+    }
+
+    @Test
+    void testParseWithPrematureJwtNotWithinAllowedClockSkew() {
+        Date exp = new Date(System.currentTimeMillis() + 3000)
+
+        String compact = Jwts.builder().setSubject('Joe').setNotBefore(exp).compact()
+
+        try {
+            Jwts.parser().setAllowedClockSkewInSeconds(1).parse(compact)
+            fail()
+        } catch (PrematureJwtException e) {
+            assertTrue e.getMessage().startsWith('JWT must not be accepted before ')
+        }
+    }
+
     // ========================================================================
     // parsePlaintextJwt tests
     // ========================================================================


### PR DESCRIPTION
I realize there is an existing pull request that references this issue, but it combines an implementation for the issue with another related but separate one. Thought there might be some value in having one that addresses this issue directly as an alternative. (This is my first pull request, my apologies if I've unwittingly committed a faux pas.)