### PR TITLE
Add project.url to satisfy the dependency-check-maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <version>0.10.0-SNAPSHOT</version>
     <name>JSON Web Token support for the JVM</name>
     <packaging>jar</packaging>
+    <url>https://github.com/jwtk/jjwt</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
The MANIFEST.MF contains an Implementation-URL key, that comes from
project.url if defined. If not defined, jjwt's url comes from sonatype
which seems to falsely associate it with a sonatype/nexus CVE and
fails the project build.

https://github.com/jwtk/jjwt/issues/234