### PR TITLE
Re-enable builds on JDK 9+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,12 @@ language: java
 jdk:
   - openjdk7
   - oraclejdk8
-#  - oraclejdk9
-#  - oraclejdk10
-#  - openjdk10
-# - openjdk11
-# - oraclejdk-ea
+  - oraclejdk9
+  - oraclejdk10
+  - openjdk10
 
 before_install:
   - export BUILD_COVERAGE="$([ $TRAVIS_JDK_VERSION == 'oraclejdk8' ] && echo 'true')"
-#  - if [[ "$TRAVIS_JDK_VERSION" != 'openjdk7' && "$TRAVIS_JDK_VERSION" != 'oraclejdk8' ]]; then export MAVEN_OPTS='--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED'; fi;
 
 install: true
 

--- a/api/src/main/java/io/jsonwebtoken/JwtBuilder.java
+++ b/api/src/main/java/io/jsonwebtoken/JwtBuilder.java
@@ -19,9 +19,9 @@ import io.jsonwebtoken.io.Decoder;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.io.Encoder;
 import io.jsonwebtoken.io.Serializer;
+import io.jsonwebtoken.security.InvalidKeyException;
 import io.jsonwebtoken.security.Keys;
 
-import java.security.InvalidKeyException;
 import java.security.Key;
 import java.util.Date;
 import java.util.Map;

--- a/pom.xml
+++ b/pom.xml
@@ -95,15 +95,16 @@
         <bouncycastle.version>1.60</bouncycastle.version>
 
         <!-- Test Dependencies: Only required for testing when building.  Not required by users at runtime: -->
-        <groovy.version>2.4.15</groovy.version>
+        <groovy.version>2.5.1</groovy.version>
         <logback.version>1.2.3</logback.version>
-        <easymock.version>3.5</easymock.version>
+        <easymock.version>3.6</easymock.version>
         <junit.version>4.12</junit.version>
         <powermock.version>2.0.0-beta.5</powermock.version> <!-- necessary for Java 9 support -->
         <failsafe.plugin.version>2.22.0</failsafe.plugin.version>
         <surefire.plugin.version>2.22.0</surefire.plugin.version>
         <clover.version>4.2.1</clover.version>
         <clover.db>${jjwt.root}/target/clover/clover.db</clover.db>
+        <surefire.argLine></surefire.argLine>
 
     </properties>
 
@@ -166,7 +167,7 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>
             <scope>test</scope>
         </dependency>
@@ -301,16 +302,18 @@
                 <dependencies>
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy-all</artifactId>
+                        <artifactId>groovy</artifactId>
                         <version>${groovy.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>
-            <!-- Override OSS parent to support Java 9. Doesn't hurt Java 8 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.plugin.version}</version>
+                <configuration>
+                    <argLine>${surefire.argLine}</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -450,6 +453,16 @@
             <properties>
                 <!-- Turn off JDK >= 8's lint checks: -->
                 <additionalparam>-Xdoclint:none</additionalparam>
+            </properties>
+        </profile>
+        <profile>
+            <!-- Added profile to address https://github.com/jwtk/jjwt/issues/364 -->
+            <id>jdk9AndLater</id>
+            <activation>
+                <jdk>[1.9,)</jdk>
+            </activation>
+            <properties>
+                <surefire.argLine>--add-opens java.base/jdk.internal.loader=ALL-UNNAMED</surefire.argLine>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
Enabled maven profile for JDK >= 9 that will add a surefire `<argLine>` with `--add-opens java.base/jdk.internal.loader=ALL-UNNAMED` to ensure module reflection can occur during tests.  Resolves #364