### PR TITLE
Always use UTF-8 in GsonDeserializer

### DIFF
--- a/extensions/gson/src/main/java/io/jsonwebtoken/gson/io/GsonDeserializer.java
+++ b/extensions/gson/src/main/java/io/jsonwebtoken/gson/io/GsonDeserializer.java
@@ -19,6 +19,8 @@ import com.google.gson.Gson;
 import io.jsonwebtoken.io.DeserializationException;
 import io.jsonwebtoken.io.Deserializer;
 import io.jsonwebtoken.lang.Assert;
+import io.jsonwebtoken.lang.Strings;
+
 import java.io.IOException;
 
 public class GsonDeserializer<T> implements Deserializer<T> {
@@ -54,6 +56,6 @@ public class GsonDeserializer<T> implements Deserializer<T> {
     }
 
     protected T readValue(byte[] bytes) throws IOException {
-        return gson.fromJson(new String(bytes), returnType);
+        return gson.fromJson(new String(bytes, Strings.UTF_8), returnType);
     }
 }


### PR DESCRIPTION
Hello,

in this piece of code:
```java
    protected T readValue(byte[] bytes) throws IOException {
        return gson.fromJson(new String(bytes), returnType);
    }
```
`new String(bytes)` will use system default Charset, while `UTF-8` should be used according to JWT RFC: https://tools.ietf.org/html/rfc7519#section-7.2

So, if JVM was started with "`-Dfile.encoding=ISO-8859-1`" system property then `GsonDeserializer` corrupts data during deserialization:
![jjwt_unicode](https://user-images.githubusercontent.com/10956519/82067749-cd9e6180-96d9-11ea-8c1e-3e5c71bb7664.png)
