### PR TITLE
Support java 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: java
 jdk:
   - openjdk7
   - oraclejdk8
+  - oraclejdk9
 
 before_install:
   - export BUILD_COVERAGE="$([ $TRAVIS_JDK_VERSION == 'oraclejdk8' ] && echo 'true')"

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <maven.jar.version>3.0.2</maven.jar.version>
         <maven.compiler.version>3.6.1</maven.compiler.version>
 
-        <jdk.version>1.8</jdk.version>
+        <jdk.version>1.7</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <buildNumber>${user.name}-${maven.build.timestamp}</buildNumber>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <maven.jar.version>3.0.2</maven.jar.version>
         <maven.compiler.version>3.6.1</maven.compiler.version>
 
-        <jdk.version>1.6</jdk.version>
+        <jdk.version>1.8</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <buildNumber>${user.name}-${maven.build.timestamp}</buildNumber>
 
@@ -92,10 +92,11 @@
         <!-- Test Dependencies: Only required for testing when building.  Not required by users at runtime: -->
         <groovy.version>2.4.11</groovy.version>
         <logback.version>1.2.3</logback.version>
-        <easymock.version>3.4</easymock.version>
+        <easymock.version>3.5</easymock.version>
         <junit.version>4.12</junit.version>
-        <powermock.version>1.6.6</powermock.version>
-        <failsafe.plugin.version>2.19.1</failsafe.plugin.version>
+        <powermock.version>2.0.0-beta.5</powermock.version> <!-- necessary for Java 9 support -->
+        <failsafe.plugin.version>2.20.1</failsafe.plugin.version>
+        <surefire.plugin.version>2.20.1</surefire.plugin.version>
         <clover.version>4.2.0</clover.version>
 
     </properties>
@@ -267,10 +268,16 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <!-- Override OSS parent to support Java 9. Doesn't hurt Java 8 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.plugin.version}</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20</version>
+                <version>${failsafe.plugin.version}</version>
                 <configuration>
                     <includes>
                         <include>**/*IT.java</include>
@@ -363,6 +370,7 @@
                     </instructions>
                 </configuration>
             </plugin>
+
             <!-- Temporarily host coveralls SNAPSHOT with clover support locally  -->
             <plugin>
                 <groupId>org.jwtk.coveralls</groupId>
@@ -370,6 +378,29 @@
                 <version>4.4.0</version>
             </plugin>
             <!-- Temporarily host coveralls SNAPSHOT with clover support locally  -->
+
+            <!-- Override OSS parent to support Java 9 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <!-- Workaround for Java 9 -->
+                    <dependency>
+                        <groupId>commons-lang</groupId>
+                        <artifactId>commons-lang</artifactId>
+                        <version>2.6</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -433,6 +464,14 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <dependencies>
+                            <!-- Workaround for Java 9 -->
+                            <dependency>
+                                <groupId>commons-lang</groupId>
+                                <artifactId>commons-lang</artifactId>
+                                <version>2.6</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/src/main/java/io/jsonwebtoken/Claims.java
+++ b/src/main/java/io/jsonwebtoken/Claims.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * claims.{@link Map#put(Object, Object) put}("someKey", "someValue");
  * </pre>
  *
- * <h4>Creation</h4>
+ * <h3>Creation</h3>
  *
  * <p>It is easiest to create a {@code Claims} instance by calling one of the
  * {@link Jwts#claims() JWTs.claims()} factory methods.</p>

--- a/src/main/java/io/jsonwebtoken/CompressionCodecs.java
+++ b/src/main/java/io/jsonwebtoken/CompressionCodecs.java
@@ -24,7 +24,7 @@ public final class CompressionCodecs {
 
     /**
      * Codec implementing the <a href="https://en.wikipedia.org/wiki/Gzip">gzip</a> compression algorithm.
-     * <h5>Compatibility Warning</h5>
+     * <h3>Compatibility Warning</h3>
      * <p><b>This is not a standard JWA compression algorithm</b>.  Be sure to use this only when you are confident
      * that all parties accessing the token support the gzip algorithm.</p>
      * <p>If you're concerned about compatibility, the {@link #DEFLATE DEFLATE} code is JWA standards-compliant.</p>

--- a/src/main/java/io/jsonwebtoken/Header.java
+++ b/src/main/java/io/jsonwebtoken/Header.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * header.{@link Map#put(Object, Object) put}("headerParamName", "headerParamValue");
  * </pre>
  *
- * <h4>Creation</h4>
+ * <h3>Creation</h3>
  *
  * <p>It is easiest to create a {@code Header} instance by calling one of the
  * {@link Jwts#header() JWTs.header()} factory methods.</p>
@@ -120,7 +120,7 @@ public interface Header<T extends Header<T>> extends Map<String,Object> {
      * Sets the JWT <code>calg</code> (Compression Algorithm) header parameter value. A {@code null} value will remove
      * the property from the JSON map.
      * <p>
-     * <p>The compression algorithm is NOT part of the <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25>JWT specification</a>
+     * <p>The compression algorithm is NOT part of the <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25">JWT specification</a>
      * and must be used carefully since, is not expected that other libraries (including previous versions of this one)
      * be able to deserialize a compressed JTW body correctly. </p>
      *

--- a/src/main/java/io/jsonwebtoken/JwtBuilder.java
+++ b/src/main/java/io/jsonwebtoken/JwtBuilder.java
@@ -368,7 +368,7 @@ public interface JwtBuilder extends ClaimsMutator<JwtBuilder> {
      * can be useful.  For example, when embedding JWTs  in URLs, some browsers may not support URLs longer than a
      * certain length.  Using compression can help ensure the compact JWT fits within that length.  However, NOTE:</p>
      *
-     * <h5>Compatibility Warning</h5>
+     * <h3>Compatibility Warning</h3>
      *
      * <p>The JWT family of specifications defines compression only for JWE (Json Web Encryption)
      * tokens.  Even so, JJWT will also support compression for JWS tokens as well if you choose to use it.

--- a/src/main/java/io/jsonwebtoken/JwtParser.java
+++ b/src/main/java/io/jsonwebtoken/JwtParser.java
@@ -228,10 +228,10 @@ public interface JwtParser {
      * Sets the {@link CompressionCodecResolver} used to acquire the {@link CompressionCodec} that should be used to
      * decompress the JWT body. If the parsed JWT is not compressed, this resolver is not used.
      * <p><b>NOTE:</b> Compression is not defined by the JWT Specification, and it is not expected that other libraries
-     * (including JJWT versions < 0.6.0) are able to consume a compressed JWT body correctly.  This method is only
-     * useful if the compact JWT was compressed with JJWT >= 0.6.0 or another library that you know implements
+     * (including JJWT versions &lt; 0.6.0) are able to consume a compressed JWT body correctly.  This method is only
+     * useful if the compact JWT was compressed with JJWT &gt;= 0.6.0 or another library that you know implements
      * the same behavior.</p>
-     * <h5>Default Support</h5>
+     * <h3>Default Support</h3>
      * <p>JJWT's default {@link JwtParser} implementation supports both the
      * {@link io.jsonwebtoken.impl.compression.DeflateCompressionCodec DEFLATE}
      * and {@link io.jsonwebtoken.impl.compression.GzipCompressionCodec GZIP} algorithms by default - you do not need to

--- a/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
+++ b/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
@@ -130,6 +130,7 @@ public enum SignatureAlgorithm {
      * following table:
      *
      * <table>
+     *     <caption>Crypto Family</caption>
      *     <thead>
      *         <tr>
      *             <th>SignatureAlgorithm</th>

--- a/src/main/java/io/jsonwebtoken/SigningKeyResolver.java
+++ b/src/main/java/io/jsonwebtoken/SigningKeyResolver.java
@@ -38,7 +38,7 @@ import java.security.Key;
  *
  * <p>A {@code SigningKeyResolver} is invoked once during parsing before the signature is verified.</p>
  *
- * <h4>SigningKeyResolverAdapter</h4>
+ * <h3>SigningKeyResolverAdapter</h3>
  *
  * <p>If you only need to resolve a signing key for a particular JWS (either a plaintext or Claims JWS), consider using
  * the {@link io.jsonwebtoken.SigningKeyResolverAdapter} and overriding only the method you need to support instead of

--- a/src/main/java/io/jsonwebtoken/impl/crypto/MacProvider.java
+++ b/src/main/java/io/jsonwebtoken/impl/crypto/MacProvider.java
@@ -67,7 +67,7 @@ public abstract class MacProvider extends SignatureProvider {
      * according to the specified {@code SignatureAlgorithm} using the specified SecureRandom number generator.  This
      * implementation returns secure-random key sizes as follows:
      *
-     * <table> <thead> <tr> <th>Signature Algorithm</th> <th>Generated Key Size</th> </tr> </thead> <tbody> <tr>
+     * <table> <caption>Key Sizes</caption> <thead> <tr> <th>Signature Algorithm</th> <th>Generated Key Size</th> </tr> </thead> <tbody> <tr>
      * <td>HS256</td> <td>256 bits (32 bytes)</td> </tr> <tr> <td>HS384</td> <td>384 bits (48 bytes)</td> </tr> <tr>
      * <td>HS512</td> <td>512 bits (64 bytes)</td> </tr> </tbody> </table>
      *

--- a/src/main/java/io/jsonwebtoken/lang/Strings.java
+++ b/src/main/java/io/jsonwebtoken/lang/Strings.java
@@ -438,7 +438,7 @@ public final class Strings {
      * Quote the given String with single quotes.
      * @param str the input String (e.g. "myString")
      * @return the quoted String (e.g. "'myString'"),
-     * or <code>null<code> if the input was <code>null</code>
+     * or <code>null</code> if the input was <code>null</code>
      */
     public static String quote(String str) {
         return (str != null ? "'" + str + "'" : null);
@@ -513,7 +513,7 @@ public final class Strings {
 
     /**
      * Extract the filename from the given path,
-     * e.g. "mypath/myfile.txt" -> "myfile.txt".
+     * e.g. "mypath/myfile.txt" -&gt; "myfile.txt".
      * @param path the file path (may be <code>null</code>)
      * @return the extracted filename, or <code>null</code> if none
      */
@@ -527,7 +527,7 @@ public final class Strings {
 
     /**
      * Extract the filename extension from the given path,
-     * e.g. "mypath/myfile.txt" -> "txt".
+     * e.g. "mypath/myfile.txt" -&gt; "txt".
      * @param path the file path (may be <code>null</code>)
      * @return the extracted filename extension, or <code>null</code> if none
      */
@@ -548,7 +548,7 @@ public final class Strings {
 
     /**
      * Strip the filename extension from the given path,
-     * e.g. "mypath/myfile.txt" -> "mypath/myfile".
+     * e.g. "mypath/myfile.txt" -&gt; "mypath/myfile".
      * @param path the file path (may be <code>null</code>)
      * @return the path with stripped filename extension,
      * or <code>null</code> if none


### PR DESCRIPTION
Fixes #259 

Added support for Java 9 build and test run. Does not impact Java 8 build and test. 
Overrode some OSS version dependency version defaults to support Java 9. 
Updated javadocs in code to pass java 9 linter.

Added Java 9 build to Travis file.