### PR TITLE
Remove redundant Proguard statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,11 +336,8 @@ You can use the following [Android Proguard](https://developer.android.com/studi
 -keepattributes InnerClasses
 
 -keep class io.jsonwebtoken.** { *; }
--keepnames class io.jsonwebtoken.* { *; }
--keepnames interface io.jsonwebtoken.* { *; }
 
 -keep class org.bouncycastle.** { *; }
--keepnames class org.bouncycastle.** { *; }
 -dontwarn org.bouncycastle.**
 ```
 


### PR DESCRIPTION
Proguard `keepnames` is redundant with `keep`. 

Based on [Proguard manual](https://www.guardsquare.com/en/products/proguard/manual/usage), `interface` modifier is redundant because `class` modifier already covers classes and interfaces.
> The class keyword refers to any interface or class. Theinterface keyword restricts matches to interface classes.