### PR TITLE
Keys and SignatureAlgorithm helper method parity

### DIFF
--- a/api/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
+++ b/api/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
@@ -187,17 +187,6 @@ class SignatureAlgorithmTest {
     }
 
     @Test
-    void testForSigningKeySecretKeyInvalidAlgName() {
-        try {
-            SignatureAlgorithm.forSigningKey(new SecretKeySpec(new byte[1], 'AES'))
-            fail()
-        } catch (InvalidKeyException e) {
-            assertEquals "The specified SecretKey algorithm did not equal one of the three required JCA " +
-                    "algorithm names of HmacSHA256, HmacSHA384, or HmacSHA512.", e.message
-        }
-    }
-
-    @Test
     void testForSigningKeySecretKeyWeakKey() {
         try {
             SignatureAlgorithm.forSigningKey(new SecretKeySpec(new byte[1], 'HmacSHA256'))

--- a/impl/src/test/groovy/io/jsonwebtoken/security/KeysImplTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/security/KeysImplTest.groovy
@@ -32,6 +32,9 @@ class KeysImplTest {
                 SecretKey key = Keys.secretKeyFor(alg)
                 assertEquals alg.minKeyLength, key.getEncoded().length * 8 //convert byte count to bit count
                 assertEquals alg.jcaName, key.algorithm
+                alg.assertValidSigningKey(key)
+                alg.assertValidVerificationKey(key)
+                assertEquals alg, SignatureAlgorithm.forSigningKey(key) // https://github.com/jwtk/jjwt/issues/381
             } else {
                 try {
                     Keys.secretKeyFor(alg)


### PR DESCRIPTION
Enhanced test case to verify symmetric logic between the Keys and SignatureAlgorithm helper methods.  Resolves #381