### PR TITLE
Avoid potentially critical vulnerability in ECDSA signature validation

### DIFF
--- a/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -312,6 +312,9 @@ public class DefaultJwtParser implements JwtParser {
                     Assert.isTrue(!algorithm.isRsa(),
                                   "Key bytes cannot be specified for RSA signatures.  Please specify a PublicKey or PrivateKey instance.");
 
+                    Assert.isTrue(!algorithm.isEllipticCurve(),
+                                  "Key bytes cannot be specified for ECDSA signatures.  Please specify a PublicKey instance.");
+
                     key = new SecretKeySpec(keyBytes, algorithm.getJcaName());
                 }
             }

--- a/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -309,11 +309,8 @@ public class DefaultJwtParser implements JwtParser {
 
                 if (!Objects.isEmpty(keyBytes)) {
 
-                    Assert.isTrue(!algorithm.isRsa(),
-                                  "Key bytes cannot be specified for RSA signatures.  Please specify a PublicKey or PrivateKey instance.");
-
-                    Assert.isTrue(!algorithm.isEllipticCurve(),
-                                  "Key bytes cannot be specified for ECDSA signatures.  Please specify a PublicKey instance.");
+                    Assert.isTrue(algorithm.isHmac(),
+                                  "Key bytes can only be specified for HMAC signatures. Please specify a PublicKey or PrivateKey instance.");
 
                     key = new SecretKeySpec(keyBytes, algorithm.getJcaName());
                 }


### PR DESCRIPTION
Quite possible we're missing something here, so please forgive if so. After seeing [this article](https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/) (see "RSA or HMAC?" section), we did a quick scan through the JJWT implementation to see if it was vulnerable. While it seems like the RSA check should work, no such check seemed to exist for ECDSA signatures.

As a result, it may be possible for users of this library to use `setSigningKey(byte[] key)` while intending to use ECDSA, but have the client alter the algorithm and signature to use HMAC with the public key as the "secret key", allowing the client to inject arbitrary payloads.

cc @thomaso-mirodin