### PR TITLE
Adding support for JCA Name along with Name on SignatureAlgorithm

### DIFF
--- a/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
+++ b/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
@@ -264,6 +264,9 @@ public enum SignatureAlgorithm {
             if (alg.getValue().equalsIgnoreCase(value)) {
                 return alg;
             }
+            if (alg.getJcaName().equalsIgnoreCase(value)) {
+              return alg;
+          }
         }
 
         throw new SignatureException("Unsupported signature algorithm '" + value + "'");

--- a/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
+++ b/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
@@ -264,7 +264,7 @@ public enum SignatureAlgorithm {
             if (alg.getValue().equalsIgnoreCase(value)) {
                 return alg;
             }
-            if (alg.getJcaName().equalsIgnoreCase(value)) {
+            if (alg.getJcaName() != null && alg.getJcaName().equalsIgnoreCase(value)) {
               return alg;
           }
         }

--- a/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
@@ -23,7 +23,7 @@ class SignatureAlgorithmTest {
     @Test
     void testNames() {
         def algNames = ['HS256', 'HS384', 'HS512', 'RS256', 'RS384', 'RS512',
-                        'ES256', 'ES384', 'ES512', 'PS256', 'PS384', 'PS512', 'NONE', 'HmacSHA256']
+                        'ES256', 'ES384', 'ES512', 'PS256', 'PS384', 'PS512', 'NONE']
 
         for( String name : algNames ) {
             testName(name)

--- a/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
@@ -23,7 +23,7 @@ class SignatureAlgorithmTest {
     @Test
     void testNames() {
         def algNames = ['HS256', 'HS384', 'HS512', 'RS256', 'RS384', 'RS512',
-                        'ES256', 'ES384', 'ES512', 'PS256', 'PS384', 'PS512', 'NONE']
+                        'ES256', 'ES384', 'ES512', 'PS256', 'PS384', 'PS512', 'NONE', 'HmacSHA256']
 
         for( String name : algNames ) {
             testName(name)
@@ -57,6 +57,15 @@ class SignatureAlgorithmTest {
     void testHmacFamilyName() {
         for(SignatureAlgorithm alg : SignatureAlgorithm.values()) {
             if (alg.name().startsWith("HS")) {
+                assertEquals alg.getFamilyName(), "HMAC"
+            }
+        }
+    }
+
+    @Test
+    void testJcaName() {
+        for(SignatureAlgorithm alg : SignatureAlgorithm.values()) {
+            if (alg.getJcaName().startsWith("HmacSHA256")) {
                 assertEquals alg.getFamilyName(), "HMAC"
             }
         }

--- a/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
@@ -65,7 +65,7 @@ class SignatureAlgorithmTest {
     @Test
     void testJcaName() {
         for(SignatureAlgorithm alg : SignatureAlgorithm.values()) {
-            if (alg.getJcaName().startsWith("HmacSHA256")) {
+            if ("HmacSHA256".equals(alg.getJcaName())) {
                 assertEquals alg.getFamilyName(), "HMAC"
             }
         }


### PR DESCRIPTION
Adding support for Headers of the type:

{
  "typ": "JWT",
  "alg": "HmacSHA256"
}