### PR TITLE
Add some convenience methods: `getAsString`/`getAsInt`/`getAsDate`/`getAsBoolean`/`getAsMap`

### DIFF
--- a/api/src/main/java/io/jsonwebtoken/Claims.java
+++ b/api/src/main/java/io/jsonwebtoken/Claims.java
@@ -171,4 +171,20 @@ public interface Claims extends Map<String, Object>, ClaimsMutator<Claims> {
     Claims setId(String jti);
 
     <T> T get(String claimName, Class<T> requiredType);
+
+    String getAsString(String claimName);
+
+    Integer getAsInt(String claimName);
+
+    Long getAsLong(String claimName);
+
+    Short getAsShort(String claimName);
+
+    Byte getAsByte(String claimName);
+
+    Date getAsDate(String claimName);
+
+    Boolean getAsBoolean(String claimName);
+
+    Map<String, ?> getAsMap(String claimName);
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultClaims.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultClaims.java
@@ -164,4 +164,44 @@ public class DefaultClaims extends JwtMap implements Claims {
 
         return requiredType.cast(value);
     }
+
+    @Override
+    public String getAsString(String claimName) {
+        return get(claimName, String.class);
+    }
+
+    @Override
+    public Integer getAsInt(String claimName) {
+        return get(claimName, Integer.class);
+    }
+
+    @Override
+    public Long getAsLong(String claimName) {
+        return get(claimName, Long.class);
+    }
+
+    @Override
+    public Short getAsShort(String claimName) {
+        return get(claimName, Short.class);
+    }
+
+    @Override
+    public Byte getAsByte(String claimName) {
+        return get(claimName, Byte.class);
+    }
+
+    @Override
+    public Date getAsDate(String claimName) {
+        return get(claimName, Date.class);
+    }
+
+    @Override
+    public Boolean getAsBoolean(String claimName) {
+        return get(claimName, Boolean.class);
+    }
+
+    @Override
+    public Map<String, ?> getAsMap(String claimName) {
+        return get(claimName, Map.class);
+    }
 }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultClaimsTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultClaimsTest.groovy
@@ -17,6 +17,7 @@ package io.jsonwebtoken.impl
 
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.RequiredTypeException
+import org.apache.groovy.util.Maps
 import org.junit.Before
 import org.junit.Test
 import static org.junit.Assert.*
@@ -281,4 +282,96 @@ class DefaultClaimsTest {
         assertEquals now, claims.get('foo') //conversion should NOT have occurred
     }
 
+    @Test
+    void testGetClaimAsString() {
+        def claimName = "aString"
+        def expected = "The quick brown fox jumps over the lazy dog"
+
+        claims.put(claimName, expected)
+        String result = claims.getAsString(claimName)
+
+        assertEquals expected, result
+    }
+
+    @Test
+    void testGetClaimAsInt() {
+        def claimName = "anInt"
+        def expected = 4_8_15_16_23
+
+        claims.put(claimName, expected)
+        Integer result = claims.getAsInt(claimName)
+
+        assertEquals expected, result
+    }
+
+    @Test
+    void testGetClaimAsLong() {
+        def claimName = "aLong"
+        def expected = 4_8_15_16_23_42L
+
+        claims.put(claimName, expected)
+        Long result = claims.getAsLong(claimName)
+
+        assertEquals expected, result
+    }
+
+    @Test
+    void testGetClaimAsShort() {
+        def claimName = "aShort"
+        def expected = 4_8_15
+
+        claims.put(claimName, expected)
+        Short result = claims.getAsShort(claimName)
+
+        assertEquals expected, result
+    }
+
+    @Test
+    void testGetClaimAsByte() {
+        def claimName = "aByte"
+        def expected = 4_8
+
+        claims.put(claimName, expected)
+        Byte result = claims.getAsByte(claimName)
+
+        assertEquals expected, result
+    }
+
+    @Test
+    void testGetClaimAsDate() {
+        def claimName = "aDate"
+        def expected = new Date()
+
+        claims.put(claimName, expected)
+        Date result = claims.getAsDate(claimName)
+
+        assertEquals expected, result
+    }
+
+    @Test
+    void testGetClaimAsBoolean() {
+        def claimName = "aBoolean"
+        def expected = true
+
+        claims.put(claimName, expected)
+        Boolean result = claims.getAsBoolean(claimName)
+
+        assertEquals expected, result
+    }
+
+    @Test
+    void testGetClaimAsMap() {
+        def claimName = "aBoolean"
+        def expected = Maps.of(
+                "key1", 4_8_15_16_23_42L,
+                "key2", "abcd",
+                "key3", true,
+                "key4", new Date()
+        )
+
+        claims.put(claimName, expected)
+        Map<String, ?> result = claims.getAsMap(claimName)
+
+        assertEquals expected, result
+    }
 }


### PR DESCRIPTION
Currently, there is only a generic method `get(...)` which need a `Class<T> requiredType` parameter, it's a little inconvenience to use, since we have to pass `requiredType` like `String.class` or `Integer.class`

So it will be more convenience if we have the following methods:
- `getAsString`
-  `getAsInt`, `getAsLong`, `getAsShort`, `getAsByte`
- `getAsDate`
- `getAsBoolean`
- `getAsMap`