### PR TITLE
Expose crypto implementation package in OSGI bundle headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,11 @@
                             *
                         ]]>
                         </Import-Package>
+                        <Export-Package>
+                            io.jsonwebtoken,
+                            io.jsonwebtoken.lang,
+                            io.jsonwebtoken.impl.crypto
+                        </Export-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
By default, maven-bundle-plugin excludes packages in private/impl namespaces from the Export-Package OSGI header.  This means that the classes in io.jsonwebtoken.impl.crypto aren't resolvable when deployed in an OSGI stack.  This change simply adds that package to the exports list.