### PR TITLE
Fixes #397 : avoid dependency side effect to affect choice of json se…

### DIFF
--- a/impl/src/main/java/io/jsonwebtoken/impl/io/RuntimeClasspathDeserializerLocator.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/io/RuntimeClasspathDeserializerLocator.java
@@ -30,9 +30,9 @@ public class RuntimeClasspathDeserializerLocator<T> implements InstanceLocator<D
 
     @SuppressWarnings("WeakerAccess") //to allow testing override
     protected Deserializer<T> locate() {
-        if (isAvailable("com.fasterxml.jackson.databind.ObjectMapper")) {
+        if (isAvailable("io.jsonwebtoken.io.JacksonDeserializer")) {
             return Classes.newInstance("io.jsonwebtoken.io.JacksonDeserializer");
-        } else if (isAvailable("org.json.JSONObject")) {
+        } else if (isAvailable("io.jsonwebtoken.io.OrgJsonDeserializer")) {
             return Classes.newInstance("io.jsonwebtoken.io.OrgJsonDeserializer");
         } else {
             throw new IllegalStateException("Unable to discover any JSON Deserializer implementations on the classpath.");

--- a/impl/src/main/java/io/jsonwebtoken/impl/io/RuntimeClasspathSerializerLocator.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/io/RuntimeClasspathSerializerLocator.java
@@ -30,9 +30,9 @@ public class RuntimeClasspathSerializerLocator implements InstanceLocator<Serial
 
     @SuppressWarnings("WeakerAccess") //to allow testing override
     protected Serializer<Object> locate() {
-        if (isAvailable("com.fasterxml.jackson.databind.ObjectMapper")) {
+        if (isAvailable("io.jsonwebtoken.io.JacksonSerializer")) {
             return Classes.newInstance("io.jsonwebtoken.io.JacksonSerializer");
-        } else if (isAvailable("org.json.JSONObject")) {
+        } else if (isAvailable("io.jsonwebtoken.io.OrgJsonSerializer")) {
             return Classes.newInstance("io.jsonwebtoken.io.OrgJsonSerializer");
         } else {
             throw new IllegalStateException("Unable to discover any JSON Serializer implementations on the classpath.");

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/io/RuntimeClasspathDeserializerLocatorTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/io/RuntimeClasspathDeserializerLocatorTest.groovy
@@ -86,7 +86,7 @@ class RuntimeClasspathDeserializerLocatorTest {
         def locator = new RuntimeClasspathDeserializerLocator() {
             @Override
             protected boolean isAvailable(String fqcn) {
-                if (ObjectMapper.class.getName().equals(fqcn)) {
+                if (JacksonDeserializer.class.getName().equals(fqcn)) {
                     return false; //skip it to allow the OrgJson impl to be created
                 }
                 return super.isAvailable(fqcn)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/io/RuntimeClasspathSerializerLocatorTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/io/RuntimeClasspathSerializerLocatorTest.groovy
@@ -1,6 +1,5 @@
 package io.jsonwebtoken.impl.io
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.jsonwebtoken.io.Serializer
 import io.jsonwebtoken.io.JacksonSerializer
 import io.jsonwebtoken.io.OrgJsonSerializer
@@ -86,7 +85,7 @@ class RuntimeClasspathSerializerLocatorTest {
         def locator = new RuntimeClasspathSerializerLocator() {
             @Override
             protected boolean isAvailable(String fqcn) {
-                if (ObjectMapper.class.getName().equals(fqcn)) {
+                if (JacksonSerializer.class.getName().equals(fqcn)) {
                     return false //skip it to allow the OrgJson impl to be created
                 }
                 return super.isAvailable(fqcn)


### PR DESCRIPTION
…rializer/deserializer.

Problem : jwt jackson des/serialization is used when a project depends on jackson and jjwt-orgjson.
```
io.jsonwebtoken.lang.UnknownClassException: Unable to load class named [io.jsonwebtoken.io.JacksonSerializer] from the thread context, current, or system/application ClassLoaders.  All heuristics have been exhausted.  Class could not be found.
	at io.jsonwebtoken.lang.Classes.forName(Classes.java:92)
	at io.jsonwebtoken.lang.Classes.newInstance(Classes.java:136)
	at io.jsonwebtoken.impl.io.RuntimeClasspathSerializerLocator.locate(RuntimeClasspathSerializerLocator.java:34)
	at io.jsonwebtoken.impl.io.RuntimeClasspathSerializerLocator.getInstance(RuntimeClasspathSerializerLocator.java:21)
	at io.jsonwebtoken.impl.io.RuntimeClasspathSerializerLocator.getInstance(RuntimeClasspathSerializerLocator.java:12)
	at io.jsonwebtoken.impl.DefaultJwtBuilder.compact(DefaultJwtBuilder.java:301)
```

This PR makes sure to test on jwtdes/serialization classes instead of json des/serialization classes. This avoids to choose jwt-jackson when a projects depends itself on jackson.