### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,9 @@ dist: trusty
 sudo: required
 
 language: java
-
-matrix:
-  include:
-    - jdk: oraclejdk8
-      addons:
-      apt:
-        packages:
-          - oracle-java8-installer
-    - jdk: oraclejdk7
-      addons:
-      apt:
-        packages:
-          - oracle-java7-installer
+jdk:
+  - oraclejdk7
+  - oraclejdk8
 
 before_install:
   - export BUILD_COVERAGE="$([ $TRAVIS_JDK_VERSION == 'oraclejdk8' ] && echo 'true')"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 # https://travis-ci.org/jwtk/jjwt
 
 dist: trusty
-
 sudo: required
-
 language: java
 jdk:
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
 
 before_install:


### PR DESCRIPTION
Simplified travis to use openjdk7 instead of oraclejdk7 as oracle 7 is no longer supported on travis.

This is per:

https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
https://docs.travis-ci.com/user/languages/java/

This will fix the build from failing.