### PR TITLE
README edits for 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 This minor release:
 
+* Adds [Google's Gson](https://github.com/google/gson) as a natively supported JSON parser. Installation instructions 
+  have been updated and new [JJWT Gson usage guidelines](https://github.com/jwtk/jjwt#json-gson) have been added.
 * Updates the Jackson dependency version to [2.9.10](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9#patches)
 to address three security vulnerabilities in Jackson.
-* A new JwtParserBuilder interface has been added and is the recommended way of creating a JwtParser instance.  Mutable methods in `JwtParser` will be removed before v1.0.
+* A new `JwtParserBuilder` interface has been added and is the recommended way of creating an immutable and thread-safe JwtParser instance.  Mutable methods in `JwtParser` will be removed before v1.0.
     Migration to the new signatures is straightforward, for example:
     
     Previous Version:
@@ -22,8 +24,15 @@ to address three security vulnerabilities in Jackson.
         .build()
         .parse(jwtString)
     ```
-* Adds support for custom types when deserializing with Jackson. To use configure your parser with `Jwts.parserBuilder().deserializeJsonWith(new JacksonDeserializer(Maps.of("claimName", YourType.class).build())).build()`.
-* Adds `io.jsonwebtoken.lang.Maps` utility class to make creation of maps fluent.
+* Adds `io.jsonwebtoken.lang.Maps` utility class to make creation of maps fluent, as demonstrated next.
+* Adds support for custom types when deserializing with Jackson. To use configure your parser:
+    ```java
+    Jwts.parserBuilder().deserializeJsonWith(
+        new JacksonDeserializer(
+            Maps.of("claimName", YourType.class).build() // <--
+        )
+    ).build()
+  ```
 * Moves JSON Serializer/Deserializer implementations to a different package name.
   - `io.jsonwebtoken.io.JacksonSerializer` -> `io.jsonwebtoken.jackson.io.JacksonSerializer`
   - `io.jsonwebtoken.io.JacksonDeserializer` -> `io.jsonwebtoken.jackson.io.JacksonDeserializer`

--- a/api/src/main/java/io/jsonwebtoken/JwtParserBuilder.java
+++ b/api/src/main/java/io/jsonwebtoken/JwtParserBuilder.java
@@ -298,8 +298,8 @@ public interface JwtParserBuilder {
     JwtParserBuilder deserializeJsonWith(Deserializer<Map<String,?>> deserializer);
 
     /**
-     * Returns a {@link JwtParser} created from the configuration from this JwtParserBuilder.
-     * @return a JwtParser created from the configuration from this JwtParserBuilder.
+     * Returns an immutable/thread-safe {@link JwtParser} created from the configuration from this JwtParserBuilder.
+     * @return an immutable/thread-safe JwtParser created from the configuration from this JwtParserBuilder.
      */
     JwtParser build();
 }

--- a/api/src/main/java/io/jsonwebtoken/Jwts.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwts.java
@@ -122,9 +122,9 @@ public final class Jwts {
     }
 
     /**
-     * Returns a new {@link JwtParserBuilder} instance that can be configured and then used to parse JWT strings.
+     * Returns a new {@link JwtParserBuilder} instance that can be configured to create an immutable/thread-safe {@link JwtParser).
      *
-     * @return a new {@link JwtParser} instance that can be configured and then used to parse JWT strings.
+     * @return a new {@link JwtParser} instance that can be configured create an immutable/thread-safe {@link JwtParser).
      */
     public static JwtParserBuilder parserBuilder() {
         return Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtParserBuilder");


### PR DESCRIPTION
- Update README to use `parserBuilder()` instead of `parser()` (#499)
- Docs: Adds section to README covering custom object parsing (#500)
- Docs: Add note about JwtParserBuilder creating an immutable JwtParser (#508)
Doc: #486
Fixes: #494
Doc: #495
Fixes: #171