### PR TITLE
Adds handling for common JSON parsing exceptions and wraps them in a `JwtException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This patch release:
 
-* Adds handling for common JSON parsing exceptions and wraps them in a `JwtException`.
+* Adds additional handling for rare JSON parsing exceptions and wraps them in a `JwtException` to allow the application to handle these conditions as JWT concerns.
 
 ### 0.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Release Notes
 
+### 0.11.3
+
+This patch release:
+
+* Adds handling for common JSON parsing exceptions and wraps them in a `JwtException`.
+
 ### 0.11.2
 
 This patch release:

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParserBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParserBuilder.java
@@ -204,7 +204,7 @@ public class DefaultJwtParserBuilder implements JwtParserBuilder {
                                      allowedClockSkewMillis,
                                      expectedClaims,
                                      base64UrlDecoder,
-                                     deserializer,
+                                     new JwtDeserializer<>(deserializer),
                                      compressionCodecResolver));
     }
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/JwtDeserializer.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/JwtDeserializer.java
@@ -24,7 +24,7 @@ import io.jsonwebtoken.lang.Assert;
 import java.nio.charset.StandardCharsets;
 
 /**
- * A {@link Deserializer} implementation that wraps another Deserializer implementation to adds common JWT related
+ * A {@link Deserializer} implementation that wraps another Deserializer implementation to add common JWT related
  * error handling.
  * @param <T> type of object to deserialize.
  * @since 0.11.3

--- a/impl/src/main/java/io/jsonwebtoken/impl/JwtDeserializer.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/JwtDeserializer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2021 jsonwebtoken.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.jsonwebtoken.impl;
+
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.io.DeserializationException;
+import io.jsonwebtoken.io.Deserializer;
+import io.jsonwebtoken.io.IOException;
+import io.jsonwebtoken.lang.Assert;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A {@link Deserializer} implementation that wraps another Deserializer implementation to adds common JWT related
+ * error handling.
+ * @param <T> type of object to deserialize.
+ * @since 0.11.3
+ */
+class JwtDeserializer<T> implements Deserializer<T> {
+
+    static final String MALFORMED_ERROR = "Malformed JWT JSON: ";
+    static final String MALFORMED_COMPLEX_ERROR = "Malformed or excessively complex JWT JSON. This could reflect a potential malicious JWT, please investigate the JWT source further. JSON: ";
+
+    private final Deserializer<T> deserializer;
+
+    JwtDeserializer(Deserializer<T> deserializer) {
+        Assert.notNull(deserializer, "deserializer cannot be null.");
+        this.deserializer = deserializer;
+    }
+
+    @Override
+    public T deserialize(byte[] bytes) throws DeserializationException {
+        try {
+            return deserializer.deserialize(bytes);
+        } catch (DeserializationException e) {
+            throw new MalformedJwtException(MALFORMED_ERROR + new String(bytes, StandardCharsets.UTF_8), e);
+        } catch (StackOverflowError e) {
+            throw new IOException(MALFORMED_COMPLEX_ERROR + new String(bytes, StandardCharsets.UTF_8), e);
+        }
+    }
+}

--- a/impl/src/test/groovy/io/jsonwebtoken/DeprecatedJwtParserTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/DeprecatedJwtParserTest.groovy
@@ -83,7 +83,7 @@ class DeprecatedJwtParserTest {
             Jwts.parser().parse(bad)
             fail()
         } catch (MalformedJwtException expected) {
-            assertEquals expected.getMessage(), 'Unable to read JSON value: ' + junkPayload
+            assertEquals expected.getMessage(), 'Malformed JWT JSON: ' + junkPayload
         }
     }
 

--- a/impl/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
@@ -86,7 +86,7 @@ class JwtParserTest {
             Jwts.parserBuilder().build().parse(bad)
             fail()
         } catch (MalformedJwtException expected) {
-            assertEquals expected.getMessage(), 'Unable to read JSON value: ' + junkPayload
+            assertEquals expected.getMessage(), 'Malformed JWT JSON: ' + junkPayload
         }
     }
 

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserBuilderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserBuilderTest.groovy
@@ -98,7 +98,7 @@ class DefaultJwtParserBuilderTest {
     }
 
     @Test
-    void testDefaultDecoder() {
+    void testDefaultDeserializer() {
         JwtParser parser = new DefaultJwtParserBuilder().build()
         assertThat parser.jwtParser.deserializer, CoreMatchers.instanceOf(JwtDeserializer)
 
@@ -107,7 +107,7 @@ class DefaultJwtParserBuilderTest {
     }
 
     @Test
-    void testUserSetDecoderWrapsImplementation() {
+    void testUserSetDeserializerWrapped() {
         Deserializer deserializer = niceMock(Deserializer)
         JwtParser parser = new DefaultJwtParserBuilder()
             .deserializeJsonWith(deserializer)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserBuilderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserBuilderTest.groovy
@@ -16,6 +16,7 @@
 package io.jsonwebtoken.impl
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.jsonwebtoken.JwtParser
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import io.jsonwebtoken.io.Decoder
@@ -23,10 +24,13 @@ import io.jsonwebtoken.io.DecodingException
 import io.jsonwebtoken.io.DeserializationException
 import io.jsonwebtoken.io.Deserializer
 import io.jsonwebtoken.security.Keys
+import org.hamcrest.CoreMatchers
 import org.junit.Test
 
+import static org.easymock.EasyMock.niceMock
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertSame
+import static org.hamcrest.MatcherAssert.assertThat
 
 // NOTE to the casual reader: even though this test class appears mostly empty, the DefaultJwtParserBuilder
 // implementation is tested to 100% coverage.  The vast majority of its tests are in the JwtsTest class.  This class
@@ -91,5 +95,26 @@ class DefaultJwtParserBuilderTest {
         } catch (IllegalArgumentException expected) {
             assertEquals DefaultJwtParserBuilder.MAX_CLOCK_SKEW_ILLEGAL_MSG, expected.message
         }
+    }
+
+    @Test
+    void testDefaultDecoder() {
+        JwtParser parser = new DefaultJwtParserBuilder().build()
+        assertThat parser.jwtParser.deserializer, CoreMatchers.instanceOf(JwtDeserializer)
+
+        // TODO: When the ImmutableJwtParser replaces the default implementation this test will need updating, something like:
+        // assertThat parser.deserializer, CoreMatchers.instanceOf(JwtDeserializer)
+    }
+
+    @Test
+    void testUserSetDecoderWrapsImplementation() {
+        Deserializer deserializer = niceMock(Deserializer)
+        JwtParser parser = new DefaultJwtParserBuilder()
+            .deserializeJsonWith(deserializer)
+            .build()
+
+        // TODO: When the ImmutableJwtParser replaces the default implementation this test will need updating
+        assertThat parser.jwtParser.deserializer, CoreMatchers.instanceOf(JwtDeserializer)
+        assertSame deserializer, parser.jwtParser.deserializer.deserializer
     }
 }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserTest.groovy
@@ -29,6 +29,7 @@ import javax.crypto.SecretKey
 
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertSame
+import static org.junit.Assert.assertTrue
 
 // NOTE to the casual reader: even though this test class appears mostly empty, the DefaultJwtParser
 // implementation is tested to 100% coverage.  The vast majority of its tests are in the JwtsTest class.  This class
@@ -69,7 +70,8 @@ class DefaultJwtParserTest {
             }
         }
         def p = new DefaultJwtParser().deserializeJsonWith(deserializer)
-        assertSame deserializer, p.deserializer
+        assertTrue("Expected wrapping deserializer to be instance of JwtDeserializer", p.deserializer instanceof JwtDeserializer )
+        assertSame deserializer, p.deserializer.deserializer
 
         def key = Keys.secretKeyFor(SignatureAlgorithm.HS256)
 

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/JwtDeserializerTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/JwtDeserializerTest.groovy
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertEquals
 class JwtDeserializerTest {
 
     /**
-     * It's common for JSON parser's to throw a StackOverflowError when body is deeply nested. Since it's common
+     * It's common for JSON parsers to throw a StackOverflowError when body is deeply nested. Since it's common
      * across multiple parsers, JJWT handles the exception when parsing.
      */
     @Test
@@ -54,7 +54,7 @@ class JwtDeserializerTest {
     }
 
     /**
-     * Check that a DeserializationException, is wrapped and rethrown as a MalformedJwtException with a developer friendly message.
+     * Check that a DeserializationException is wrapped and rethrown as a MalformedJwtException with a developer friendly message.
      */
     @Test
     void testDeserializationExceptionMessage() {

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/JwtDeserializerTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/JwtDeserializerTest.groovy
@@ -38,7 +38,8 @@ class JwtDeserializerTest {
     @Test
     void testParserStackOverflowError() {
 
-        byte[] jsonBytes = '{"test": "testParserStackOverflowError"}'.getBytes(StandardCharsets.UTF_8)
+        String json = '{"test": "testParserStackOverflowError"}'
+        byte[] jsonBytes = json.getBytes(StandardCharsets.UTF_8)
 
         // create a Deserializer that will throw a StackOverflowError
         Deserializer<Map<String,?>> deserializer = mock(Deserializer)
@@ -49,7 +50,7 @@ class JwtDeserializerTest {
             new JwtDeserializer<>(deserializer).deserialize(jsonBytes)
             Assert.fail("Expected IOException")
         } catch (IOException e) {
-            assertEquals JwtDeserializer.MALFORMED_COMPLEX_ERROR + new String(jsonBytes), e.message
+            assertEquals JwtDeserializer.MALFORMED_COMPLEX_ERROR + json, e.message
         }
     }
 
@@ -59,7 +60,8 @@ class JwtDeserializerTest {
     @Test
     void testDeserializationExceptionMessage() {
 
-        byte[] jsonBytes = '{"test": "testDeserializationExceptionMessage"}'.getBytes(StandardCharsets.UTF_8)
+        String json = '{"test": "testDeserializationExceptionMessage"}'
+        byte[] jsonBytes = json.getBytes(StandardCharsets.UTF_8)
 
         // create a Deserializer that will throw a DeserializationException
         Deserializer<Map<String,?>> deserializer = mock(Deserializer)
@@ -70,7 +72,7 @@ class JwtDeserializerTest {
             new JwtDeserializer<>(deserializer).deserialize(jsonBytes)
             Assert.fail("Expected MalformedJwtException")
         } catch (MalformedJwtException e) {
-            assertEquals JwtDeserializer.MALFORMED_ERROR + new String(jsonBytes), e.message
+            assertEquals JwtDeserializer.MALFORMED_ERROR + json, e.message
         }
     }
 }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/JwtDeserializerTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/JwtDeserializerTest.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2021 jsonwebtoken.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.jsonwebtoken.impl
+
+import io.jsonwebtoken.MalformedJwtException
+import io.jsonwebtoken.io.DeserializationException
+import io.jsonwebtoken.io.Deserializer
+import io.jsonwebtoken.io.IOException
+import org.junit.Assert
+import org.junit.Test
+
+import java.nio.charset.StandardCharsets
+
+import static org.easymock.EasyMock.expect
+import static org.easymock.EasyMock.mock
+import static org.easymock.EasyMock.replay
+import static org.junit.Assert.assertEquals
+
+class JwtDeserializerTest {
+
+    /**
+     * It's common for JSON parser's to throw a StackOverflowError when body is deeply nested. Since it's common
+     * across multiple parsers, JJWT handles the exception when parsing.
+     */
+    @Test
+    void testParserStackOverflowError() {
+
+        byte[] jsonBytes = '{"test": "testParserStackOverflowError"}'.getBytes(StandardCharsets.UTF_8)
+
+        // create a Deserializer that will throw a StackOverflowError
+        Deserializer<Map<String,?>> deserializer = mock(Deserializer)
+        expect(deserializer.deserialize(jsonBytes)).andThrow(new StackOverflowError("Test exception: testParserStackOverflowError" ))
+        replay(deserializer)
+
+        try {
+            new JwtDeserializer<>(deserializer).deserialize(jsonBytes)
+            Assert.fail("Expected IOException")
+        } catch (IOException e) {
+            assertEquals JwtDeserializer.MALFORMED_COMPLEX_ERROR + new String(jsonBytes), e.message
+        }
+    }
+
+    /**
+     * Check that a DeserializationException, is wrapped and rethrown as a MalformedJwtException with a developer friendly message.
+     */
+    @Test
+    void testDeserializationExceptionMessage() {
+
+        byte[] jsonBytes = '{"test": "testDeserializationExceptionMessage"}'.getBytes(StandardCharsets.UTF_8)
+
+        // create a Deserializer that will throw a DeserializationException
+        Deserializer<Map<String,?>> deserializer = mock(Deserializer)
+        expect(deserializer.deserialize(jsonBytes)).andThrow(new DeserializationException("Test exception: testDeserializationExceptionMessage" ))
+        replay(deserializer)
+
+        try {
+            new JwtDeserializer<>(deserializer).deserialize(jsonBytes)
+            Assert.fail("Expected MalformedJwtException")
+        } catch (MalformedJwtException e) {
+            assertEquals JwtDeserializer.MALFORMED_ERROR + new String(jsonBytes), e.message
+        }
+    }
+}


### PR DESCRIPTION
Move the parser error handling logic out of DefaultJwtParser into the new JwtDeserializer and wraps them with developer freiendly exceptions
Add check for common JSON parsing exceptions like stack overflow when parsing deeply nested (or malformed) JSON
