### PR TITLE
Add support for jdk14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ jdk:
   - oraclejdk9
   - openjdk10
   - openjdk11
+  - openjdk14
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <bouncycastle.version>1.60</bouncycastle.version>
 
         <!-- Test Dependencies: Only required for testing when building.  Not required by users at runtime: -->
-        <groovy.version>2.5.9</groovy.version>
+        <groovy.version>2.5.11</groovy.version>
         <logback.version>1.2.3</logback.version>
         <easymock.version>3.6</easymock.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
Hi,

I've noticed, that jjwt tests fail in JDK14 because of [GROOVY-9211]. I've taken the liberty to add openjdk14 as a build in travis configuration and bumped the groovy version to 2.5.11, where the issue is fixed.

[GROOVY-9211]: https://issues.apache.org/jira/browse/GROOVY-9211