### PR TITLE
Removes Java 7 from CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@
 dist: trusty
 language: java
 jdk:
-  - openjdk7 # not really openjdk7 - we're just using this travis placeholder for our own Oracle JDK 7 installation
   - oraclejdk8
   - oraclejdk9
   - openjdk10
@@ -18,25 +17,6 @@ cache:
 before_install:
   - echo "TRAVIS_JDK_VERSION is ${TRAVIS_JDK_VERSION}"
   - export MVN_CMD="./mvnw --no-transfer-progress" # hide verbose download messages (log spam)
-  - |
-    if [[ "${TRAVIS_JDK_VERSION}" == "openjdk7" ]]; then
-      
-      export MAVEN_OPTS="-Dhttps.protocols=TLSv1.2 -Xmx512m -XX:MaxPermSize=128m"
-      export JAVA_HOME="/usr/lib/jvm/java-7-oracle" # Set JAVA_HOME to where we want to install Oracle JDK 7
-      export PATH="${JAVA_HOME}/bin:${PATH}"
-      
-      if [[ ! -d "${JAVA_HOME}" ]]; then
-        # Download and install Oracle JDK 7:
-        wget https://s3.amazonaws.com/d2fbee19-5fe2-425f-ae11-cd25b35dc99a/jdk-7u80-linux-x64.tar.gz -O /tmp/jdk-7u80-linux-x64.tar.gz
-        tar xvfz /tmp/jdk-7u80-linux-x64.tar.gz -C /tmp
-        sudo mv /tmp/jdk1.7.0_80 "${JAVA_HOME}"
-      fi
-      
-      # Download and install JCE Unlimited Strength Crypto policies for Oracle JDK 7:
-      curl -q -L -C - https://238dj3282as03k369.s3-us-west-1.amazonaws.com/UnlimitedJCEPolicyJDK7.zip -o /tmp/UnlimitedJCEPolicyJDK7.zip
-      sudo unzip -oj -d "$JAVA_HOME/jre/lib/security" /tmp/UnlimitedJCEPolicyJDK7.zip \*/\*.jar
-      rm /tmp/UnlimitedJCEPolicyJDK7.zip
-    fi
   # If on JDK 8, ensure build coverage assertions are run (we only need to run this on one JDK to reduce overall build times):
   - export BUILD_COVERAGE="$([ $TRAVIS_JDK_VERSION == 'oraclejdk8' ] && echo 'true')"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Release Notes
 
+### 0.11.3
+
+This patch release:
+
+* CI is no longer running tests against Java 7. Classes are still compiled to a source/target of 1.7 to ensure compatibility with Android.
+
 ### 0.11.2
 
 This patch release:


### PR DESCRIPTION

🤔 once Java 15 drops, we _should_ probably update the test to run against 8, 11, latest (15). So we don't run into issues where it becomes difficult to install the older unsupported JVMs