### PR TITLE
Test for instanceof PrivateKey and instanceof ECKey when signing

### DIFF
--- a/src/main/java/io/jsonwebtoken/impl/crypto/EllipticCurveSigner.java
+++ b/src/main/java/io/jsonwebtoken/impl/crypto/EllipticCurveSigner.java
@@ -19,6 +19,7 @@ import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.PrivateKey;
 import java.security.Signature;
+import java.security.interfaces.ECKey;
 import java.security.interfaces.ECPrivateKey;
 
 import io.jsonwebtoken.JwtException;
@@ -29,9 +30,9 @@ public class EllipticCurveSigner extends EllipticCurveProvider implements Signer
 
     public EllipticCurveSigner(SignatureAlgorithm alg, Key key) {
         super(alg, key);
-        if (!(key instanceof ECPrivateKey)) {
-            String msg = "Elliptic Curve signatures must be computed using an ECPrivateKey.  The specified key of " +
-                         "type " + key.getClass().getName() + " is not an ECPrivateKey.";
+        if (!(key instanceof PrivateKey && key instanceof ECKey)) {
+            String msg = "Elliptic Curve signatures must be computed using an EC PrivateKey.  The specified key of " +
+                         "type " + key.getClass().getName() + " is not an EC PrivateKey.";
             throw new IllegalArgumentException(msg);
         }
     }

--- a/src/test/groovy/io/jsonwebtoken/impl/crypto/EllipticCurveSignerTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/impl/crypto/EllipticCurveSignerTest.groovy
@@ -46,8 +46,8 @@ class EllipticCurveSignerTest {
             new EllipticCurveSigner(SignatureAlgorithm.ES256, key);
             fail('EllipticCurveSigner should reject non ECPrivateKey instances.')
         } catch (IllegalArgumentException expected) {
-            assertEquals expected.message, "Elliptic Curve signatures must be computed using an ECPrivateKey.  The specified key of " +
-            "type " + key.getClass().getName() + " is not an ECPrivateKey.";
+            assertEquals expected.message, "Elliptic Curve signatures must be computed using an EC PrivateKey.  The specified key of " +
+            "type " + key.getClass().getName() + " is not an EC PrivateKey.";
         }
     }
 


### PR DESCRIPTION
Similar to issue #68  (https://github.com/jwtk/jjwt/issues/68), EC keys on Android do not implement ECPrivateKey.  This changes the check in EllipticCurveSigner.java to use the same test as was used to solve issue #68 for RSA keys.