### PR TITLE
Fix ES512 description typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ try {
     * PS512: RSASSA-PSS using SHA-512 and MGF1 with SHA-512
     * ES256: ECDSA using P-256 and SHA-256
     * ES384: ECDSA using P-384 and SHA-384
-    * ES512: ECDSA using P-512 and SHA-512
+    * ES512: ECDSA using P-521 and SHA-512
 
 ### Enhancements Beyond the Specification:
 


### PR DESCRIPTION
Resolves issue #149: the NIST `P-521` curve is misnamed as `P-512` in the `ES512` JWS algorithm description in the README.

Reference: the [RFC on ECC in TLS](https://tools.ietf.org/html/rfc4492#appendix-A).