### PR TITLE
Removed openjdk7 from travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: java
 
 jdk:
-  - openjdk7
   - oraclejdk7
   - oraclejdk8
 


### PR DESCRIPTION
Resolves #97 

Oracle JDK 7 works fine and JDK 7 is end-of-life anyway