### PR TITLE
Fallback to checking algorithm name if key not instanceof RSAKey or EC.

### DIFF
--- a/impl/src/main/java/io/jsonwebtoken/impl/crypto/EllipticCurveSigner.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/crypto/EllipticCurveSigner.java
@@ -29,7 +29,7 @@ public class EllipticCurveSigner extends EllipticCurveProvider implements Signer
 
     public EllipticCurveSigner(SignatureAlgorithm alg, Key key) {
         super(alg, key);
-        if (!(key instanceof PrivateKey && key instanceof ECKey)) {
+        if (!(key instanceof PrivateKey && (key instanceof ECKey || "EC".equals(key.getAlgorithm()) || "ECDSA".equals(key.getAlgorithm())))) {
             String msg = "Elliptic Curve signatures must be computed using an EC PrivateKey.  The specified key of " +
                          "type " + key.getClass().getName() + " is not an EC PrivateKey.";
             throw new IllegalArgumentException(msg);

--- a/impl/src/main/java/io/jsonwebtoken/impl/crypto/RsaSigner.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/crypto/RsaSigner.java
@@ -30,7 +30,7 @@ public class RsaSigner extends RsaProvider implements Signer {
         super(alg, key);
         // https://github.com/jwtk/jjwt/issues/68
         // Instead of checking for an instance of RSAPrivateKey, check for PrivateKey and RSAKey:
-        if (!(key instanceof PrivateKey && key instanceof RSAKey)) {
+        if (!(key instanceof PrivateKey && (key instanceof RSAKey || "RSA".equals(key.getAlgorithm())))) {
             String msg = "RSA signatures must be computed using an RSA PrivateKey.  The specified key of type " +
                          key.getClass().getName() + " is not an RSA PrivateKey.";
             throw new IllegalArgumentException(msg);


### PR DESCRIPTION
Thank you all for a great library!

**For this pull request I am suggesting a small improvement which would take away the need to override the RsaSigner or EllipticCurveSigner to support PrivateKeys not being instances of RSAKey or ECKey but still being able to check the key type as today but to also use the method recommended in the PKCS#11 guide. The change is basically to fallback to check PrivateKey.getAlgorithm().**

Background:

PrivateKey objects protected by hardware such as smart card or HSM and using the SunPKCS11 provider do not implement RSAKey and ECKey as they are unextractable. This makes it cumbersome with a lot of overriding to do in order to use JJWT. This has previously been discussed in #273 and #160 and possibly some other all though from a different angle.

Explanation in the Java PKCS#11 guide is here:
> Key objects representing unextractable token keys should only implement the relevant generic interfaces in the java.security and javax.crypto packages (PrivateKey, PublicKey, or SecretKey). Identification of the algorithm of a key should be performed using the Key.getAlgorithm() method. 
[PKCS#11 Reference Guide section Token Keys](https://docs.oracle.com/en/java/javase/11/security/pkcs11-reference-guide1.html#GUID-508B5E3B-BF39-4E02-A1BD-523352D3AA12)

For the cases where those interfaces are used to check key parameters it is not so easy to see how this could be improved without API changes. Probably for those cases the API would have to take a KeyPair and not just the PrivateKey as the parameters could then be checked on the PublicKey object instead of the PrivateKey one. This is out of scope for this PR.