### PR TITLE
Extension Packaging

### DIFF
--- a/extensions/jackson/src/main/java/io/jsonwebtoken/io/JacksonDeserializer.java
+++ b/extensions/jackson/src/main/java/io/jsonwebtoken/io/JacksonDeserializer.java
@@ -1,0 +1,9 @@
+package io.jsonwebtoken.io;
+
+/**
+ * @deprecated Please use io.jsonwebtoken.io.serializer.JacksonDeserializer instead.
+ */
+@Deprecated
+public class JacksonDeserializer<T> extends io.jsonwebtoken.io.serializer.JacksonDeserializer<T> {
+
+}

--- a/extensions/jackson/src/main/java/io/jsonwebtoken/io/JacksonDeserializer.java
+++ b/extensions/jackson/src/main/java/io/jsonwebtoken/io/JacksonDeserializer.java
@@ -1,9 +1,18 @@
 package io.jsonwebtoken.io;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * @deprecated Please use io.jsonwebtoken.io.serializer.JacksonDeserializer instead.
  */
 @Deprecated
 public class JacksonDeserializer<T> extends io.jsonwebtoken.io.serializer.JacksonDeserializer<T> {
 
+    public JacksonDeserializer() {
+        super();
+    }
+
+    public JacksonDeserializer(ObjectMapper objectMapper) {
+        super(objectMapper);
+    }
 }

--- a/extensions/jackson/src/main/java/io/jsonwebtoken/io/JacksonSerializer.java
+++ b/extensions/jackson/src/main/java/io/jsonwebtoken/io/JacksonSerializer.java
@@ -1,0 +1,9 @@
+package io.jsonwebtoken.io;
+
+/**
+ * @deprecated Please use io.jsonwebtoken.io.serializer.JacksonSerializer instead.
+ */
+@Deprecated
+public class JacksonSerializer<T> extends io.jsonwebtoken.io.serializer.JacksonSerializer<T> {
+
+}

--- a/extensions/jackson/src/main/java/io/jsonwebtoken/io/JacksonSerializer.java
+++ b/extensions/jackson/src/main/java/io/jsonwebtoken/io/JacksonSerializer.java
@@ -1,9 +1,18 @@
 package io.jsonwebtoken.io;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * @deprecated Please use io.jsonwebtoken.io.serializer.JacksonSerializer instead.
  */
 @Deprecated
 public class JacksonSerializer<T> extends io.jsonwebtoken.io.serializer.JacksonSerializer<T> {
 
+    public JacksonSerializer() {
+        super();
+    }
+
+    public JacksonSerializer(ObjectMapper objectMapper) {
+        super(objectMapper);
+    }
 }

--- a/extensions/jackson/src/main/java/io/jsonwebtoken/io/serializer/JacksonDeserializer.java
+++ b/extensions/jackson/src/main/java/io/jsonwebtoken/io/serializer/JacksonDeserializer.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 public class JacksonDeserializer<T> implements Deserializer<T> {
 
     private final Class<T> returnType;
-    private final ObjectMapper objectMapper;
+    protected final ObjectMapper objectMapper;
 
     @SuppressWarnings("unused") //used via reflection by RuntimeClasspathDeserializerLocator
     public JacksonDeserializer() {

--- a/extensions/jackson/src/main/java/io/jsonwebtoken/io/serializer/JacksonDeserializer.java
+++ b/extensions/jackson/src/main/java/io/jsonwebtoken/io/serializer/JacksonDeserializer.java
@@ -1,6 +1,8 @@
-package io.jsonwebtoken.io;
+package io.jsonwebtoken.io.serializer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.io.DeserializationException;
+import io.jsonwebtoken.io.Deserializer;
 import io.jsonwebtoken.lang.Assert;
 
 import java.io.IOException;

--- a/extensions/jackson/src/main/java/io/jsonwebtoken/io/serializer/JacksonSerializer.java
+++ b/extensions/jackson/src/main/java/io/jsonwebtoken/io/serializer/JacksonSerializer.java
@@ -1,7 +1,9 @@
-package io.jsonwebtoken.io;
+package io.jsonwebtoken.io.serializer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.io.SerializationException;
+import io.jsonwebtoken.io.Serializer;
 import io.jsonwebtoken.lang.Assert;
 
 /**

--- a/extensions/jackson/src/main/java/io/jsonwebtoken/io/serializer/JacksonSerializer.java
+++ b/extensions/jackson/src/main/java/io/jsonwebtoken/io/serializer/JacksonSerializer.java
@@ -13,7 +13,7 @@ public class JacksonSerializer<T> implements Serializer<T> {
 
     static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper();
 
-    private final ObjectMapper objectMapper;
+    protected final ObjectMapper objectMapper;
 
     @SuppressWarnings("unused") //used via reflection by RuntimeClasspathDeserializerLocator
     public JacksonSerializer() {

--- a/extensions/jackson/src/test/groovy/io/jsonwebtoken/io/JacksonDeserializerTest.groovy
+++ b/extensions/jackson/src/test/groovy/io/jsonwebtoken/io/JacksonDeserializerTest.groovy
@@ -1,6 +1,7 @@
 package io.jsonwebtoken.io
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.jsonwebtoken.io.serializer.JacksonDeserializer
 import io.jsonwebtoken.lang.Strings
 import org.junit.Test
 

--- a/extensions/jackson/src/test/groovy/io/jsonwebtoken/io/JacksonDeserializerTest.groovy
+++ b/extensions/jackson/src/test/groovy/io/jsonwebtoken/io/JacksonDeserializerTest.groovy
@@ -11,6 +11,19 @@ import static org.junit.Assert.*
 class JacksonDeserializerTest {
 
     @Test
+    void testDeprecatedDefaultConstructor() {
+        def deserializer = new io.jsonwebtoken.io.JacksonDeserializer()
+        assertNotNull deserializer.objectMapper
+    }
+
+    @Test
+    void testDeprecatedObjectMapperConstructor() {
+        def customOM = new ObjectMapper()
+        def deserializer = new io.jsonwebtoken.io.JacksonDeserializer(customOM)
+        assertSame customOM, deserializer.objectMapper
+    }
+
+    @Test
     void testDefaultConstructor() {
         def deserializer = new JacksonDeserializer()
         assertNotNull deserializer.objectMapper

--- a/extensions/jackson/src/test/groovy/io/jsonwebtoken/io/JacksonSerializerTest.groovy
+++ b/extensions/jackson/src/test/groovy/io/jsonwebtoken/io/JacksonSerializerTest.groovy
@@ -2,6 +2,7 @@ package io.jsonwebtoken.io
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.jsonwebtoken.io.serializer.JacksonSerializer
 import io.jsonwebtoken.lang.Strings
 import org.junit.Test
 

--- a/extensions/jackson/src/test/groovy/io/jsonwebtoken/io/JacksonSerializerTest.groovy
+++ b/extensions/jackson/src/test/groovy/io/jsonwebtoken/io/JacksonSerializerTest.groovy
@@ -12,6 +12,19 @@ import static org.junit.Assert.*
 class JacksonSerializerTest {
 
     @Test
+    void testDefaultDeprecatedConstructor() {
+        def serializer = new io.jsonwebtoken.io.JacksonSerializer()
+        assertNotNull serializer.objectMapper
+    }
+
+    @Test
+    void testObjectDeprecatedMapperConstructor() {
+        def customOM = new ObjectMapper()
+        def serializer = new io.jsonwebtoken.io.JacksonSerializer(customOM)
+        assertSame customOM, serializer.objectMapper
+    }
+
+    @Test
     void testDefaultConstructor() {
         def serializer = new JacksonSerializer()
         assertNotNull serializer.objectMapper

--- a/extensions/orgjson/src/main/java/io/jsonwebtoken/io/OrgJsonDeserializer.java
+++ b/extensions/orgjson/src/main/java/io/jsonwebtoken/io/OrgJsonDeserializer.java
@@ -1,0 +1,9 @@
+package io.jsonwebtoken.io;
+
+/**
+ * @deprecated Please use io.jsonwebtoken.io.serializer.OrgJsonDeserializer instead.
+ */
+@Deprecated
+public class OrgJsonDeserializer extends io.jsonwebtoken.io.serializer.OrgJsonDeserializer {
+
+}

--- a/extensions/orgjson/src/main/java/io/jsonwebtoken/io/OrgJsonSerializer.java
+++ b/extensions/orgjson/src/main/java/io/jsonwebtoken/io/OrgJsonSerializer.java
@@ -1,0 +1,9 @@
+package io.jsonwebtoken.io;
+
+/**
+ * @deprecated Please use io.jsonwebtoken.io.serializer.OrgJsonSerializer instead.
+ */
+@Deprecated
+public class OrgJsonSerializer<T> extends io.jsonwebtoken.io.serializer.OrgJsonSerializer<T> {
+
+}

--- a/extensions/orgjson/src/main/java/io/jsonwebtoken/io/serializer/OrgJsonDeserializer.java
+++ b/extensions/orgjson/src/main/java/io/jsonwebtoken/io/serializer/OrgJsonDeserializer.java
@@ -1,5 +1,7 @@
-package io.jsonwebtoken.io;
+package io.jsonwebtoken.io.serializer;
 
+import io.jsonwebtoken.io.DeserializationException;
+import io.jsonwebtoken.io.Deserializer;
 import io.jsonwebtoken.lang.Assert;
 import io.jsonwebtoken.lang.Strings;
 import org.json.JSONArray;

--- a/extensions/orgjson/src/main/java/io/jsonwebtoken/io/serializer/OrgJsonSerializer.java
+++ b/extensions/orgjson/src/main/java/io/jsonwebtoken/io/serializer/OrgJsonSerializer.java
@@ -1,5 +1,8 @@
-package io.jsonwebtoken.io;
+package io.jsonwebtoken.io.serializer;
 
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.io.SerializationException;
+import io.jsonwebtoken.io.Serializer;
 import io.jsonwebtoken.lang.Classes;
 import io.jsonwebtoken.lang.Collections;
 import io.jsonwebtoken.lang.DateFormats;

--- a/extensions/orgjson/src/test/groovy/io/jsonwebtoken/io/AndroidOrgJsonSerializerTest.groovy
+++ b/extensions/orgjson/src/test/groovy/io/jsonwebtoken/io/AndroidOrgJsonSerializerTest.groovy
@@ -1,5 +1,6 @@
 package io.jsonwebtoken.io
 
+import io.jsonwebtoken.io.serializer.OrgJsonSerializer
 import io.jsonwebtoken.lang.Classes
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/extensions/orgjson/src/test/groovy/io/jsonwebtoken/io/OrgJsonDeserializerTest.groovy
+++ b/extensions/orgjson/src/test/groovy/io/jsonwebtoken/io/OrgJsonDeserializerTest.groovy
@@ -144,4 +144,14 @@ class OrgJsonDeserializerTest {
         def expected = [hello: '世界', test: [foo: 'bar']]
         assertEquals expected, value
     }
+
+    @Test
+    void testDeprecatedSimpleObject() {
+        def d = new io.jsonwebtoken.io.OrgJsonDeserializer();
+        def b = '{"hello": "世界"}'.getBytes(Strings.UTF_8)
+        def value = d.deserialize(b)
+        assert value instanceof Map
+        def expected = [hello: '世界']
+        assertEquals expected, value
+    }
 }

--- a/extensions/orgjson/src/test/groovy/io/jsonwebtoken/io/OrgJsonDeserializerTest.groovy
+++ b/extensions/orgjson/src/test/groovy/io/jsonwebtoken/io/OrgJsonDeserializerTest.groovy
@@ -1,5 +1,6 @@
 package io.jsonwebtoken.io
 
+import io.jsonwebtoken.io.serializer.OrgJsonDeserializer
 import io.jsonwebtoken.lang.Strings
 import org.junit.Test
 import static org.junit.Assert.*

--- a/extensions/orgjson/src/test/groovy/io/jsonwebtoken/io/OrgJsonSerializerTest.groovy
+++ b/extensions/orgjson/src/test/groovy/io/jsonwebtoken/io/OrgJsonSerializerTest.groovy
@@ -31,6 +31,18 @@ class OrgJsonSerializerTest {
     }
 
     @Test
+    void testDeprecatedConstructor() {
+        def serializer = new io.jsonwebtoken.io.OrgJsonSerializer()
+        def jsonString = new JSONString() {
+            @Override
+            String toJSONString() {
+                return '"foo"'
+            }
+        }
+        assertEquals '"foo"', new String(serializer.serialize(jsonString), Strings.UTF_8)
+    }
+
+    @Test
     void testToBytesFailure() {
 
         final IllegalArgumentException iae = new IllegalArgumentException("foo")

--- a/extensions/orgjson/src/test/groovy/io/jsonwebtoken/io/OrgJsonSerializerTest.groovy
+++ b/extensions/orgjson/src/test/groovy/io/jsonwebtoken/io/OrgJsonSerializerTest.groovy
@@ -1,6 +1,7 @@
 package io.jsonwebtoken.io
 
 import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.io.serializer.OrgJsonSerializer
 import io.jsonwebtoken.lang.DateFormats
 import io.jsonwebtoken.lang.Strings
 import org.json.JSONObject

--- a/impl/src/main/java/io/jsonwebtoken/impl/io/RuntimeClasspathDeserializerLocator.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/io/RuntimeClasspathDeserializerLocator.java
@@ -31,9 +31,9 @@ public class RuntimeClasspathDeserializerLocator<T> implements InstanceLocator<D
     @SuppressWarnings("WeakerAccess") //to allow testing override
     protected Deserializer<T> locate() {
         if (isAvailable("com.fasterxml.jackson.databind.ObjectMapper")) {
-            return Classes.newInstance("io.jsonwebtoken.io.JacksonDeserializer");
+            return Classes.newInstance("io.jsonwebtoken.io.serializer.JacksonDeserializer");
         } else if (isAvailable("org.json.JSONObject")) {
-            return Classes.newInstance("io.jsonwebtoken.io.OrgJsonDeserializer");
+            return Classes.newInstance("io.jsonwebtoken.io.serializer.OrgJsonDeserializer");
         } else {
             throw new IllegalStateException("Unable to discover any JSON Deserializer implementations on the classpath.");
         }

--- a/impl/src/main/java/io/jsonwebtoken/impl/io/RuntimeClasspathSerializerLocator.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/io/RuntimeClasspathSerializerLocator.java
@@ -31,9 +31,9 @@ public class RuntimeClasspathSerializerLocator implements InstanceLocator<Serial
     @SuppressWarnings("WeakerAccess") //to allow testing override
     protected Serializer<Object> locate() {
         if (isAvailable("com.fasterxml.jackson.databind.ObjectMapper")) {
-            return Classes.newInstance("io.jsonwebtoken.io.JacksonSerializer");
+            return Classes.newInstance("io.jsonwebtoken.io.serializer.JacksonSerializer");
         } else if (isAvailable("org.json.JSONObject")) {
-            return Classes.newInstance("io.jsonwebtoken.io.OrgJsonSerializer");
+            return Classes.newInstance("io.jsonwebtoken.io.serializer.OrgJsonSerializer");
         } else {
             throw new IllegalStateException("Unable to discover any JSON Serializer implementations on the classpath.");
         }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/io/RuntimeClasspathDeserializerLocatorTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/io/RuntimeClasspathDeserializerLocatorTest.groovy
@@ -2,8 +2,8 @@ package io.jsonwebtoken.impl.io
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.jsonwebtoken.io.Deserializer
-import io.jsonwebtoken.io.JacksonDeserializer
-import io.jsonwebtoken.io.OrgJsonDeserializer
+import io.jsonwebtoken.io.serializer.JacksonDeserializer
+import io.jsonwebtoken.io.serializer.OrgJsonDeserializer
 import org.junit.After
 import org.junit.Before
 import org.junit.Test

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/io/RuntimeClasspathSerializerLocatorTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/io/RuntimeClasspathSerializerLocatorTest.groovy
@@ -2,8 +2,8 @@ package io.jsonwebtoken.impl.io
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.jsonwebtoken.io.Serializer
-import io.jsonwebtoken.io.JacksonSerializer
-import io.jsonwebtoken.io.OrgJsonSerializer
+import io.jsonwebtoken.io.serializer.JacksonSerializer
+import io.jsonwebtoken.io.serializer.OrgJsonSerializer
 import org.junit.After
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
Addresses #399 

I have encountered the same issue reported by @gutmox when trying to use jjwt with Java 11 modules. (The module system doesn't work with split packages)

This PR takes @gutmox's commit in #400 and adds some backwards compatibility and deprecation notices to the original class names.

I would note, however, that this issue won't be resolved until the `io.jsonwebtokens.io` package is no longer exported by the extension modules. This PR would allow you to release a 0.10.6 with the deprecation notice and a path towards desired future use. Then, with release 0.11, you could eliminate the split package issue entirely by removing the classes that are (re-)introduced here.