### PR TITLE
Added POJO deserialisation to get(Object, Class<T> requiredType)

### DIFF
--- a/src/main/java/io/jsonwebtoken/impl/DefaultClaims.java
+++ b/src/main/java/io/jsonwebtoken/impl/DefaultClaims.java
@@ -128,9 +128,7 @@ public class DefaultClaims extends JwtMap implements Claims {
     private <T> T castClaimValue(Object value, Class<T> requiredType) {
         if (requiredType == Date.class && value instanceof Long) {
             value = new Date((Long)value);
-        }
-
-        if (value instanceof Integer) {
+        } else if (value instanceof Integer) {
             int intValue = (Integer) value;
             if (requiredType == Long.class) {
                 value = (long) intValue;
@@ -139,9 +137,7 @@ public class DefaultClaims extends JwtMap implements Claims {
             } else if (requiredType == Byte.class && Byte.MIN_VALUE <= intValue && intValue <= Byte.MAX_VALUE) {
                 value = (byte) intValue;
             }
-        }
-
-        if (!requiredType.isInstance(value)) {
+        } else if (!requiredType.isInstance(value)) {
         	try {
         		return new ObjectMapper().convertValue(value, requiredType);
         	} catch (IllegalArgumentException e) {

--- a/src/main/java/io/jsonwebtoken/impl/DefaultClaims.java
+++ b/src/main/java/io/jsonwebtoken/impl/DefaultClaims.java
@@ -21,6 +21,8 @@ import io.jsonwebtoken.RequiredTypeException;
 import java.util.Date;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public class DefaultClaims extends JwtMap implements Claims {
 
     public DefaultClaims() {
@@ -140,7 +142,11 @@ public class DefaultClaims extends JwtMap implements Claims {
         }
 
         if (!requiredType.isInstance(value)) {
-            throw new RequiredTypeException("Expected value to be of type: " + requiredType + ", but was " + value.getClass());
+        	try {
+        		return new ObjectMapper().convertValue(value, requiredType);
+        	} catch (IllegalArgumentException e) {
+        		throw new RequiredTypeException("Expected value to be of type: " + requiredType + ", but was " + value.getClass());
+        	}
         }
 
         return requiredType.cast(value);

--- a/src/main/java/io/jsonwebtoken/impl/DefaultClaims.java
+++ b/src/main/java/io/jsonwebtoken/impl/DefaultClaims.java
@@ -25,126 +25,130 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DefaultClaims extends JwtMap implements Claims {
 
-    public DefaultClaims() {
-        super();
-    }
+	public DefaultClaims() {
+		super();
+	}
 
-    public DefaultClaims(Map<String, Object> map) {
-        super(map);
-    }
+	public DefaultClaims(Map<String, Object> map) {
+		super(map);
+	}
 
-    @Override
-    public String getIssuer() {
-        return getString(ISSUER);
-    }
+	@Override
+	public String getIssuer() {
+		return getString(ISSUER);
+	}
 
-    @Override
-    public Claims setIssuer(String iss) {
-        setValue(ISSUER, iss);
-        return this;
-    }
+	@Override
+	public Claims setIssuer(String iss) {
+		setValue(ISSUER, iss);
+		return this;
+	}
 
-    @Override
-    public String getSubject() {
-        return getString(SUBJECT);
-    }
+	@Override
+	public String getSubject() {
+		return getString(SUBJECT);
+	}
 
-    @Override
-    public Claims setSubject(String sub) {
-        setValue(SUBJECT, sub);
-        return this;
-    }
+	@Override
+	public Claims setSubject(String sub) {
+		setValue(SUBJECT, sub);
+		return this;
+	}
 
-    @Override
-    public String getAudience() {
-        return getString(AUDIENCE);
-    }
+	@Override
+	public String getAudience() {
+		return getString(AUDIENCE);
+	}
 
-    @Override
-    public Claims setAudience(String aud) {
-        setValue(AUDIENCE, aud);
-        return this;
-    }
+	@Override
+	public Claims setAudience(String aud) {
+		setValue(AUDIENCE, aud);
+		return this;
+	}
 
-    @Override
-    public Date getExpiration() {
-        return get(Claims.EXPIRATION, Date.class);
-    }
+	@Override
+	public Date getExpiration() {
+		return get(Claims.EXPIRATION, Date.class);
+	}
 
-    @Override
-    public Claims setExpiration(Date exp) {
-        setDate(Claims.EXPIRATION, exp);
-        return this;
-    }
+	@Override
+	public Claims setExpiration(Date exp) {
+		setDate(Claims.EXPIRATION, exp);
+		return this;
+	}
 
-    @Override
-    public Date getNotBefore() {
-        return get(Claims.NOT_BEFORE, Date.class);
-    }
+	@Override
+	public Date getNotBefore() {
+		return get(Claims.NOT_BEFORE, Date.class);
+	}
 
-    @Override
-    public Claims setNotBefore(Date nbf) {
-        setDate(Claims.NOT_BEFORE, nbf);
-        return this;
-    }
+	@Override
+	public Claims setNotBefore(Date nbf) {
+		setDate(Claims.NOT_BEFORE, nbf);
+		return this;
+	}
 
-    @Override
-    public Date getIssuedAt() {
-        return get(Claims.ISSUED_AT, Date.class);
-    }
+	@Override
+	public Date getIssuedAt() {
+		return get(Claims.ISSUED_AT, Date.class);
+	}
 
-    @Override
-    public Claims setIssuedAt(Date iat) {
-        setDate(Claims.ISSUED_AT, iat);
-        return this;
-    }
+	@Override
+	public Claims setIssuedAt(Date iat) {
+		setDate(Claims.ISSUED_AT, iat);
+		return this;
+	}
 
-    @Override
-    public String getId() {
-        return getString(ID);
-    }
+	@Override
+	public String getId() {
+		return getString(ID);
+	}
 
-    @Override
-    public Claims setId(String jti) {
-        setValue(Claims.ID, jti);
-        return this;
-    }
+	@Override
+	public Claims setId(String jti) {
+		setValue(Claims.ID, jti);
+		return this;
+	}
 
-    @Override
-    public <T> T get(String claimName, Class<T> requiredType) {
-        Object value = get(claimName);
-        if (value == null) { return null; }
+	@Override
+	public <T> T get(String claimName, Class<T> requiredType) {
+		Object value = get(claimName);
+		if (value == null) { return null; }
 
-        if (Claims.EXPIRATION.equals(claimName) ||
-            Claims.ISSUED_AT.equals(claimName) ||
-            Claims.NOT_BEFORE.equals(claimName)
-        ) {
-            value = getDate(claimName);
-        }
+		if (Claims.EXPIRATION.equals(claimName) ||
+				Claims.ISSUED_AT.equals(claimName) ||
+				Claims.NOT_BEFORE.equals(claimName)
+				) {
+			value = getDate(claimName);
+		}
 
-        return castClaimValue(value, requiredType);
-    }
+		return castClaimValue(value, requiredType);
+	}
 
-    private <T> T castClaimValue(Object value, Class<T> requiredType) {
-        if (requiredType == Date.class && value instanceof Long) {
-            value = new Date((Long)value);
-        } else if (value instanceof Integer) {
-            int intValue = (Integer) value;
-            if (requiredType == Long.class) {
-                value = (long) intValue;
-            } else if (requiredType == Short.class && Short.MIN_VALUE <= intValue && intValue <= Short.MAX_VALUE) {
-                value = (short) intValue;
-            } else if (requiredType == Byte.class && Byte.MIN_VALUE <= intValue && intValue <= Byte.MAX_VALUE) {
-                value = (byte) intValue;
-            }
-        } else if (!requiredType.isInstance(value)) {
-        	try {
-        		return new ObjectMapper().convertValue(value, requiredType);
-        	} catch (IllegalArgumentException e) {
-        		throw new RequiredTypeException("Expected value to be of type: " + requiredType + ", but was " + value.getClass());
-        	}
-        }
+	private <T> T castClaimValue(Object value, Class<T> requiredType) {
+		if (requiredType == Date.class && value instanceof Long) {
+			value = new Date((Long)value);
+		} else if (value instanceof Integer) {
+			int intValue = (Integer) value;
+			if (requiredType == Long.class) {
+				value = (long) intValue;
+			} else if (requiredType == Short.class && Short.MIN_VALUE <= intValue && intValue <= Short.MAX_VALUE) {
+				value = (short) intValue;
+			} else if (requiredType == Byte.class && Byte.MIN_VALUE <= intValue && intValue <= Byte.MAX_VALUE) {
+				value = (byte) intValue;
+			}
+		} else {        	
+			try {
+				value = new ObjectMapper().convertValue(value,requiredType);
+			} catch (IllegalArgumentException e) {
+				//Conversion failed
+			}
+		}
 
-        return requiredType.cast(value);
-    }
+		if (!requiredType.isInstance(value)) {
+			throw new RequiredTypeException("Expected value to be of type: " + requiredType + ", but was " + value.getClass());
+		}
+
+		return requiredType.cast(value);
+	}
 }

--- a/src/test/groovy/io/jsonwebtoken/impl/DefaultClaimsTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/impl/DefaultClaimsTest.groovy
@@ -162,7 +162,7 @@ class DefaultClaimsTest {
         } catch (RequiredTypeException e) {
             assertEquals(
                     e.getMessage(),
-                    "Expected value to be of type: class java.util.HashMap, but was class java.util.List"
+                    "Expected value to be of type: class java.util.HashMap, but was class java.util.ArrayList"
             )
         }
     }

--- a/src/test/groovy/io/jsonwebtoken/impl/DefaultClaimsTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/impl/DefaultClaimsTest.groovy
@@ -162,7 +162,7 @@ class DefaultClaimsTest {
         } catch (RequiredTypeException e) {
             assertEquals(
                     e.getMessage(),
-                    "Expected value to be of type: class java.util.Map, but was class java.util.List"
+                    "Expected value to be of type: class java.util.HashMap, but was class java.util.List"
             )
         }
     }

--- a/src/test/groovy/io/jsonwebtoken/impl/DefaultClaimsTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/impl/DefaultClaimsTest.groovy
@@ -158,7 +158,7 @@ class DefaultClaimsTest {
         claims.put("wrongPOJO", new ArrayList())
         try {
             claims.get("wrongPOJO", HashMap.class)
-            fail("getClaim() shouldn't silently lose precision.")
+            fail("getClaim() shouldn't map ArrayList to HashMap.")
         } catch (RequiredTypeException e) {
             assertEquals(
                     e.getMessage(),

--- a/src/test/groovy/io/jsonwebtoken/impl/DefaultClaimsTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/impl/DefaultClaimsTest.groovy
@@ -17,6 +17,8 @@ package io.jsonwebtoken.impl
 
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.RequiredTypeException
+import java.util.ArrayList;
+import java.util.HashMap;
 import org.junit.Before
 import org.junit.Test
 import static org.junit.Assert.*
@@ -147,6 +149,20 @@ class DefaultClaimsTest {
             assertEquals(
                     e.getMessage(),
                     "Expected value to be of type: class java.lang.Byte, but was class java.lang.Integer"
+            )
+        }
+    }
+    
+    @Test
+      void testGetClaimWithRequiredType_MapWithList_Exception() {
+        claims.put("wrongPOJO", new ArrayList())
+        try {
+            claims.get("wrongPOJO", HashMap.class)
+            fail("getClaim() shouldn't silently lose precision.")
+        } catch (RequiredTypeException e) {
+            assertEquals(
+                    e.getMessage(),
+                    "Expected value to be of type: class java.util.Map, but was class java.util.List"
             )
         }
     }


### PR DESCRIPTION
When you can do this:
```
String token = Jwts.builder()
				.claim("user", new User(1L,"test","testPass"))
				.signWith(SignatureAlgorithm.HS512, key)
				.compact();
```
shouldn't you be able to do this?:
```
User usr = Jwts.parser().
setSigningKey(key).
parseClaimsJws(tokenString).
getBody().
get("user", User.class);
```
There might be a good reason why not?