### PR TITLE
Using Base64 instead of DatatypeConverter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: trusty
 sudo: required
 language: java
 jdk:
-  - openjdk7
   - oraclejdk8
   - oraclejdk9
 

--- a/src/main/java/io/jsonwebtoken/impl/Base64Codec.java
+++ b/src/main/java/io/jsonwebtoken/impl/Base64Codec.java
@@ -15,14 +15,20 @@
  */
 package io.jsonwebtoken.impl;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 public class Base64Codec extends AbstractTextCodec {
 
+    private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
+    private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
+
     public String encode(byte[] data) {
-        return javax.xml.bind.DatatypeConverter.printBase64Binary(data);
+        return BASE64_ENCODER.encodeToString(data);
     }
 
     @Override
-    public byte[] decode(String encoded) {
-        return javax.xml.bind.DatatypeConverter.parseBase64Binary(encoded);
+    public byte[] decode(String src) {
+        return BASE64_DECODER.decode(src.getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
This PR addresses issues #317 & https://github.com/jwtk/jjwt/issues/297 and https://github.com/jwtk/jjwt/issues/143 (points out a significant difference between the `DatatypeConverter` & `Base64`)

Replacing usages of `javax/xml/bind/DatatypeConverter` with ` java.util.Base64`

### Please note
This PR removes support for building the library against Java 7 as it leverages `java.util.Base64` which was added in Java 8. I do not know what the maintainers of `jjwt` have in mind in terms of sunsetting support for Java 7, so I am not sure if my PR is the right direction. If support for for Java 7 will be dropped, then the issue https://github.com/jwtk/jjwt/issues/308 will be addressed too

As an alternative, the following PR https://github.com/jwtk/jjwt/pull/283 tries to solve this issue by adding a dependency on `jaxb-api`, which  brings in `DatatypeConverter` without dropping the Java 7 build support