### PR TITLE
Added support for java.time Instant instead of java.util.Date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: trusty
 sudo: required
 language: java
 jdk:
-  - openjdk7
   - oraclejdk8
   - oraclejdk9
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,12 @@
             <version>${jackson.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
         <!-- Optional Dependencies: -->
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/main/java/io/jsonwebtoken/Claims.java
+++ b/src/main/java/io/jsonwebtoken/Claims.java
@@ -15,7 +15,7 @@
  */
 package io.jsonwebtoken;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.Map;
 
 /**
@@ -111,13 +111,13 @@ public interface Claims extends Map<String, Object>, ClaimsMutator<Claims> {
      *
      * @return the JWT {@code exp} value or {@code null} if not present.
      */
-    Date getExpiration();
+    Instant getExpiration();
 
     /**
      * {@inheritDoc}
      */
     @Override //only for better/targeted JavaDoc
-    Claims setExpiration(Date exp);
+    Claims setExpiration(Instant exp);
 
     /**
      * Returns the JWT <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.5">
@@ -127,13 +127,13 @@ public interface Claims extends Map<String, Object>, ClaimsMutator<Claims> {
      *
      * @return the JWT {@code nbf} value or {@code null} if not present.
      */
-    Date getNotBefore();
+    Instant getNotBefore();
 
     /**
      * {@inheritDoc}
      */
     @Override //only for better/targeted JavaDoc
-    Claims setNotBefore(Date nbf);
+    Claims setNotBefore(Instant nbf);
 
     /**
      * Returns the JWT <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.6">
@@ -143,13 +143,13 @@ public interface Claims extends Map<String, Object>, ClaimsMutator<Claims> {
      *
      * @return the JWT {@code nbf} value or {@code null} if not present.
      */
-    Date getIssuedAt();
+    Instant getIssuedAt();
 
     /**
      * {@inheritDoc}
      */
     @Override //only for better/targeted JavaDoc
-    Claims setIssuedAt(Date iat);
+    Claims setIssuedAt(Instant iat);
 
     /**
      * Returns the JWTs <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.7">

--- a/src/main/java/io/jsonwebtoken/ClaimsMutator.java
+++ b/src/main/java/io/jsonwebtoken/ClaimsMutator.java
@@ -15,7 +15,7 @@
  */
 package io.jsonwebtoken;
 
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * Mutation (modifications) to a {@link io.jsonwebtoken.Claims Claims} instance.
@@ -63,7 +63,7 @@ public interface ClaimsMutator<T extends ClaimsMutator> {
      * @param exp the JWT {@code exp} value or {@code null} to remove the property from the JSON map.
      * @return the {@code Claims} instance for method chaining.
      */
-    T setExpiration(Date exp);
+    T setExpiration(Instant exp);
 
     /**
      * Sets the JWT <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.5">
@@ -74,7 +74,7 @@ public interface ClaimsMutator<T extends ClaimsMutator> {
      * @param nbf the JWT {@code nbf} value or {@code null} to remove the property from the JSON map.
      * @return the {@code Claims} instance for method chaining.
      */
-    T setNotBefore(Date nbf);
+    T setNotBefore(Instant nbf);
 
     /**
      * Sets the JWT <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.6">
@@ -85,7 +85,7 @@ public interface ClaimsMutator<T extends ClaimsMutator> {
      * @param iat the JWT {@code iat} value or {@code null} to remove the property from the JSON map.
      * @return the {@code Claims} instance for method chaining.
      */
-    T setIssuedAt(Date iat);
+    T setIssuedAt(Instant iat);
 
     /**
      * Sets the JWT <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.7">

--- a/src/main/java/io/jsonwebtoken/Clock.java
+++ b/src/main/java/io/jsonwebtoken/Clock.java
@@ -1,6 +1,6 @@
 package io.jsonwebtoken;
 
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * A clock represents a time source that can be used when creating and verifying JWTs.
@@ -14,5 +14,5 @@ public interface Clock {
      *
      * @return the clock's current timestamp at the instant the method is invoked.
      */
-    Date now();
+    Instant now();
 }

--- a/src/main/java/io/jsonwebtoken/JwtBuilder.java
+++ b/src/main/java/io/jsonwebtoken/JwtBuilder.java
@@ -16,7 +16,7 @@
 package io.jsonwebtoken;
 
 import java.security.Key;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Map;
 
 /**
@@ -198,16 +198,16 @@ public interface JwtBuilder extends ClaimsMutator<JwtBuilder> {
      * <p>A JWT obtained after this timestamp should not be used.</p>
      *
      * <p>This is a convenience method.  It will first ensure a Claims instance exists as the JWT body and then set
-     * the Claims {@link Claims#setExpiration(java.util.Date) expiration} field with the specified value.  This allows
+     * the Claims {@link Claims#setExpiration(java.time.Instant) expiration} field with the specified value.  This allows
      * you to write code like this:</p>
      *
      * <pre>
-     * String jwt = Jwts.builder().setExpiration(new Date(System.currentTimeMillis() + 3600000)).compact();
+     * String jwt = Jwts.builder().setExpiration(Instant.ofEpochMilli(System.currentTimeMillis() + 3600000)).compact();
      * </pre>
      *
      * <p>instead of this:</p>
      * <pre>
-     * Claims claims = Jwts.claims().setExpiration(new Date(System.currentTimeMillis() + 3600000));
+     * Claims claims = Jwts.claims().setExpiration(Instant.ofEpochMilli(System.currentTimeMillis() + 3600000));
      * String jwt = Jwts.builder().setClaims(claims).compact();
      * </pre>
      * <p>if desired.</p>
@@ -217,7 +217,7 @@ public interface JwtBuilder extends ClaimsMutator<JwtBuilder> {
      * @since 0.2
      */
     @Override //only for better/targeted JavaDoc
-    JwtBuilder setExpiration(Date exp);
+    JwtBuilder setExpiration(Instant exp);
 
     /**
      * Sets the JWT Claims <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.5">
@@ -226,16 +226,16 @@ public interface JwtBuilder extends ClaimsMutator<JwtBuilder> {
      * <p>A JWT obtained before this timestamp should not be used.</p>
      *
      * <p>This is a convenience method.  It will first ensure a Claims instance exists as the JWT body and then set
-     * the Claims {@link Claims#setNotBefore(java.util.Date) notBefore} field with the specified value.  This allows
+     * the Claims {@link Claims#setNotBefore(java.time.Instant) notBefore} field with the specified value.  This allows
      * you to write code like this:</p>
      *
      * <pre>
-     * String jwt = Jwts.builder().setNotBefore(new Date()).compact();
+     * String jwt = Jwts.builder().setNotBefore(Instant.now()).compact();
      * </pre>
      *
      * <p>instead of this:</p>
      * <pre>
-     * Claims claims = Jwts.claims().setNotBefore(new Date());
+     * Claims claims = Jwts.claims().setNotBefore(Instant.now());
      * String jwt = Jwts.builder().setClaims(claims).compact();
      * </pre>
      * <p>if desired.</p>
@@ -245,7 +245,7 @@ public interface JwtBuilder extends ClaimsMutator<JwtBuilder> {
      * @since 0.2
      */
     @Override //only for better/targeted JavaDoc
-    JwtBuilder setNotBefore(Date nbf);
+    JwtBuilder setNotBefore(Instant nbf);
 
     /**
      * Sets the JWT Claims <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.6">
@@ -254,7 +254,7 @@ public interface JwtBuilder extends ClaimsMutator<JwtBuilder> {
      * <p>The value is the timestamp when the JWT was created.</p>
      *
      * <p>This is a convenience method.  It will first ensure a Claims instance exists as the JWT body and then set
-     * the Claims {@link Claims#setIssuedAt(java.util.Date) issuedAt} field with the specified value.  This allows
+     * the Claims {@link Claims#setIssuedAt(java.time.Instant) issuedAt} field with the specified value.  This allows
      * you to write code like this:</p>
      *
      * <pre>
@@ -263,7 +263,7 @@ public interface JwtBuilder extends ClaimsMutator<JwtBuilder> {
      *
      * <p>instead of this:</p>
      * <pre>
-     * Claims claims = Jwts.claims().setIssuedAt(new Date());
+     * Claims claims = Jwts.claims().setIssuedAt(Instant.now());
      * String jwt = Jwts.builder().setClaims(claims).compact();
      * </pre>
      * <p>if desired.</p>
@@ -273,7 +273,7 @@ public interface JwtBuilder extends ClaimsMutator<JwtBuilder> {
      * @since 0.2
      */
     @Override //only for better/targeted JavaDoc
-    JwtBuilder setIssuedAt(Date iat);
+    JwtBuilder setIssuedAt(Instant iat);
 
     /**
      * Sets the JWT Claims <a href="https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.7">

--- a/src/main/java/io/jsonwebtoken/JwtParser.java
+++ b/src/main/java/io/jsonwebtoken/JwtParser.java
@@ -18,7 +18,7 @@ package io.jsonwebtoken;
 import io.jsonwebtoken.impl.DefaultClock;
 
 import java.security.Key;
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * A parser for reading JWT strings, used to convert them into a {@link Jwt} object representing the expanded JWT.
@@ -87,7 +87,7 @@ public interface JwtParser {
      * @see MissingClaimException
      * @see IncorrectClaimException
      */
-    JwtParser requireIssuedAt(Date issuedAt);
+    JwtParser requireIssuedAt(Instant issuedAt);
 
     /**
      * Ensures that the specified {@code exp} exists in the parsed JWT.  If missing or if the parsed
@@ -99,7 +99,7 @@ public interface JwtParser {
      * @see MissingClaimException
      * @see IncorrectClaimException
      */
-    JwtParser requireExpiration(Date expiration);
+    JwtParser requireExpiration(Instant expiration);
 
     /**
      * Ensures that the specified {@code nbf} exists in the parsed JWT.  If missing or if the parsed
@@ -111,7 +111,7 @@ public interface JwtParser {
      * @see MissingClaimException
      * @see IncorrectClaimException
      */
-    JwtParser requireNotBefore(Date notBefore);
+    JwtParser requireNotBefore(Instant notBefore);
 
     /**
      * Ensures that the specified {@code claimName} exists in the parsed JWT.  If missing or if the parsed

--- a/src/main/java/io/jsonwebtoken/impl/DefaultClaims.java
+++ b/src/main/java/io/jsonwebtoken/impl/DefaultClaims.java
@@ -18,7 +18,7 @@ package io.jsonwebtoken.impl;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.RequiredTypeException;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.Map;
 
 public class DefaultClaims extends JwtMap implements Claims {
@@ -65,35 +65,35 @@ public class DefaultClaims extends JwtMap implements Claims {
     }
 
     @Override
-    public Date getExpiration() {
-        return get(Claims.EXPIRATION, Date.class);
+    public Instant getExpiration() {
+        return get(Claims.EXPIRATION, Instant.class);
     }
 
     @Override
-    public Claims setExpiration(Date exp) {
-        setDate(Claims.EXPIRATION, exp);
+    public Claims setExpiration(Instant exp) {
+        setInstant(Claims.EXPIRATION, exp);
         return this;
     }
 
     @Override
-    public Date getNotBefore() {
-        return get(Claims.NOT_BEFORE, Date.class);
+    public Instant getNotBefore() {
+        return get(Claims.NOT_BEFORE, Instant.class);
     }
 
     @Override
-    public Claims setNotBefore(Date nbf) {
-        setDate(Claims.NOT_BEFORE, nbf);
+    public Claims setNotBefore(Instant nbf) {
+        setInstant(Claims.NOT_BEFORE, nbf);
         return this;
     }
 
     @Override
-    public Date getIssuedAt() {
-        return get(Claims.ISSUED_AT, Date.class);
+    public Instant getIssuedAt() {
+        return get(Claims.ISSUED_AT, Instant.class);
     }
 
     @Override
-    public Claims setIssuedAt(Date iat) {
-        setDate(Claims.ISSUED_AT, iat);
+    public Claims setIssuedAt(Instant iat) {
+        setInstant(Claims.ISSUED_AT, iat);
         return this;
     }
 
@@ -117,15 +117,15 @@ public class DefaultClaims extends JwtMap implements Claims {
             Claims.ISSUED_AT.equals(claimName) ||
             Claims.NOT_BEFORE.equals(claimName)
         ) {
-            value = getDate(claimName);
+            value = getInstant(claimName);
         }
 
         return castClaimValue(value, requiredType);
     }
 
     private <T> T castClaimValue(Object value, Class<T> requiredType) {
-        if (requiredType == Date.class && value instanceof Long) {
-            value = new Date((Long)value);
+        if (requiredType == Instant.class && value instanceof Number) {
+            value = Instant.ofEpochSecond(Long.parseLong(value.toString()));
         }
 
         if (value instanceof Integer) {

--- a/src/main/java/io/jsonwebtoken/impl/DefaultClock.java
+++ b/src/main/java/io/jsonwebtoken/impl/DefaultClock.java
@@ -2,7 +2,7 @@ package io.jsonwebtoken.impl;
 
 import io.jsonwebtoken.Clock;
 
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * Default {@link Clock} implementation.
@@ -17,12 +17,12 @@ public class DefaultClock implements Clock {
     public static final Clock INSTANCE = new DefaultClock();
 
     /**
-     * Simply returns <code>new {@link Date}()</code>.
+     * Simply returns <code>new {@link Instant}()</code>.
      *
-     * @return a new {@link Date} instance.
+     * @return a new {@link Instant} instance.
      */
     @Override
-    public Date now() {
-        return new Date();
+    public Instant now() {
+        return Instant.now();
     }
 }

--- a/src/main/java/io/jsonwebtoken/impl/FixedClock.java
+++ b/src/main/java/io/jsonwebtoken/impl/FixedClock.java
@@ -2,7 +2,7 @@ package io.jsonwebtoken.impl;
 
 import io.jsonwebtoken.Clock;
 
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * A {@code Clock} implementation that is constructed with a seed timestamp and always reports that same
@@ -12,28 +12,28 @@ import java.util.Date;
  */
 public class FixedClock implements Clock {
 
-    private final Date now;
+    private final Instant now;
 
     /**
-     * Creates a new fixed clock using <code>new {@link Date Date}()</code> as the seed timestamp.  All calls to
+     * Creates a new fixed clock using <code>new {@link Instant instant}()</code> as the seed timestamp.  All calls to
      * {@link #now now()} will always return this seed Date.
      */
     public FixedClock() {
-        this(new Date());
+        this(Instant.now());
     }
 
     /**
      * Creates a new fixed clock using the specified seed timestamp.  All calls to
-     * {@link #now now()} will always return this seed Date.
+     * {@link #now now()} will always return this seed Instant.
      *
-     * @param now the specified Date to always return from all calls to {@link #now now()}.
+     * @param now the specified Instant to always return from all calls to {@link #now now()}.
      */
-    public FixedClock(Date now) {
+    public FixedClock(Instant now) {
         this.now = now;
     }
 
     @Override
-    public Date now() {
+    public Instant now() {
         return this.now;
     }
 }

--- a/src/main/java/io/jsonwebtoken/impl/JwtMap.java
+++ b/src/main/java/io/jsonwebtoken/impl/JwtMap.java
@@ -17,8 +17,8 @@ package io.jsonwebtoken.impl;
 
 import io.jsonwebtoken.lang.Assert;
 
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -41,27 +41,23 @@ public class JwtMap implements Map<String,Object> {
         return v != null ? String.valueOf(v) : null;
     }
 
-    protected static Date toDate(Object v, String name) {
+    protected static Instant toInstant(Object v, String name) {
         if (v == null) {
             return null;
-        } else if (v instanceof Date) {
-            return (Date) v;
+        } else if (v instanceof Instant) {
+            return (Instant) v;
         } else if (v instanceof Number) {
             // https://github.com/jwtk/jjwt/issues/122:
             // The JWT RFC *mandates* NumericDate values are represented as seconds.
-            // Because Because java.util.Date requires milliseconds, we need to multiply by 1000:
             long seconds = ((Number) v).longValue();
-            long millis = seconds * 1000;
-            return new Date(millis);
+            return Instant.ofEpochSecond(seconds);
         } else if (v instanceof String) {
             // https://github.com/jwtk/jjwt/issues/122
             // The JWT RFC *mandates* NumericDate values are represented as seconds.
-            // Because Because java.util.Date requires milliseconds, we need to multiply by 1000:
             long seconds = Long.parseLong((String) v);
-            long millis = seconds * 1000;
-            return new Date(millis);
+            return Instant.ofEpochSecond(seconds);
         } else {
-            throw new IllegalStateException("Cannot convert '" + name + "' value [" + v + "] to Date instance.");
+            throw new IllegalStateException("Cannot convert '" + name + "' value [" + v + "] to Instant instance.");
         }
     }
 
@@ -73,17 +69,16 @@ public class JwtMap implements Map<String,Object> {
         }
     }
 
-    protected Date getDate(String name) {
+    protected Instant getInstant(String name) {
         Object v = map.get(name);
-        return toDate(v, name);
+        return toInstant(v, name);
     }
 
-    protected void setDate(String name, Date d) {
-        if (d == null) {
+    protected void setInstant(String name, Instant instant) {
+        if (instant == null) {
             map.remove(name);
         } else {
-            long seconds = d.getTime() / 1000;
-            map.put(name, seconds);
+            map.put(name, instant.getEpochSecond());
         }
     }
 

--- a/src/test/groovy/io/jsonwebtoken/impl/DefaultClaimsTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/impl/DefaultClaimsTest.groovy
@@ -19,6 +19,9 @@ import io.jsonwebtoken.Claims
 import io.jsonwebtoken.RequiredTypeException
 import org.junit.Before
 import org.junit.Test
+
+import java.time.Instant
+
 import static org.junit.Assert.*
 
 class DefaultClaimsTest {
@@ -152,43 +155,43 @@ class DefaultClaimsTest {
     }
 
     @Test
-    void testGetClaimWithRequiredType_Date_Success() {
-        def actual = new Date();
-        claims.put("aDate", actual)
-        Date expected = claims.get("aDate", Date.class);
+    void testGetClaimWithRequiredType_Instant_Success() {
+        def actual = Instant.now();
+        claims.put("anInstant", actual)
+        Instant expected = claims.get("anInstant", Instant.class);
         assertEquals(expected, actual)
     }
 
     @Test
-    void testGetClaimWithRequiredType_DateWithLong_Success() {
-        def actual = new Date();
+    void testGetClaimWithRequiredType_InstantWithLong_Success() {
+        Instant actual = Instant.ofEpochMilli(System.currentTimeMillis())
         // note that Long is stored in claim
-        claims.put("aDate", actual.getTime())
-        Date expected = claims.get("aDate", Date.class);
-        assertEquals(expected, actual)
+        claims.put("aInstant", actual.getEpochSecond())
+        Instant expected = claims.get("aInstant", Instant.class);
+        assertEquals(expected.getEpochSecond(), actual.getEpochSecond())
     }
 
     @Test
     void testGetClaimExpiration_Success() {
-        def now = new Date(System.currentTimeMillis())
+        Instant now = Instant.ofEpochMilli(System.currentTimeMillis())
         claims.setExpiration(now)
-        Date expected = claims.get("exp", Date.class)
+        Instant expected = claims.get("exp", Instant.class)
         assertEquals(expected, claims.getExpiration())
     }
 
     @Test
     void testGetClaimIssuedAt_Success() {
-        def now = new Date(System.currentTimeMillis())
+        Instant now = Instant.ofEpochMilli(System.currentTimeMillis())
         claims.setIssuedAt(now)
-        Date expected = claims.get("iat", Date.class)
+        Instant expected = claims.get("iat", Instant.class)
         assertEquals(expected, claims.getIssuedAt())
     }
 
     @Test
     void testGetClaimNotBefore_Success() {
-        def now = new Date(System.currentTimeMillis())
+        Instant now = Instant.ofEpochMilli(System.currentTimeMillis())
         claims.setNotBefore(now)
-        Date expected = claims.get("nbf", Date.class)
+        Instant expected = claims.get("nbf", Instant.class)
         assertEquals(expected, claims.getNotBefore())
     }
 

--- a/src/test/groovy/io/jsonwebtoken/impl/FixedClockTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/impl/FixedClockTest.groovy
@@ -10,10 +10,10 @@ class FixedClockTest {
 
         def clock = new FixedClock()
 
-        def date1 = clock.now()
+        def now1 = clock.now()
         Thread.sleep(100)
-        def date2 = clock.now()
+        def now2 = clock.now()
 
-        assertSame date1, date2
+        assertSame now1, now2
     }
 }

--- a/src/test/groovy/io/jsonwebtoken/impl/JwtMapTest.groovy
+++ b/src/test/groovy/io/jsonwebtoken/impl/JwtMapTest.groovy
@@ -16,47 +16,51 @@
 package io.jsonwebtoken.impl
 
 import org.junit.Test
+
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.Month
+import java.time.ZoneOffset
+
 import static org.junit.Assert.*
 
 class JwtMapTest {
 
     @Test
-    void testToDateFromNull() {
-        Date actual = JwtMap.toDate(null, 'foo')
+    void testToInstantFromNull() {
+        Instant actual = JwtMap.toInstant(null, 'foo')
         assertNull actual
     }
 
     @Test
-    void testToDateFromDate() {
+    void testToInstantFromInstant() {
 
-        def d = new Date()
+        def now = Instant.now()
 
-        Date date = JwtMap.toDate(d, 'foo')
+        Instant convertedInstant = JwtMap.toInstant(now, 'foo')
 
-        assertSame date, d
-
-    }
-
-    @Test
-    void testToDateFromString() {
-
-        Date d = new Date(2015, 1, 1, 12, 0, 0)
-
-        String s = (d.getTime() / 1000) + '' //JWT timestamps are in seconds - need to strip millis
-
-        Date date = JwtMap.toDate(s, 'foo')
-
-        assertEquals date, d
+        assertSame convertedInstant, now
 
     }
 
     @Test
-    void testToDateFromNonDateObject() {
+    void testToInstantFromString() {
+
+        Instant date = LocalDateTime.of(2015, Month.JANUARY, 1, 12, 0, 0)
+                .toInstant(ZoneOffset.UTC)
+
+        Instant convertedInstant = JwtMap.toInstant(String.valueOf(date.getEpochSecond()), 'foo')
+
+        assertEquals date, convertedInstant
+    }
+
+    @Test
+    void testToInstantFromNonInstantObject() {
         try {
-            JwtMap.toDate(new Object() { @Override public String toString() {return 'hi'} }, 'foo')
+            JwtMap.toInstant(new Object() { @Override public String toString() {return 'hi'} }, 'foo')
             fail()
         } catch (IllegalStateException iae) {
-            assertEquals iae.message, "Cannot convert 'foo' value [hi] to Date instance."
+            assertEquals iae.message, "Cannot convert 'foo' value [hi] to Instant instance."
         }
     }
 


### PR DESCRIPTION
This PR is trying to address what has been requested in https://github.com/jwtk/jjwt/issues/286 & indirectly in https://github.com/jwtk/jjwt/issues/291

### Summary
- Added support for `java.time.Instant` instead of `java.util.Date`
- Made `ObjectMapper` `static final` in `DefaultJwtParser`.

### Highlights
- Added dependency on Jackson's `jackson-datatype-jsr310`, which brings in support for Java 8 date/time types (specified in `JSR-310` specification)
- All occurrences of `java.util.Date` have been replaced with `java.time.Instant` in prod & test code
- In `DefaultJwtParser`, an instance of `JavaTimeModule` has been registered to bring in deserialization support for parsing timestamp into an `Instant` & the `ObjectMapper` has been made `static final`, since I already touched that code. This also addressed https://github.com/jwtk/jjwt/pull/203 (https://github.com/FasterXML/jackson-docs/wiki/Presentation:-Jackson-Performance)
- In `DefaultJwtBuilder`, a serializer for `Instant` has been registered with `ObjectMapper` to serialize `Instant` as a timestamp in seconds as per JWT RFC
- JavaDocs have been updated where appropriate 

### Please note
This PR removes support for building the library against Java 7 as it leverages `java.time.*` classes which were added in Java 8. I do not know what the maintainers of `jjwt` have in mind in terms of sunsetting support for Java 7, so I am not sure if my PR is the right direction