### PR TITLE
Follow RFC of "alg" claim being case-sensitive

### DIFF
--- a/api/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
+++ b/api/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
@@ -40,7 +40,7 @@ public enum SignatureAlgorithm {
     /**
      * JWA name for {@code No digital signature or MAC performed}
      */
-    NONE("none", "No digital signature or MAC performed", "None", null, false, 0, 0),
+    none("none", "No digital signature or MAC performed", "None", null, false, 0, 0),
 
     /**
      * JWA algorithm name for {@code HMAC using SHA-256}
@@ -327,9 +327,9 @@ public enum SignatureAlgorithm {
      */
     private void assertValid(Key key, boolean signing) throws InvalidKeyException {
 
-        if (this == NONE) {
+        if (this == none) {
 
-            String msg = "The 'NONE' signature algorithm does not support cryptographic keys.";
+            String msg = "The 'none' signature algorithm does not support cryptographic keys.";
             throw new InvalidKeyException(msg);
 
         } else if (isHmac()) {
@@ -629,7 +629,7 @@ public enum SignatureAlgorithm {
      */
     public static SignatureAlgorithm forName(String value) throws SignatureException {
         for (SignatureAlgorithm alg : values()) {
-            if (alg.getValue().equalsIgnoreCase(value)) {
+            if (alg.getValue().equals(value)) {
                 return alg;
             }
         }

--- a/api/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
+++ b/api/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
@@ -39,7 +39,7 @@ class SignatureAlgorithmTest {
     @Test
     void testNames() {
         def algNames = ['HS256', 'HS384', 'HS512', 'RS256', 'RS384', 'RS512',
-                        'ES256', 'ES384', 'ES512', 'PS256', 'PS384', 'PS512', 'NONE']
+                        'ES256', 'ES384', 'ES512', 'PS256', 'PS384', 'PS512', 'none']
 
         for (String name : algNames) {
             testName(name)
@@ -121,7 +121,7 @@ class SignatureAlgorithmTest {
     @Test
     void testIsJdkStandard() {
         for (SignatureAlgorithm alg : SignatureAlgorithm.values()) {
-            if (alg.name().startsWith("PS") || alg == SignatureAlgorithm.NONE) {
+            if (alg.name().startsWith("PS") || alg == SignatureAlgorithm.none) {
                 assertFalse alg.isJdkStandard()
             } else {
                 assertTrue alg.isJdkStandard()
@@ -132,7 +132,7 @@ class SignatureAlgorithmTest {
     @Test
     void testGetMinKeyLength() {
         for(SignatureAlgorithm alg : SignatureAlgorithm.values()) {
-            if (alg == SignatureAlgorithm.NONE) {
+            if (alg == SignatureAlgorithm.none) {
                 assertEquals 0, alg.getMinKeyLength()
             } else {
                 if (alg.isRsa()) {
@@ -283,10 +283,10 @@ class SignatureAlgorithmTest {
     void testAssertValidSigningKeyWithNoneAlgorithm() {
         Key key = createMock(Key)
         try {
-            SignatureAlgorithm.NONE.assertValidSigningKey(key)
+            SignatureAlgorithm.none.assertValidSigningKey(key)
             fail()
         } catch (InvalidKeyException expected) {
-            assertEquals "The 'NONE' signature algorithm does not support cryptographic keys." as String, expected.message
+            assertEquals "The 'none' signature algorithm does not support cryptographic keys." as String, expected.message
         }
     }
 
@@ -613,10 +613,10 @@ class SignatureAlgorithmTest {
     void testAssertValidVerificationKeyWithNoneAlgorithm() {
         Key key = createMock(Key)
         try {
-            SignatureAlgorithm.NONE.assertValidVerificationKey(key)
+            SignatureAlgorithm.none.assertValidVerificationKey(key)
             fail()
         } catch (InvalidKeyException expected) {
-            assertEquals "The 'NONE' signature algorithm does not support cryptographic keys." as String, expected.message
+            assertEquals "The 'none' signature algorithm does not support cryptographic keys." as String, expected.message
         }
     }
 

--- a/api/src/test/groovy/io/jsonwebtoken/security/KeysTest.groovy
+++ b/api/src/test/groovy/io/jsonwebtoken/security/KeysTest.groovy
@@ -113,7 +113,7 @@ class KeysTest {
 
             String name = alg.name()
 
-            if (name.equals('NONE') || name.startsWith('H')) {
+            if (name.equals('none') || name.startsWith('H')) {
                 try {
                     Keys.keyPairFor(alg)
                     fail()

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
@@ -322,7 +322,7 @@ public class DefaultJwtBuilder implements JwtBuilder {
             jwsHeader.setAlgorithm(algorithm.getValue());
         } else {
             //no signature - plaintext JWT:
-            jwsHeader.setAlgorithm(SignatureAlgorithm.NONE.getValue());
+            jwsHeader.setAlgorithm(SignatureAlgorithm.none.getValue());
         }
 
         if (compressionCodec != null) {

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -344,7 +344,7 @@ public class DefaultJwtParser implements JwtParser {
                 }
             }
 
-            if (algorithm == null || algorithm == SignatureAlgorithm.NONE) {
+            if (algorithm == null || algorithm == SignatureAlgorithm.none) {
                 //it is plaintext, but it has a signature.  This is invalid:
                 String msg = "JWT string has a digest/signature, but the header does not reference a valid signature " +
                     "algorithm.";

--- a/impl/src/test/groovy/io/jsonwebtoken/DeprecatedJwtsTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/DeprecatedJwtsTest.groovy
@@ -625,7 +625,7 @@ class DeprecatedJwtsTest {
         //now let's create a fake header and payload with whatever we want (without signing):
         String forged = Jwts.builder().setSubject("Not Joe").compact()
 
-        //assert that our forged header has a 'NONE' algorithm:
+        //assert that our forged header has a 'none' algorithm:
         assertEquals Jwts.parser().parseClaimsJwt(forged).getHeader().get('alg'), 'none'
 
         //now let's forge it by appending the signature the server expects:

--- a/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
@@ -625,7 +625,7 @@ class JwtsTest {
         //now let's create a fake header and payload with whatever we want (without signing):
         String forged = Jwts.builder().setSubject("Not Joe").compact()
 
-        //assert that our forged header has a 'NONE' algorithm:
+        //assert that our forged header has a 'none' algorithm:
         assertEquals Jwts.parserBuilder().build().parseClaimsJwt(forged).getHeader().get('alg'), 'none'
 
         //now let's forge it by appending the signature the server expects:

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/crypto/DefaultSignatureValidatorFactoryTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/crypto/DefaultSignatureValidatorFactoryTest.groovy
@@ -28,10 +28,10 @@ class DefaultSignatureValidatorFactoryTest {
     void testNoneAlgorithm() {
         try {
             new DefaultSignatureValidatorFactory().createSignatureValidator(
-                    SignatureAlgorithm.NONE, Keys.secretKeyFor(SignatureAlgorithm.HS256))
+                    SignatureAlgorithm.none, Keys.secretKeyFor(SignatureAlgorithm.HS256))
             fail()
         } catch (IllegalArgumentException iae) {
-            assertEquals iae.message, "The 'NONE' algorithm cannot be used for signing."
+            assertEquals iae.message, "The 'none' algorithm cannot be used for signing."
         }
     }
 }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/crypto/DefaultSignerFactoryTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/crypto/DefaultSignerFactoryTest.groovy
@@ -30,10 +30,10 @@ class DefaultSignerFactoryTest {
         def factory = new DefaultSignerFactory();
 
         try {
-            factory.createSigner(SignatureAlgorithm.NONE, Keys.secretKeyFor(SignatureAlgorithm.HS256))
+            factory.createSigner(SignatureAlgorithm.none, Keys.secretKeyFor(SignatureAlgorithm.HS256))
             fail();
         } catch (IllegalArgumentException iae) {
-            assertEquals iae.message, "The 'NONE' algorithm cannot be used for signing."
+            assertEquals iae.message, "The 'none' algorithm cannot be used for signing."
         }
     }
 


### PR DESCRIPTION
According to [https://tools.ietf.org/html/rfc7515#section-4.1.1](https://tools.ietf.org/html/rfc7515#section-4.1.1) the "alg" claim is case sensitive and should be treated as such.