### PR TITLE
#84 JwtBuilder.setClaims() now accepts `Map<String, ?> claims`

### DIFF
--- a/api/src/main/java/io/jsonwebtoken/JwtBuilder.java
+++ b/api/src/main/java/io/jsonwebtoken/JwtBuilder.java
@@ -21,7 +21,6 @@ import io.jsonwebtoken.io.Encoder;
 import io.jsonwebtoken.io.Serializer;
 import io.jsonwebtoken.security.InvalidKeyException;
 import io.jsonwebtoken.security.Keys;
-
 import java.security.Key;
 import java.util.Date;
 import java.util.Map;
@@ -106,7 +105,7 @@ public interface JwtBuilder extends ClaimsMutator<JwtBuilder> {
      * @param claims the JWT claims to be set as the JWT body.
      * @return the builder for method chaining.
      */
-    JwtBuilder setClaims(Map<String, Object> claims);
+    JwtBuilder setClaims(Map<String, ?> claims);
 
     /**
      * Adds all given name/value pairs to the JSON Claims in the payload. If a Claims instance does not yet exist at the

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultClaims.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultClaims.java
@@ -17,7 +17,6 @@ package io.jsonwebtoken.impl;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.RequiredTypeException;
-
 import java.util.Date;
 import java.util.Map;
 
@@ -27,7 +26,7 @@ public class DefaultClaims extends JwtMap implements Claims {
         super();
     }
 
-    public DefaultClaims(Map<String, Object> map) {
+    public DefaultClaims(Map<String, ?> map) {
         super(map);
     }
 

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
@@ -175,7 +175,7 @@ public class DefaultJwtBuilder implements JwtBuilder {
     }
 
     @Override
-    public JwtBuilder setClaims(Map<String, Object> claims) {
+    public JwtBuilder setClaims(Map<String, ?> claims) {
         this.claims = new DefaultClaims(claims);
         return this;
     }

--- a/impl/src/main/java/io/jsonwebtoken/impl/JwtMap.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/JwtMap.java
@@ -17,7 +17,6 @@ package io.jsonwebtoken.impl;
 
 import io.jsonwebtoken.lang.Assert;
 import io.jsonwebtoken.lang.DateFormats;
-
 import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Collection;
@@ -34,7 +33,7 @@ public class JwtMap implements Map<String, Object> {
         this.map = new LinkedHashMap<>();
     }
 
-    public JwtMap(Map<String, Object> map) {
+    public JwtMap(Map<String, ?> map) {
         this();
         Assert.notNull(map, "Map argument cannot be null.");
         putAll(map);


### PR DESCRIPTION
fixes #84

This would allow to pass `Map<String,String>`