### PR TITLE
Fix an inefficient keyset iterator

### DIFF
--- a/impl/src/main/java/io/jsonwebtoken/impl/JwtMap.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/JwtMap.java
@@ -172,8 +172,9 @@ public class JwtMap implements Map<String, Object> {
         if (m == null) {
             return;
         }
-        for (String s : m.keySet()) {
-            put(s, m.get(s));
+        for (Map.Entry <? extends String, ?>entry : m.entrySet()) {
+            String s = entry.getKey();
+            put(s, entry.getValue());
         }
     }
 


### PR DESCRIPTION
Found via infer on Lift, an inefficient keyset iterator is in the form:

```
for key in mapping:
    entry = mapping.find(key)
```

Which is linear-log instead of the more optimal linear solution.

N.B. This commit bundles in the Lift configuration (i.e. https://github.com/marketplace/muse-dev) used when this bug was found. If you install the app then depending on the preferences, we might want to add some of the other observed issue types to an ignore list.