### PR TITLE
closes #282: Fix Java9 jaxb problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <buildNumber>${user.name}-${maven.build.timestamp}</buildNumber>
 
         <jackson.version>2.8.9</jackson.version>
+        <jaxb.version>2.3.0</jaxb.version>
 
         <!-- Optional Runtime Dependencies: -->
         <bouncycastle.version>1.56</bouncycastle.version>
@@ -107,6 +108,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.version}</version>
         </dependency>
 
         <!-- Optional Dependencies: -->


### PR DESCRIPTION
This adds an explicit jaxb dependency to fix consuming projects that build with
and target java 9.