### PR TITLE
allow the injection of a time source

### DIFF
--- a/src/main/java/io/jsonwebtoken/Clock.java
+++ b/src/main/java/io/jsonwebtoken/Clock.java
@@ -1,0 +1,7 @@
+package io.jsonwebtoken;
+
+import java.util.Date;
+
+public interface Clock {
+    Date now();
+}

--- a/src/main/java/io/jsonwebtoken/DefaultClock.java
+++ b/src/main/java/io/jsonwebtoken/DefaultClock.java
@@ -1,0 +1,10 @@
+package io.jsonwebtoken;
+
+import java.util.Date;
+
+public class DefaultClock implements Clock {
+    @Override
+    public Date now() {
+        return new Date();
+    }
+}

--- a/src/main/java/io/jsonwebtoken/JwtParser.java
+++ b/src/main/java/io/jsonwebtoken/JwtParser.java
@@ -125,13 +125,13 @@ public interface JwtParser {
     JwtParser require(String claimName, Object value);
 
     /**
-     * Replaces the system time-of-day call to return this fixed value instead. A {@code null} value will remove
-     * the fixed date output and return the system time-of-day instead.
+     * Replace the {@code clock} used by the parser to determine the current time-of-day to use when validating
+     * the parsed JWT. If {@code null}, will reset the behavior to use the system clock.
      *
-     * @param now the time-of-day to use for parsimg this JWT or {@code null} to use the current time-of-day
+     * @param clock a {@code Clock} object to return the time-of-day or {@code null}
      * @return the builder instance for method chaining.
      */
-    JwtParser setFixedClock(Date now);
+    JwtParser setClock(Clock clock);
 
     /**
      * Sets the signing key used to verify any discovered JWS digital signature.  If the specified JWT string is not

--- a/src/main/java/io/jsonwebtoken/JwtParser.java
+++ b/src/main/java/io/jsonwebtoken/JwtParser.java
@@ -125,6 +125,15 @@ public interface JwtParser {
     JwtParser require(String claimName, Object value);
 
     /**
+     * Replaces the system time-of-day call to return this fixed value instead. A {@code null} value will remove
+     * the fixed date output and return the system time-of-day instead.
+     *
+     * @param now the time-of-day to use for parsimg this JWT or {@code null} to use the current time-of-day
+     * @return the builder instance for method chaining.
+     */
+    JwtParser setFixedClock(Date now);
+
+    /**
      * Sets the signing key used to verify any discovered JWS digital signature.  If the specified JWT string is not
      * a JWS (no signature), this key is not used.
      * <p>

--- a/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -18,8 +18,10 @@ package io.jsonwebtoken.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.ClaimJwtException;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Clock;
 import io.jsonwebtoken.CompressionCodec;
 import io.jsonwebtoken.CompressionCodecResolver;
+import io.jsonwebtoken.DefaultClock;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.IncorrectClaimException;
@@ -69,7 +71,7 @@ public class DefaultJwtParser implements JwtParser {
 
     Claims expectedClaims = new DefaultClaims();
 
-    private Date now = new Date();
+    private Clock clock = new DefaultClock();
 
     @Override
     public JwtParser requireIssuedAt(Date issuedAt) {
@@ -130,11 +132,11 @@ public class DefaultJwtParser implements JwtParser {
     }
 
     @Override
-    public JwtParser setFixedClock(Date now) {
-        if (now == null) {
-            this.now = new Date();
+    public JwtParser setClock(Clock clock) {
+        if (clock == null) {
+            this.clock = new DefaultClock();
         } else {
-            this.now = now;
+            this.clock = clock;
         }
 
         return this;
@@ -360,6 +362,8 @@ public class DefaultJwtParser implements JwtParser {
         if (claims != null) {
 
             SimpleDateFormat sdf;
+
+            final Date now = this.clock.now();
 
             //https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-30#section-4.1.4
             //token MUST NOT be accepted on or after any specified exp time:

--- a/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -69,6 +69,8 @@ public class DefaultJwtParser implements JwtParser {
 
     Claims expectedClaims = new DefaultClaims();
 
+    private Date now = new Date();
+
     @Override
     public JwtParser requireIssuedAt(Date issuedAt) {
         expectedClaims.setIssuedAt(issuedAt);
@@ -123,6 +125,17 @@ public class DefaultJwtParser implements JwtParser {
         Assert.hasText(claimName, "claim name cannot be null or empty.");
         Assert.notNull(value, "The value cannot be null for claim name: " + claimName);
         expectedClaims.put(claimName, value);
+
+        return this;
+    }
+
+    @Override
+    public JwtParser setFixedClock(Date now) {
+        if (now == null) {
+            this.now = new Date();
+        } else {
+            this.now = now;
+        }
 
         return this;
     }
@@ -346,15 +359,12 @@ public class DefaultJwtParser implements JwtParser {
         //since 0.3:
         if (claims != null) {
 
-            Date now = null;
             SimpleDateFormat sdf;
 
             //https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-30#section-4.1.4
             //token MUST NOT be accepted on or after any specified exp time:
             Date exp = claims.getExpiration();
             if (exp != null) {
-
-                now = new Date();
 
                 if (now.equals(exp) || now.after(exp)) {
                     sdf = new SimpleDateFormat(ISO_8601_FORMAT);
@@ -370,10 +380,6 @@ public class DefaultJwtParser implements JwtParser {
             //token MUST NOT be accepted before any specified nbf time:
             Date nbf = claims.getNotBefore();
             if (nbf != null) {
-
-                if (now == null) {
-                    now = new Date();
-                }
 
                 if (now.before(nbf)) {
                     sdf = new SimpleDateFormat(ISO_8601_FORMAT);

--- a/src/main/java/io/jsonwebtoken/impl/FixedClock.java
+++ b/src/main/java/io/jsonwebtoken/impl/FixedClock.java
@@ -1,0 +1,22 @@
+package io.jsonwebtoken.impl;
+
+import io.jsonwebtoken.Clock;
+
+import java.util.Date;
+
+public class FixedClock implements Clock {
+    private final Date now;
+
+    public FixedClock() {
+        this(new Date());
+    }
+
+    public FixedClock(Date now) {
+        this.now = now;
+    }
+
+    @Override
+    public Date now() {
+        return this.now;
+    }
+}

--- a/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
@@ -15,6 +15,7 @@
  */
 package io.jsonwebtoken
 
+import io.jsonwebtoken.impl.FixedClock
 import io.jsonwebtoken.impl.TextCodec
 import org.junit.Test
 
@@ -1394,13 +1395,41 @@ class JwtParserTest {
     }
 
     @Test
-    void testParseClockManipulation() {
+    void testParseClockManipulationWithFixedClock() {
         def then = System.currentTimeMillis() - 1000
         Date expiry = new Date(then)
         Date beforeExpiry = new Date(then - 1000)
 
         String compact = Jwts.builder().setSubject('Joe').setExpiration(expiry).compact()
 
-        Jwts.parser().setFixedClock(beforeExpiry).parse(compact)
+        Jwts.parser().setClock(new FixedClock(beforeExpiry)).parse(compact)
+    }
+
+    @Test
+    void testParseClockManipulationWithNullClock() {
+        Date expiry = new Date(System.currentTimeMillis() - 1000)
+
+        String compact = Jwts.builder().setSubject('Joe').setExpiration(expiry).compact()
+
+        try {
+            Jwts.parser().setClock(null).parse(compact)
+            fail()
+        } catch (ExpiredJwtException e) {
+            assertTrue e.getMessage().startsWith('JWT expired at ')
+        }
+    }
+
+    @Test
+    void testParseClockManipulationWithDefaultClock() {
+        Date expiry = new Date(System.currentTimeMillis() - 1000)
+
+        String compact = Jwts.builder().setSubject('Joe').setExpiration(expiry).compact()
+
+        try {
+            Jwts.parser().setClock(new DefaultClock()).parse(compact)
+            fail()
+        } catch (ExpiredJwtException e) {
+            assertTrue e.getMessage().startsWith('JWT expired at ')
+        }
     }
 }

--- a/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
@@ -1392,4 +1392,15 @@ class JwtParserTest {
             )
         }
     }
+
+    @Test
+    void testParseClockManipulation() {
+        def then = System.currentTimeMillis() - 1000
+        Date expiry = new Date(then)
+        Date beforeExpiry = new Date(then - 1000)
+
+        String compact = Jwts.builder().setSubject('Joe').setExpiration(expiry).compact()
+
+        Jwts.parser().setFixedClock(beforeExpiry).parse(compact)
+    }
 }


### PR DESCRIPTION
This PR allows the injection of a clock source into the JwtParser for cases where we need to control the clock used during parsing.

