### PR TITLE
closes #302: Update jackson version

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Maven:
 <dependency>
     <groupId>io.jsonwebtoken</groupId>
     <artifactId>jjwt</artifactId>
-    <version>0.7.0</version>
+    <version>0.9.0</version>
 </dependency>
 ```
 
@@ -76,7 +76,7 @@ Gradle:
 
 ```groovy
 dependencies {
-    compile 'io.jsonwebtoken:jjwt:0.7.0'
+    compile 'io.jsonwebtoken:jjwt:0.9.0'
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>io.jsonwebtoken</groupId>
     <artifactId>jjwt</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.9.0</version>
     <name>JSON Web Token support for the JVM</name>
     <packaging>jar</packaging>
 
@@ -41,7 +41,7 @@
         <connection>scm:git:https://github.com/jwtk/jjwt.git</connection>
         <developerConnection>scm:git:git@github.com:jwtk/jjwt.git</developerConnection>
         <url>git@github.com:jwtk/jjwt.git</url>
-        <tag>HEAD</tag>
+        <tag>jjwt-0.9.0</tag>
     </scm>
     <issueManagement>
         <system>GitHub Issues</system>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <buildNumber>${user.name}-${maven.build.timestamp}</buildNumber>
 
-        <jackson.version>2.8.9</jackson.version>
+        <jackson.version>2.8.11.1</jackson.version>
 
         <!-- Optional Runtime Dependencies: -->
         <bouncycastle.version>1.56</bouncycastle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>io.jsonwebtoken</groupId>
     <artifactId>jjwt</artifactId>
-    <version>0.9.0</version>
+    <version>0.10.0-SNAPSHOT</version>
     <name>JSON Web Token support for the JVM</name>
     <packaging>jar</packaging>
 
@@ -41,7 +41,7 @@
         <connection>scm:git:https://github.com/jwtk/jjwt.git</connection>
         <developerConnection>scm:git:git@github.com:jwtk/jjwt.git</developerConnection>
         <url>git@github.com:jwtk/jjwt.git</url>
-        <tag>jjwt-0.9.0</tag>
+        <tag>HEAD</tag>
     </scm>
     <issueManagement>
         <system>GitHub Issues</system>


### PR DESCRIPTION
* Updates jackson-databind version to 2.8.11.1 to fix CVE-2017-17485

Signed-off-by: John Bard <jbard@vmware.com>