### PR TITLE
make_objectmapper_static

### DIFF
--- a/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -59,7 +59,7 @@ public class DefaultJwtParser implements JwtParser {
     private static final String ISO_8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
     private static final int MILLISECONDS_PER_SECOND = 1000;
 
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private byte[] keyBytes;
 


### PR DESCRIPTION
Makes ObjectMapper static in DefaultJwtParser.
See: http://wiki.fasterxml.com/JacksonBestPracticesPerformance