### PR TITLE
Allow JacksonDeserializer to work with Java 9+ Map.of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Release Notes
 
+### 0.11.1
+
+This patch release:
+
+* Fixes issue when using Java 9+ `Map.of` with JacksonDeserializer which resulted in an NullPointerException
+
 ### 0.11.0
 
 This minor release:

--- a/extensions/jackson/src/main/java/io/jsonwebtoken/jackson/io/JacksonDeserializer.java
+++ b/extensions/jackson/src/main/java/io/jsonwebtoken/jackson/io/JacksonDeserializer.java
@@ -120,8 +120,9 @@ public class JacksonDeserializer<T> implements Deserializer<T> {
         @Override
         public Object deserialize(JsonParser parser, DeserializationContext context) throws IOException {
             // check if the current claim key is mapped, if so traverse it's value
-            if (claimTypeMap != null && claimTypeMap.containsKey(parser.currentName())) {
-                Class type = claimTypeMap.get(parser.currentName());
+            String name = parser.currentName();
+            if (claimTypeMap != null && name != null && claimTypeMap.containsKey(name)) {
+                Class type = claimTypeMap.get(name);
                 return parser.readValueAsTree().traverse(parser.getCodec()).readValueAs(type);
             }
             // otherwise default to super


### PR DESCRIPTION
and other maps that do NOT allow null keys