### PR TITLE
added support for throwing custom exceptions in SigningKeyResolver

### DIFF
--- a/src/main/java/io/jsonwebtoken/JwtParser.java
+++ b/src/main/java/io/jsonwebtoken/JwtParser.java
@@ -287,7 +287,7 @@ public interface JwtParser {
      * @see #parsePlaintextJws(String)
      * @see #parseClaimsJws(String)
      */
-    Jwt parse(String jwt) throws ExpiredJwtException, MalformedJwtException, SignatureException, IllegalArgumentException;
+    Jwt parse(String jwt) throws ExpiredJwtException, MalformedJwtException, SignatureException, IllegalArgumentException, Exception;
 
     /**
      * Parses the specified compact serialized JWT string based on the builder's current configuration state and
@@ -336,7 +336,7 @@ public interface JwtParser {
      * @since 0.2
      */
     <T> T parse(String jwt, JwtHandler<T> handler)
-            throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException;
+            throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException, Exception;
 
     /**
      * Parses the specified compact serialized JWT string based on the builder's current configuration state and
@@ -366,7 +366,7 @@ public interface JwtParser {
      * @since 0.2
      */
     Jwt<Header, String> parsePlaintextJwt(String plaintextJwt)
-            throws UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException;
+            throws UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException, Exception;
 
     /**
      * Parses the specified compact serialized JWT string based on the builder's current configuration state and
@@ -397,7 +397,7 @@ public interface JwtParser {
      * @since 0.2
      */
     Jwt<Header, Claims> parseClaimsJwt(String claimsJwt)
-            throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException;
+            throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException, Exception;
 
     /**
      * Parses the specified compact serialized JWS string based on the builder's current configuration state and
@@ -425,7 +425,7 @@ public interface JwtParser {
      * @since 0.2
      */
     Jws<String> parsePlaintextJws(String plaintextJws)
-            throws UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException;
+            throws UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException, Exception;
 
     /**
      * Parses the specified compact serialized JWS string based on the builder's current configuration state and
@@ -454,5 +454,5 @@ public interface JwtParser {
      * @since 0.2
      */
     Jws<Claims> parseClaimsJws(String claimsJws)
-            throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException;
+            throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException, Exception;
 }

--- a/src/main/java/io/jsonwebtoken/SigningKeyResolver.java
+++ b/src/main/java/io/jsonwebtoken/SigningKeyResolver.java
@@ -58,7 +58,7 @@ public interface SigningKeyResolver {
      * @return the signing key that should be used to validate a digital signature for the Claims JWS with the specified
      * header and claims.
      */
-    Key resolveSigningKey(JwsHeader header, Claims claims);
+    Key resolveSigningKey(JwsHeader header, Claims claims) throws Exception;
 
     /**
      * Returns the signing key that should be used to validate a digital signature for the Plaintext JWS with the
@@ -69,5 +69,5 @@ public interface SigningKeyResolver {
      * @return the signing key that should be used to validate a digital signature for the Plaintext JWS with the
      * specified header and plaintext payload.
      */
-    Key resolveSigningKey(JwsHeader header, String plaintext);
+    Key resolveSigningKey(JwsHeader header, String plaintext) throws Exception;
 }

--- a/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -198,7 +198,7 @@ public class DefaultJwtParser implements JwtParser {
     }
 
     @Override
-    public Jwt parse(String jwt) throws ExpiredJwtException, MalformedJwtException, SignatureException {
+    public Jwt parse(String jwt) throws ExpiredJwtException, MalformedJwtException, SignatureException, Exception {
 
         Assert.hasText(jwt, "JWT String argument cannot be null or empty.");
 
@@ -474,7 +474,7 @@ public class DefaultJwtParser implements JwtParser {
 
     @Override
     public <T> T parse(String compact, JwtHandler<T> handler)
-        throws ExpiredJwtException, MalformedJwtException, SignatureException {
+        throws ExpiredJwtException, MalformedJwtException, SignatureException, Exception {
         Assert.notNull(handler, "JwtHandler argument cannot be null.");
         Assert.hasText(compact, "JWT String argument cannot be null or empty.");
 
@@ -499,7 +499,7 @@ public class DefaultJwtParser implements JwtParser {
     }
 
     @Override
-    public Jwt<Header, String> parsePlaintextJwt(String plaintextJwt) {
+    public Jwt<Header, String> parsePlaintextJwt(String plaintextJwt) throws Exception {
         return parse(plaintextJwt, new JwtHandlerAdapter<Jwt<Header, String>>() {
             @Override
             public Jwt<Header, String> onPlaintextJwt(Jwt<Header, String> jwt) {
@@ -509,7 +509,7 @@ public class DefaultJwtParser implements JwtParser {
     }
 
     @Override
-    public Jwt<Header, Claims> parseClaimsJwt(String claimsJwt) {
+    public Jwt<Header, Claims> parseClaimsJwt(String claimsJwt) throws Exception {
         try {
             return parse(claimsJwt, new JwtHandlerAdapter<Jwt<Header, Claims>>() {
                 @Override
@@ -523,7 +523,7 @@ public class DefaultJwtParser implements JwtParser {
     }
 
     @Override
-    public Jws<String> parsePlaintextJws(String plaintextJws) {
+    public Jws<String> parsePlaintextJws(String plaintextJws) throws Exception {
         try {
             return parse(plaintextJws, new JwtHandlerAdapter<Jws<String>>() {
                 @Override
@@ -537,7 +537,7 @@ public class DefaultJwtParser implements JwtParser {
     }
 
     @Override
-    public Jws<Claims> parseClaimsJws(String claimsJws) {
+    public Jws<Claims> parseClaimsJws(String claimsJws)  throws Exception {
         return parse(claimsJws, new JwtHandlerAdapter<Jws<Claims>>() {
             @Override
             public Jws<Claims> onClaimsJws(Jws<Claims> jws) {


### PR DESCRIPTION
Added support for throwing custom exceptions in SigningKeyResolver to get more granular errors while retrieving the key for sign verification.

Issue : #189 