### PR TITLE
Accept oid in assertValid

### DIFF
--- a/api/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
+++ b/api/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
@@ -123,18 +123,20 @@ public enum SignatureAlgorithm {
     private final int digestLength;
     private final int minKeyLength;
     /**
+     * Algorithm name as given by {@link Key#getAlgorithm()} if the key was loaded from a pkcs12 Keystore.
+     *
      * @deprecated This is just a workaround for https://bugs.openjdk.java.net/browse/JDK-8243551
      */
     @Deprecated
-    private final String oid;
+    private final String pkcs12Name;
 
     SignatureAlgorithm(String value, String description, String familyName, String jcaName, boolean jdkStandard,
                        int digestLength, int minKeyLength) {
-        this(value, description,familyName, jcaName, jdkStandard, digestLength, minKeyLength, null);
+        this(value, description,familyName, jcaName, jdkStandard, digestLength, minKeyLength, jcaName);
     }
 
     SignatureAlgorithm(String value, String description, String familyName, String jcaName, boolean jdkStandard,
-                       int digestLength, int minKeyLength, String oid) {
+                       int digestLength, int minKeyLength, String pkcs12Name) {
         this.value = value;
         this.description = description;
         this.familyName = familyName;
@@ -142,7 +144,7 @@ public enum SignatureAlgorithm {
         this.jdkStandard = jdkStandard;
         this.digestLength = digestLength;
         this.minKeyLength = minKeyLength;
-        this.oid = oid;
+        this.pkcs12Name = pkcs12Name;
     }
 
     /**
@@ -365,9 +367,9 @@ public enum SignatureAlgorithm {
             if (!HS256.jcaName.equalsIgnoreCase(alg) &&
                 !HS384.jcaName.equalsIgnoreCase(alg) &&
                 !HS512.jcaName.equalsIgnoreCase(alg) &&
-                !HS256.oid.equals(alg) &&
-                !HS384.oid.equals(alg) &&
-                !HS512.oid.equals(alg)) {
+                !HS256.pkcs12Name.equals(alg) &&
+                !HS384.pkcs12Name.equals(alg) &&
+                !HS512.pkcs12Name.equals(alg)) {
                 throw new InvalidKeyException("The " + keyType(signing) + " key's algorithm '" + alg +
                     "' does not equal a valid HmacSHA* algorithm name and cannot be used with " + name() + ".");
             }

--- a/api/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
+++ b/api/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
@@ -298,10 +298,9 @@ public enum SignatureAlgorithm {
      * @return alternative algorithm names to the {@link #getJcaName() jcaName} that may occur, e.g. when loading keys
      * from a pkcs#12 keystore.
      * @since 0.11.2
-     * @deprecated To be removed, when the corresponding JDK Bug is fixed.
+     * @deprecated To be removed, when <a href="https://bugs.openjdk.java.net/browse/JDK-8243551">JDK-8243551</a> is fixed.
      */
-    // TODO: Link JDK Bug in documentation
-    @Deprecated()
+    @Deprecated
     public List<String> getAlternativeNames() {
         return this.alternativeNames;
     }

--- a/api/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
+++ b/api/src/main/java/io/jsonwebtoken/SignatureAlgorithm.java
@@ -122,10 +122,19 @@ public enum SignatureAlgorithm {
     private final boolean jdkStandard;
     private final int digestLength;
     private final int minKeyLength;
-    private final List<String> alternativeNames;
+    /**
+     * @deprecated This is just a workaround for https://bugs.openjdk.java.net/browse/JDK-8243551
+     */
+    @Deprecated
+    private final String oid;
 
     SignatureAlgorithm(String value, String description, String familyName, String jcaName, boolean jdkStandard,
-                       int digestLength, int minKeyLength, String... alternativeNames) {
+                       int digestLength, int minKeyLength) {
+        this(value, description,familyName, jcaName, jdkStandard, digestLength, minKeyLength, null);
+    }
+
+    SignatureAlgorithm(String value, String description, String familyName, String jcaName, boolean jdkStandard,
+                       int digestLength, int minKeyLength, String oid) {
         this.value = value;
         this.description = description;
         this.familyName = familyName;
@@ -133,7 +142,7 @@ public enum SignatureAlgorithm {
         this.jdkStandard = jdkStandard;
         this.digestLength = digestLength;
         this.minKeyLength = minKeyLength;
-        this.alternativeNames = Collections.unmodifiableList(Arrays.asList(alternativeNames));
+        this.oid = oid;
     }
 
     /**
@@ -292,20 +301,6 @@ public enum SignatureAlgorithm {
     }
 
     /**
-     * Returns alternative algorithm names to the {@link #getJcaName() jcaName} that may occur, e.g. when loading keys
-     * from a pkcs#12 keystore.
-     *
-     * @return alternative algorithm names to the {@link #getJcaName() jcaName} that may occur, e.g. when loading keys
-     * from a pkcs#12 keystore.
-     * @since 0.11.2
-     * @deprecated To be removed, when <a href="https://bugs.openjdk.java.net/browse/JDK-8243551">JDK-8243551</a> is fixed.
-     */
-    @Deprecated
-    public List<String> getAlternativeNames() {
-        return this.alternativeNames;
-    }
-
-    /**
      * Returns quietly if the specified key is allowed to create signatures using this algorithm
      * according to the <a href="https://tools.ietf.org/html/rfc7518">JWT JWA Specification (RFC 7518)</a> or throws an
      * {@link InvalidKeyException} if the key is not allowed or not secure enough for this algorithm.
@@ -370,9 +365,9 @@ public enum SignatureAlgorithm {
             if (!HS256.jcaName.equalsIgnoreCase(alg) &&
                 !HS384.jcaName.equalsIgnoreCase(alg) &&
                 !HS512.jcaName.equalsIgnoreCase(alg) &&
-                !HS256.alternativeNames.contains(alg) &&
-                !HS384.alternativeNames.contains(alg) &&
-                !HS512.alternativeNames.contains(alg)) {
+                !HS256.oid.equals(alg) &&
+                !HS384.oid.equals(alg) &&
+                !HS512.oid.equals(alg)) {
                 throw new InvalidKeyException("The " + keyType(signing) + " key's algorithm '" + alg +
                     "' does not equal a valid HmacSHA* algorithm name and cannot be used with " + name() + ".");
             }

--- a/api/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
+++ b/api/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
@@ -396,21 +396,19 @@ class SignatureAlgorithmTest {
             int numBits = alg.minKeyLength
             int numBytes = numBits / 8 as int
 
-            for(String altName in alg.alternativeNames) {
-                SecretKey key = createMock(SecretKey)
-                expect(key.getEncoded()).andReturn(new byte[numBytes])
-                expect(key.getAlgorithm()).andReturn(altName)
+            SecretKey key = createMock(SecretKey)
+            expect(key.getEncoded()).andReturn(new byte[numBytes])
+            expect(key.getAlgorithm()).andReturn(alg.oid)
 
-                replay key
+            replay key
 
-                alg.assertValidSigningKey(key)
+            alg.assertValidSigningKey(key)
 
-                verify key
-            }
+            verify key
         }
 
         for (SignatureAlgorithm alg in SignatureAlgorithm.values().findAll {!it.isHmac()}) {
-            assertEquals(Collections.emptyList(), alg.alternativeNames)
+            assertNull(alg.oid)
         }
     }
 

--- a/api/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
+++ b/api/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
@@ -24,9 +24,7 @@ import org.junit.Test
 import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
 import java.security.Key
-import java.security.KeyStore
 import java.security.PrivateKey
-import java.security.cert.Certificate
 import java.security.interfaces.ECPrivateKey
 import java.security.interfaces.ECPublicKey
 import java.security.interfaces.RSAPrivateKey
@@ -391,6 +389,10 @@ class SignatureAlgorithmTest {
 
     @Test // https://github.com/jwtk/jjwt/issues/588
     void assertAssertValidHmacSigningKeyCaseOidAlgorithmName() {
+        for (SignatureAlgorithm alg in EnumSet.complementOf(EnumSet.of(SignatureAlgorithm.NONE))) {
+            assertNotNull(alg.pkcs12Name)
+        }
+
         for (SignatureAlgorithm alg in SignatureAlgorithm.values().findAll {it.isHmac()}) {
 
             int numBits = alg.minKeyLength
@@ -398,7 +400,7 @@ class SignatureAlgorithmTest {
 
             SecretKey key = createMock(SecretKey)
             expect(key.getEncoded()).andReturn(new byte[numBytes])
-            expect(key.getAlgorithm()).andReturn(alg.oid)
+            expect(key.getAlgorithm()).andReturn(alg.pkcs12Name)
 
             replay key
 
@@ -408,7 +410,8 @@ class SignatureAlgorithmTest {
         }
 
         for (SignatureAlgorithm alg in SignatureAlgorithm.values().findAll {!it.isHmac()}) {
-            assertNull(alg.oid)
+            assertEquals("For non HmacSHA-keys the name when loaded from pkcs12 key store is identical to the jcaName",
+                    alg.jcaName, alg.pkcs12Name)
         }
     }
 

--- a/api/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
+++ b/api/src/test/groovy/io/jsonwebtoken/SignatureAlgorithmTest.groovy
@@ -24,7 +24,9 @@ import org.junit.Test
 import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
 import java.security.Key
+import java.security.KeyStore
 import java.security.PrivateKey
+import java.security.cert.Certificate
 import java.security.interfaces.ECPrivateKey
 import java.security.interfaces.ECPublicKey
 import java.security.interfaces.RSAPrivateKey
@@ -384,6 +386,22 @@ class SignatureAlgorithmTest {
             alg.assertValidSigningKey(key)
 
             verify key
+        }
+    }
+
+    @Test // https://github.com/jwtk/jjwt/issues/588
+    void testPkcs12Names() {
+        KeyStore pkcs12 = KeyStore.getInstance("pkcs12")
+        pkcs12.load(null, "keystorepassword".toCharArray())
+        for (SignatureAlgorithm alg in SignatureAlgorithm.values().findAll {it.isHmac()}) {
+            Key sk = new SecretKeySpec(new byte[alg.minKeyLength / 8], alg.jcaName)
+            pkcs12.setKeyEntry(alg.name(), sk, "keypassword".toCharArray(), new Certificate[0]);
+            Key sk2 = pkcs12.getKey(alg.name(), "keypassword".toCharArray());
+            alg.assertValidSigningKey(sk2);
+        }
+
+        for (SignatureAlgorithm alg in SignatureAlgorithm.values().findAll {!it.isHmac()}) {
+            assertEquals(Collections.emptyList(), alg.alternativeNames)
         }
     }
 


### PR DESCRIPTION
Hello,

This is a first draft for jwtk/jjwt#588

I've added the OIDs for Hmac-Keys and extended the check in the assertValid method. There are multiple ways of doing this, I decided to extend the SignatureAlgorithm's constructor with a varargs parameter to avoid having to modify all enum values.

For the test, an actual pkcs12 KeyStore instance is used to store and load the key. I suppose, one could mock the key. Would that be necessary?

The coverage checks failed to upload in my cloned repository, I suppose they will successfully do so, when the pr is built.