### PR TITLE
Idea: Use a ServiceLoader to find the Serializer/Deserializer on the classpath

### DIFF
--- a/extensions/gson/src/main/resources/META-INF/services/io.jsonwebtoken.io.Deserializer
+++ b/extensions/gson/src/main/resources/META-INF/services/io.jsonwebtoken.io.Deserializer
@@ -1,0 +1,1 @@
+io.jsonwebtoken.gson.io.GsonDeserializer

--- a/extensions/gson/src/main/resources/META-INF/services/io.jsonwebtoken.io.Serializer
+++ b/extensions/gson/src/main/resources/META-INF/services/io.jsonwebtoken.io.Serializer
@@ -1,0 +1,1 @@
+io.jsonwebtoken.gson.io.GsonSerializer

--- a/extensions/jackson/src/main/resources/META-INF/services/io.jsonwebtoken.io.Deserializer
+++ b/extensions/jackson/src/main/resources/META-INF/services/io.jsonwebtoken.io.Deserializer
@@ -1,0 +1,1 @@
+io.jsonwebtoken.jackson.io.JacksonDeserializer

--- a/extensions/jackson/src/main/resources/META-INF/services/io.jsonwebtoken.io.Serializer
+++ b/extensions/jackson/src/main/resources/META-INF/services/io.jsonwebtoken.io.Serializer
@@ -1,0 +1,1 @@
+io.jsonwebtoken.jackson.io.JacksonSerializer

--- a/extensions/orgjson/src/main/resources/META-INF/services/io.jsonwebtoken.io.Deserializer
+++ b/extensions/orgjson/src/main/resources/META-INF/services/io.jsonwebtoken.io.Deserializer
@@ -1,0 +1,1 @@
+io.jsonwebtoken.orgjson.io.OrgJsonDeserializer

--- a/extensions/orgjson/src/main/resources/META-INF/services/io.jsonwebtoken.io.Serializer
+++ b/extensions/orgjson/src/main/resources/META-INF/services/io.jsonwebtoken.io.Serializer
@@ -1,0 +1,1 @@
+io.jsonwebtoken.orgjson.io.OrgJsonSerializer

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
@@ -297,7 +297,7 @@ public class DefaultJwtBuilder implements JwtBuilder {
         if (this.serializer == null) {
             //try to find one based on the runtime environment:
             InstanceLocator<Serializer<Map<String,?>>> locator =
-                Classes.newInstance("io.jsonwebtoken.impl.io.RuntimeClasspathSerializerLocator");
+                Classes.newInstance("io.jsonwebtoken.impl.io.ServiceLoaderSerializerLocator");
             this.serializer = locator.getInstance();
         }
 

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -223,7 +223,7 @@ public class DefaultJwtParser implements JwtParser {
         if (this.deserializer == null) {
             //try to find one based on the runtime environment:
             InstanceLocator<Deserializer<Map<String, ?>>> locator =
-                Classes.newInstance("io.jsonwebtoken.impl.io.RuntimeClasspathDeserializerLocator");
+                Classes.newInstance("io.jsonwebtoken.impl.io.ServiceLoaderDeserializerLocator");
             this.deserializer = locator.getInstance();
         }
 

--- a/impl/src/main/java/io/jsonwebtoken/impl/io/ServiceLoaderDeserializerLocator.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/io/ServiceLoaderDeserializerLocator.java
@@ -1,0 +1,18 @@
+package io.jsonwebtoken.impl.io;
+
+import io.jsonwebtoken.io.Deserializer;
+
+/**
+ * @since 0.11.0
+ */
+public class ServiceLoaderDeserializerLocator implements InstanceLocator<Deserializer> {
+
+    @Override
+    public Deserializer getInstance() {
+        return Holder.serializer;
+    }
+
+    private static class Holder {
+        private static final Deserializer serializer = ServiceLoaderUtil.loadFromService(Deserializer.class);
+    }
+}

--- a/impl/src/main/java/io/jsonwebtoken/impl/io/ServiceLoaderSerializerLocator.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/io/ServiceLoaderSerializerLocator.java
@@ -1,0 +1,18 @@
+package io.jsonwebtoken.impl.io;
+
+import io.jsonwebtoken.io.Serializer;
+
+/**
+ * @since 0.11.0
+ */
+public class ServiceLoaderSerializerLocator implements InstanceLocator<Serializer> {
+
+    @Override
+    public Serializer getInstance() {
+        return Holder.serializer;
+    }
+
+    private static class Holder {
+        private static final Serializer serializer = ServiceLoaderUtil.loadFromService(Serializer.class);
+    }
+}

--- a/impl/src/main/java/io/jsonwebtoken/impl/io/ServiceLoaderUtil.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/io/ServiceLoaderUtil.java
@@ -1,0 +1,24 @@
+package io.jsonwebtoken.impl.io;
+
+import java.util.Iterator;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+final class ServiceLoaderUtil {
+
+    static <T> T loadFromService(Class<T> serviceClass) {
+            String errorMessage = "ServiceLoader failed to find implementation for class: '%s', you are likely missing" +
+                    "a dependency such as 'io.jsonwebtoken:jjwt-jackson', see https://github.com/jwtk/jjwt#json-support";
+        try {
+            ServiceLoader<T> serviceLoader = ServiceLoader.load(serviceClass);
+
+            Iterator<T> iter = serviceLoader.iterator();
+            if (iter.hasNext()) {
+                return iter.next();
+            }
+        } catch(ServiceConfigurationError e) {
+            throw new IllegalStateException(String.format(errorMessage, serviceClass.getName()), e);
+        }
+        throw new IllegalStateException(String.format(errorMessage, serviceClass.getName()));
+    }
+}


### PR DESCRIPTION
This allows for the discovery of the Serializer implementation without needing to hardcode the class names in RuntimeClasspathSerializerLocator

**NOTE:** Java 1.8+ we can drop the manual managing of the META-INF/services dir and use a compile-time annotation processor: https://github.com/google/auto/tree/master/service

TODO:
- [ ] fix coverage
- [ ] remove RuntimeClasspathSerializerLocator