### PR TITLE
Rename parsing methods with misleading names

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ JJWT is a pure Java implementation based
 exclusively on the [JWT](https://tools.ietf.org/html/rfc7519), 
 [JWS](https://tools.ietf.org/html/rfc7515), [JWE](https://tools.ietf.org/html/rfc7516), 
 [JWK](https://tools.ietf.org/html/rfc7517) and [JWA](https://tools.ietf.org/html/rfc7518) RFC specifications and 
-open source under the terms of the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).
+open source under the terms of the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
 
-The library was created by [Okta's](http://www.okta.com) Senior Architect, [Les Hazlewood](https://github.com/lhazlewood)
+The library was created by [Okta's](https://www.okta.com/) Senior Architect, [Les Hazlewood](https://github.com/lhazlewood)
 and is supported and maintained by a [community](https://github.com/jwtk/jjwt/graphs/contributors) of contributors.
 
 [Okta](https://developer.okta.com/) is a complete authentication and user management API for developers.
@@ -90,7 +90,7 @@ enforcement.
  * Fully functional on all JDKs and Android
  * Automatic security best practices and assertions
  * Easy to learn and read API
- * Convenient and readable [fluent](http://en.wikipedia.org/wiki/Fluent_interface) interfaces, great for IDE auto-completion to write code quickly
+ * Convenient and readable [fluent](https://en.wikipedia.org/wiki/Fluent_interface) interfaces, great for IDE auto-completion to write code quickly
  * Fully RFC specification compliant on all implemented functionality, tested against RFC-specified test vectors
  * Stable implementation with enforced 100% test code coverage.  Literally every single method, statement and 
    conditional branch variant in the entire codebase is tested and required to pass on every build.
@@ -368,7 +368,7 @@ you more quickly and efficiently.
 <a name="quickstart"></a>
 ## Quickstart
 
-Most complexity is hidden behind a convenient and readable builder-based [fluent interface](http://en.wikipedia.org/wiki/Fluent_interface), great for relying on IDE auto-completion to write code quickly.  Here's an example:
+Most complexity is hidden behind a convenient and readable builder-based [fluent interface](https://en.wikipedia.org/wiki/Fluent_interface), great for relying on IDE auto-completion to write code quickly.  Here's an example:
 
 ```java
 import io.jsonwebtoken.Jwts;
@@ -1397,7 +1397,7 @@ Jwts.parserBuilder()
 
     .build()
 
-    .parseClaimsJwt(aJwtString)
+    .parsePlaintextUnsignedJwt(aJwtString)
 
     .getBody()
     
@@ -1639,4 +1639,4 @@ Maintained by Les Hazlewood &amp; [Okta](https://okta.com/)
 <a name="license"></a>
 ## License
 
-This project is open-source via the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).
+This project is open-source via the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/api/src/main/java/io/jsonwebtoken/Claims.java
+++ b/api/src/main/java/io/jsonwebtoken/Claims.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * <p>This is ultimately a JSON map and any values can be added to it, but JWT standard names are provided as
  * type-safe getters and setters for convenience.</p>
  *
- * <p>Because this interface extends {@code Map&lt;String, Object&gt;}, if you would like to add your own properties,
+ * <p>Because this interface extends {@code Map<String, Object>}, if you would like to add your own properties,
  * you simply use map methods, for example:</p>
  *
  * <pre>

--- a/api/src/main/java/io/jsonwebtoken/JwtHandler.java
+++ b/api/src/main/java/io/jsonwebtoken/JwtHandler.java
@@ -19,6 +19,19 @@ package io.jsonwebtoken;
  * A JwtHandler is invoked by a {@link io.jsonwebtoken.JwtParser JwtParser} after parsing a JWT to indicate the exact
  * type of JWT or JWS parsed.
  *
+ * <p>The handler differentiates between signed (JWS) and unsigned tokens, and tokens whose payload consists of JSON
+ * data (represented as {@link Claims}) or non-JSON data (represented as {@code String} and called 'plaintext' in the
+ * following):
+ * <ul>
+ * <li>Unsigned tokens:<ul>
+ * <li>{@link #onPlaintextJwt(Jwt)}</li>
+ * <li>{@link #onClaimsJwt(Jwt)}</li>
+ * </ul></li>
+ * <li>Signed tokens (JWS):<ul>
+ * <li>{@link #onPlaintextJws(Jws)}</li>
+ * <li>{@link #onClaimsJws(Jws)}</li>
+ * </ul></li>
+ *
  * @param <T> the type of object to return to the parser caller after handling the parsed JWT.
  * @since 0.2
  */
@@ -26,7 +39,7 @@ public interface JwtHandler<T> {
 
     /**
      * This method is invoked when a {@link io.jsonwebtoken.JwtParser JwtParser} determines that the parsed JWT is
-     * a plaintext JWT.  A plaintext JWT has a String (non-JSON) body payload and it is not cryptographically signed.
+     * a plaintext JWT.  A plaintext JWT has a String (non-JSON) body payload and it is <b>not cryptographically signed</b>.
      *
      * @param jwt the parsed plaintext JWT
      * @return any object to be used after inspecting the JWT, or {@code null} if no return value is necessary.
@@ -35,7 +48,7 @@ public interface JwtHandler<T> {
 
     /**
      * This method is invoked when a {@link io.jsonwebtoken.JwtParser JwtParser} determines that the parsed JWT is
-     * a Claims JWT.  A Claims JWT has a {@link Claims} body and it is not cryptographically signed.
+     * a Claims JWT.  A Claims JWT has a {@link Claims} body and it is <b>not cryptographically signed</b>.
      *
      * @param jwt the parsed claims JWT
      * @return any object to be used after inspecting the JWT, or {@code null} if no return value is necessary.

--- a/api/src/main/java/io/jsonwebtoken/JwtHandlerAdapter.java
+++ b/api/src/main/java/io/jsonwebtoken/JwtHandlerAdapter.java
@@ -16,7 +16,7 @@
 package io.jsonwebtoken;
 
 /**
- * An <a href="http://en.wikipedia.org/wiki/Adapter_pattern">Adapter</a> implementation of the
+ * An <a href="https://en.wikipedia.org/wiki/Adapter_pattern">Adapter</a> implementation of the
  * {@link JwtHandler} interface that allows for anonymous subclasses to process only the JWT results that are
  * known/expected for a particular use case.
  *

--- a/api/src/main/java/io/jsonwebtoken/JwtParserBuilder.java
+++ b/api/src/main/java/io/jsonwebtoken/JwtParserBuilder.java
@@ -29,7 +29,7 @@ import java.util.Map;
  *         .setSigningKey(...)
  *         .requireIssuer("https://issuer.example.com")
  *         .build()
- *         .parse(jwtString)
+ *         .parseClaimsJws(jwtString)
  * }</pre>
  * @since 0.11.0
  */

--- a/api/src/main/java/io/jsonwebtoken/Jwts.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwts.java
@@ -105,14 +105,14 @@ public final class Jwts {
      * <pre>{@code
      *     Jwts.parser()
      *         .requireAudience("string")
-     *         .parse(jwtString)
+     *         .parseClaimsUnsignedJwt(jwtString)
      * }</pre>
      * <p>New code:
      * <pre>{@code
      *     Jwts.parserBuilder()
      *         .requireAudience("string")
      *         .build()
-     *         .parse(jwtString)
+     *         .parseClaimsUnsignedJwt(jwtString)
      * }</pre>
      * <p><b>NOTE: this method will be removed before version 1.0</b>
      */

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -245,9 +245,14 @@ public class DefaultJwtParser implements JwtParser {
         return false;
     }
 
+    @Deprecated
     @Override
     public Jwt parse(String jwt) throws ExpiredJwtException, MalformedJwtException, SignatureException {
+        return parseSignedOrUnsigned(jwt);
+    }
 
+    @Override
+    public Jwt parseSignedOrUnsigned(String jwt) throws ExpiredJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
         // TODO, this logic is only need for a now deprecated code path
         // remove this block in v1.0 (the equivalent is already in DefaultJwtParserBuilder)
         if (this.deserializer == null) {
@@ -567,8 +572,14 @@ public class DefaultJwtParser implements JwtParser {
         }
     }
 
+    @Deprecated
     @Override
-    public Jwt<Header, String> parsePlaintextJwt(String plaintextJwt) {
+    public Jwt<Header, String> parsePlaintextJwt(String plaintextJwt) throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
+        return parsePlaintextUnsignedJwt(plaintextJwt);
+    }
+
+    @Override
+    public Jwt<Header, String> parsePlaintextUnsignedJwt(String plaintextJwt) throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
         return parse(plaintextJwt, new JwtHandlerAdapter<Jwt<Header, String>>() {
             @Override
             public Jwt<Header, String> onPlaintextJwt(Jwt<Header, String> jwt) {
@@ -577,8 +588,14 @@ public class DefaultJwtParser implements JwtParser {
         });
     }
 
+    @Deprecated
     @Override
-    public Jwt<Header, Claims> parseClaimsJwt(String claimsJwt) {
+    public Jwt<Header, Claims> parseClaimsJwt(String claimsJwt) throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
+        return parseClaimsUnsignedJwt(claimsJwt);
+    }
+
+    @Override
+    public Jwt<Header, Claims> parseClaimsUnsignedJwt(String claimsJwt) throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
         try {
             return parse(claimsJwt, new JwtHandlerAdapter<Jwt<Header, Claims>>() {
                 @Override

--- a/impl/src/main/java/io/jsonwebtoken/impl/ImmutableJwtParser.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/ImmutableJwtParser.java
@@ -143,9 +143,15 @@ class ImmutableJwtParser implements JwtParser {
         return this.jwtParser.isSigned(jwt);
     }
 
+    @Deprecated
     @Override
     public Jwt parse(String jwt) throws ExpiredJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
-        return this.jwtParser.parse(jwt);
+        return parseSignedOrUnsigned(jwt);
+    }
+
+    @Override
+    public Jwt parseSignedOrUnsigned(String jwt) throws ExpiredJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
+        return this.jwtParser.parseSignedOrUnsigned(jwt);
     }
 
     @Override
@@ -153,14 +159,26 @@ class ImmutableJwtParser implements JwtParser {
         return this.jwtParser.parse(jwt, handler);
     }
 
+    @Deprecated
     @Override
     public Jwt<Header, String> parsePlaintextJwt(String plaintextJwt) throws UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
-        return this.jwtParser.parsePlaintextJwt(plaintextJwt);
+        return parsePlaintextUnsignedJwt(plaintextJwt);
     }
 
     @Override
+    public Jwt<Header, String> parsePlaintextUnsignedJwt(String plaintextJwt) throws UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
+        return this.jwtParser.parsePlaintextUnsignedJwt(plaintextJwt);
+    }
+
+    @Deprecated
+    @Override
     public Jwt<Header, Claims> parseClaimsJwt(String claimsJwt) throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
-        return this.jwtParser.parseClaimsJwt(claimsJwt);
+        return parseClaimsUnsignedJwt(claimsJwt);
+    }
+
+    @Override
+    public Jwt<Header, Claims> parseClaimsUnsignedJwt(String claimsJwt) throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
+        return this.jwtParser.parseClaimsUnsignedJwt(claimsJwt);
     }
 
     @Override


### PR DESCRIPTION
Fixes #212

The interface `JwtParser` has multiple methods with misleading names:
- `parse`: Allows both signed and unsigned tokens
- `parseClaimsJwt`, `parsePlaintextJwt`: Name is misleading because JWT only describes the data format, so a signed token can also be considered a JWT. Additionally there is only a one character difference (<code>Jw<i>t</i></code> vs. <code>Jw<i>s</i></code>) between the method for unsigned and signed tokens, making it likely that the wrong method is chosen from IDE auto complete, and it is likely to be missed during code review.

This has lead to multiple applications being vulnerable due to having used the wrong method by accident.  #212 lists a few, additionally some further prominent examples (based on https://github.com/github/securitylab/issues/333):
- [DP3T](https://github.com/DP-3T/dp3t-sdk-backend/pull/208)
- [Apache Pulsar](https://github.com/apache/pulsar/pull/9172)
- [NHS Contact Tracing App](https://www.zofrex.com/blog/2020/10/20/alg-none-jwt-nhs-contact-tracing-app/)

This pull request deprecates these methods and instead adds methods with more expressive names. Note that this is a binary incompatible change because it introduces new abstract methods for the `JwtParser` interface. However, that is most likely not an issue because user code probably does not implement `JwtParser`. It appears this issue cannot be solved in a different way because this project is built with Java 7 which does not support `default` methods for interfaces.
