### PR TITLE
Microoptimalization: Dates ++

### DIFF
--- a/api/src/main/java/io/jsonwebtoken/Clock.java
+++ b/api/src/main/java/io/jsonwebtoken/Clock.java
@@ -28,6 +28,16 @@ public interface Clock {
      * Returns the clock's current timestamp at the instant the method is invoked.
      *
      * @return the clock's current timestamp at the instant the method is invoked.
+     * @deprecated
      */
     Date now();
+
+    /**
+     * Returns the clock's current timestamp at the instant the method is invoked.
+     *
+     * @return the clock's current timestamp at the instant the method is invoked.
+     */
+
+    long millis();
+
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultClock.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultClock.java
@@ -36,8 +36,12 @@ public class DefaultClock implements Clock {
      *
      * @return a new {@link Date} instance.
      */
-    @Override
     public Date now() {
-        return new Date();
+        return new Date(millis());
+    }
+
+    @Override
+    public long millis() {
+        return System.currentTimeMillis();
     }
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/FixedClock.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/FixedClock.java
@@ -27,14 +27,14 @@ import java.util.Date;
  */
 public class FixedClock implements Clock {
 
-    private final Date now;
+    private final long now;
 
     /**
      * Creates a new fixed clock using <code>new {@link Date Date}()</code> as the seed timestamp.  All calls to
      * {@link #now now()} will always return this seed Date.
      */
     public FixedClock() {
-        this(new Date());
+        this(System.currentTimeMillis());
     }
 
     /**
@@ -43,12 +43,20 @@ public class FixedClock implements Clock {
      *
      * @param now the specified Date to always return from all calls to {@link #now now()}.
      */
-    public FixedClock(Date now) {
+    public FixedClock(long now) {
         this.now = now;
     }
 
-    @Override
+    public FixedClock(Date now) {
+        this(now.getTime());
+    }
+
     public Date now() {
+    	return new Date(millis());
+    }
+    
+    @Override
+    public long millis() {
         return this.now;
     }
 }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/FixedClockTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/FixedClockTest.groovy
@@ -29,6 +29,6 @@ class FixedClockTest {
         Thread.sleep(100)
         def date2 = clock.now()
 
-        assertSame date1, date2
+        assertEquals date1, date2
     }
 }


### PR DESCRIPTION
Hi, 

I'm looking into the [performance](https://github.com/skjolber/java-jwt-benchmark) of the decoder, and though I'd start with at few low-hanging fruits.

Reduce the (unnessesary) use of throwaway Date objects.
Remove `allowSkew` variable.
Use a big enough StringBuilder. 