### PR TITLE
Add a Sonatype Lift configuration to ignore uninteresting results

### DIFF
--- a/.lift/config.toml
+++ b/.lift/config.toml
@@ -1,0 +1,4 @@
+ignoreRules = ["MissingOverride"]
+ignoreFiles = '''
+**/test/**
+'''


### PR DESCRIPTION
Following up on the conversation in #690, this is a Sonatype Lift configuration if desired. It's an automation of many tools including Cobra, Semgrep, FindSecBugs, Infer, and Errorprone.  The [app is here](https://github.com/apps/sonatype-lift) and the [marketplace is there](https://github.com/marketplace/muse-dev).