### PR TITLE
Added support for pluggable custom Crypto Implementation

### DIFF
--- a/src/main/java/io/jsonwebtoken/CryptoProvider.java
+++ b/src/main/java/io/jsonwebtoken/CryptoProvider.java
@@ -13,7 +13,7 @@ public interface CryptoProvider {
 	 * 
 	 * Parsing of the config map is left for the implementation
 	 */
-	public String sign(String plain, Map<String, Object> config);
+	public String sign(String plain, Map<String, Object> config) throws SignatureException;
 	
 	/**
 	 * 
@@ -24,6 +24,6 @@ public interface CryptoProvider {
 	 * 		an instance for using jjwt. 
 	 * @return Boolean value identifying if the sign is valid or not
 	 */
-	public Boolean verify(String plain, String sign, Map<String, Object> config);
+	public Boolean verify(String plain, String sign, Map<String, Object> config) throws SignatureException;
 	
 }

--- a/src/main/java/io/jsonwebtoken/CryptoProvider.java
+++ b/src/main/java/io/jsonwebtoken/CryptoProvider.java
@@ -1,0 +1,29 @@
+package io.jsonwebtoken;
+
+import java.util.Map;
+
+public interface CryptoProvider {
+	/**
+	 * 
+	 * @param plain the string that needs to be signed
+	 * @param config configuration hashmap that requires exclusive information required for sign
+	 * 		This config map can be implementation specific as the user will have to implement the CryptoProvider and provide
+	 * 		an instance for using jjwt.
+	 * @return String the signed value as a String
+	 * 
+	 * Parsing of the config map is left for the implementation
+	 */
+	public String sign(String plain, Map<String, Object> config);
+	
+	/**
+	 * 
+	 * @param plain the string that has been signed
+	 * @param sign the sign that is to be verified for the given plain text
+	 * @param config configuration hashmap that requires exclusive information required for verify
+	 *		This config map can be implementation specific as the user will have to implement the CryptoProvider and provide
+	 * 		an instance for using jjwt. 
+	 * @return Boolean value identifying if the sign is valid or not
+	 */
+	public Boolean verify(String plain, String sign, Map<String, Object> config);
+	
+}

--- a/src/main/java/io/jsonwebtoken/JwtBuilder.java
+++ b/src/main/java/io/jsonwebtoken/JwtBuilder.java
@@ -382,5 +382,30 @@ public interface JwtBuilder extends ClaimsMutator<JwtBuilder> {
      *
      * @return A compact URL-safe JWT string.
      */
+    
+    /**
+     * Sets the {@link CryptoProvider} used to implement custom crypto features. The default builder requires the keys to
+     * be extracted and then passed to the lib by the application. But for some applications used in PCI, getting the keys are
+     * not an option. They use some sort of Hardware security module that gives out handles to the keys stored in them and never
+     * the actual keys. The keys have several layers of encryption on it using multiple keys. The default implementation does not 
+     * support custom crypto. This can be used to override the default and use you own Crypto Implementation by implementing the 
+     * {@link CryptoProvider} interface.
+     * @param cryptoProvider	the cryptoProvider object for implementing custom sign and verify
+     * @return the builder for method chaining.
+     */
+    JwtBuilder setCryptoProvider(CryptoProvider cryptoProvider);
+    
+    /**
+     * Sets the {@link config}, used to provide the custom crypto Implementation all the information it needs to execute it's
+     * functions. 
+     * <p>
+     * 	Eg. for a crypto module it accepts blob / token for the original key but some other case it might accept the actual key
+     * but encrypted. So we can pass the identifier for such cases in the config map with the info of our keys / tokens.
+     * </p> 
+     * @param config	hashmap that contains all the secondary information required for the custom Crypto Implementation to work.
+     * @return the builder for method chaining.
+     */
+    JwtBuilder setConfigParams(Map<String, Object> config);
+    
     String compact();
 }

--- a/src/main/java/io/jsonwebtoken/JwtParser.java
+++ b/src/main/java/io/jsonwebtoken/JwtParser.java
@@ -19,6 +19,7 @@ import io.jsonwebtoken.impl.DefaultClock;
 
 import java.security.Key;
 import java.util.Date;
+import java.util.Map;
 
 /**
  * A parser for reading JWT strings, used to convert them into a {@link Jwt} object representing the expanded JWT.
@@ -226,6 +227,30 @@ public interface JwtParser {
      * @since 0.4
      */
     JwtParser setSigningKeyResolver(SigningKeyResolver signingKeyResolver);
+    
+    /**
+     * Sets the {@link CryptoProvider} used to implement custom crypto features. The default builder requires the keys to
+     * be extracted and then passed to the lib by the application. But for some applications used in PCI, getting the keys are
+     * not an option. They use some sort of Hardware security module that gives out handles to the keys stored in them and never
+     * the actual keys. The keys have several layers of encryption on it using multiple keys. The default implementation does not 
+     * support custom crypto. This can be used to override the default and use you own Crypto Implementation by implementing the 
+     * {@link CryptoProvider} interface.
+     * @param cryptoProvider the cryptoProvider object for implementing custom sign and verify
+     * @return the parser for method chaining.
+     */
+    JwtParser setCryptoProvider(CryptoProvider cryptoProvider);
+    
+    /**
+     * Sets the {@link config}, used to provide the custom crypto Implementation all the information it needs to execute it's
+     * functions. 
+     * <p>
+     * 	Eg. for a crypto module it accepts blob / token for the original key but some other case it might accept the actual key
+     * but encrypted. So we can pass the identifier for such cases in the config map with the info of our keys / tokens.
+     * </p> 
+     * @param config hashmap that contains all the secondary information required for the custom Crypto Implementation to work.
+     * @return the parser for method chaining.
+     */
+    JwtParser setConfigParams(Map<String, Object> config);
 
     /**
      * Sets the {@link CompressionCodecResolver} used to acquire the {@link CompressionCodec} that should be used to

--- a/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
@@ -34,6 +34,11 @@ import java.nio.charset.Charset
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import java.util.Base64;
+import java.util.Map;
 
 import static org.junit.Assert.*
 
@@ -700,6 +705,67 @@ class JwtsTest {
         } catch (UnsupportedJwtException expected) {
             assertTrue expected.getMessage().startsWith('The parsed JWT indicates it was signed with the')
         }
+    }
+    
+    @Test
+    void customCryptoImpl() {
+    	//Simple MD5 check can be any algorithm
+    	CryptoProvider cryptoProvider = new CryptoProvider() {
+    		@Override
+    		public String sign(String plain, Map<String, Object> config) {
+				try {
+					MessageDigest md = MessageDigest.getInstance((String)config.get("algo"));
+					byte[] signValue = md.digest(plain.getBytes());
+					String res = Base64.getEncoder().encodeToString(signValue);
+					return res;
+				} catch (NoSuchAlgorithmException e) {
+					e.printStackTrace();
+				}
+				return null;
+			}
+
+			public Boolean verify(String plain, String sign, Map<String, Object> config) {
+				try{
+					MessageDigest md = MessageDigest.getInstance((String)config.get("algo"));
+					byte[] signValue = md.digest(plain.getBytes());
+					String signString = Base64.getEncoder().encodeToString(signValue);
+					if (signString.equals(sign)) return true;
+					return false;
+				} catch (NoSuchAlgorithmException e) {
+					e.printStackTrace();
+				}
+				return false;
+			}
+		};
+		
+		// Building a token
+		Date generatedTime = now();
+		Date expirationTime = laterDate(180);
+		Map<String, Object> config = new HashMap<String, Object>();
+		config.put("algo", "MD5");
+		
+		String jwtToken = Jwts.builder()
+				.setSubject("sampleUser")
+				.setIssuer("SampleApp")
+				.setIssuedAt(generatedTime)
+				.setExpiration(expirationTime)
+				.setCryptoProvider(cryptoProvider)
+				.setConfigParams(config)
+				.compact();
+		
+		//verify the token
+		Claims claims = Jwts.parser()
+				.setCryptoProvider(cryptoProvider)
+				.setConfigParams(config)
+				.parseClaimsJws(jwtToken)
+				.getBody();
+				
+		Date now = now();
+		Boolean res = true;
+		if (claims.getExpiration().before(now) || claims.getIssuedAt().after(now) || !claims.getIssuer().equals("SampleApp")) {
+			res = false;
+		}
+		assertTrue res;
     }
 
     static void testRsa(SignatureAlgorithm alg, int keySize=1024, boolean verifyWithPrivateKey=false) {

--- a/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
@@ -37,8 +37,9 @@ import java.security.PublicKey
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import java.util.Base64;
+
 import java.util.Map;
+import javax.xml.bind.DatatypeConverter;
 
 import static org.junit.Assert.*
 
@@ -716,7 +717,8 @@ class JwtsTest {
 				try {
 					MessageDigest md = MessageDigest.getInstance((String)config.get("algo"));
 					byte[] signValue = md.digest(plain.getBytes());
-					String res = Base64.getEncoder().encodeToString(signValue);
+					//String res = Base64.getEncoder().encodeToString(signValue);
+					String res = DatatypeConverter.printBase64Binary(signValue);
 					return res;
 				} catch (NoSuchAlgorithmException e) {
 					e.printStackTrace();
@@ -728,7 +730,8 @@ class JwtsTest {
 				try{
 					MessageDigest md = MessageDigest.getInstance((String)config.get("algo"));
 					byte[] signValue = md.digest(plain.getBytes());
-					String signString = Base64.getEncoder().encodeToString(signValue);
+					//String signString = Base64.getEncoder().encodeToString(signValue);
+					String signString = DatatypeConverter.printBase64Binary(signValue);
 					if (signString.equals(sign)) return true;
 					return false;
 				} catch (NoSuchAlgorithmException e) {

--- a/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
@@ -755,7 +755,7 @@ class JwtsTest {
 				.setCryptoProvider(cryptoProvider)
 				.setConfigParams(config)
 				.compact();
-		
+				
 		//verify the token
 		Claims claims = Jwts.parser()
 				.setCryptoProvider(cryptoProvider)
@@ -769,6 +769,20 @@ class JwtsTest {
 			res = false;
 		}
 		assertTrue res;
+		
+		//corrupt the token
+		jwtToken = jwtToken + 'X';
+		
+		try {
+			claims = Jwts.parser()
+				.setCryptoProvider(cryptoProvider)
+				.setConfigParams(config)
+				.parseClaimsJws(jwtToken)
+				.getBody();
+		} catch (SignatureException e) {
+			assertTrue e.getMessage().startsWith("JWT signature does not match locally computed signature. JWT validity cannot be " +
+                            "asserted and should not be trusted.");
+        }
     }
 
     static void testRsa(SignatureAlgorithm alg, int keySize=1024, boolean verifyWithPrivateKey=false) {


### PR DESCRIPTION
This commit allows a user to plug their own crypto Implementation to the jjwt library and use it instead of the default provided Crypto layer. This may be required becuase the jjwt expects the user to get a private key to sign the token. But there might be cases that one cannot get the clear private key out, as in some applications (e.g. PCI compliant applications).

These applications use a HSM (https://en.wikipedia.org/wiki/Hardware_security_module) for all the encryption and decryption and key management. So the application never has access to clear keys, but only a handle. As far as I know there is no mechanism in the current build to have tokens instead of actual clear Key for crypto functions. Also the library relies completely on the default crypto layer provided. there must a mechanism to set custom crypto implementations that is flexible enough to accept tokens / blobs of actual keys and delegate the crypto functions to the centralised module (eg HSM). 

The above commit has such features. 

It adds 2 new data members CryptoProvider and Map<String, Object>, CryptoProvider being the flexible interface that provides sign() and verify() functions for the token and the map being the extra parameters that are required to do so (The provider might require some sort of identifier or a different algorithm / parameters to sign and verify).

Now one can pass the cryptoProvider using setCryptoProvider() and the config as setConfigParams(), also added in the DefaultJwtParser/Builder interfaces.

The user defined Crypto function need to implement the added CryptoProvider interface and pass an instance of that to the Jwts builder / parser. The parsing and error checking of the config map is left to the implementation of CryptoProvider as it is completely implementation / use case specific.

The original specs of the project are not violated in any way. Only if the cryptoProvider is set, the flow moves to the custom implementation, otherwise it will continue the default implementation, So completely backwards compatible (all tests are passing).