### PR TITLE
Fix master branch pom project version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>io.jsonwebtoken</groupId>
     <artifactId>jjwt</artifactId>
-    <version>0.9.1-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
     <name>JSON Web Token support for the JVM</name>
     <packaging>jar</packaging>
     <url>https://github.com/jwtk/jjwt</url>


### PR DESCRIPTION
Fixed master branch pom project version - it should always be a Maj.min.0-SNAPSHOT version.