### PR TITLE
Made the android dep optional in OSGi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.5</version>
+                <version>3.0.1</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -366,6 +366,17 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <instructions>
+                        <Import-Package><![CDATA[
+                            android.util;resolution:=optional,
+                            org.bouncycastle.jce;resolution:=optional,
+                            org.bouncycastle.jce.spec;resolution:=optional,
+                            *
+                        ]]>
+                        </Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>


### PR DESCRIPTION
Changed the packaging type to bundle - required
by the bundle plugin.

Upgraded to the latest version of the maven
bundle plugin.