### PR TITLE
Update fork of coverall-maven-plugin fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,29 +60,6 @@
         <url>https://travis-ci.org/jwtk/jjwt</url>
     </ciManagement>
 
-    <!-- temporary fix until official release of coverall-maven-plugin with clover support -->
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>bintray-jwtk-coveralls-maven-plugin</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/jwtk/coveralls-maven-plugin</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>bintray-jwtk-coveralls-maven-plugin</id>
-            <name>bintray-plugins</name>
-            <url>https://dl.bintray.com/jwtk/coveralls-maven-plugin</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <!-- temporary fix until official release of coverall-maven-plugin with clover support -->
-
     <properties>
 
         <jjwt.root>${basedir}</jjwt.root>
@@ -519,9 +496,9 @@
             </plugin>
             <!-- Temporarily host coveralls SNAPSHOT with clover support locally  -->
             <plugin>
-                <groupId>org.jwtk.coveralls</groupId>
+                <groupId>io.jsonwebtoken.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.4.0</version>
+                <version>4.4.1</version>
             </plugin>
             <!-- Temporarily host coveralls SNAPSHOT with clover support locally  -->
 


### PR DESCRIPTION
NOTE: This fork supports Clover for test coverage