### PR TITLE
[#719] JSON-B extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1287,8 +1287,7 @@ They are checked in order, and the first one found is used:
 Jackson will force a sizable (> 1 MB) dependency to an Android application thus increasing the app download size for 
 mobile users.
 
-If you want to use POJOs and a JSON-B compliant specification _**or**_ you want to use JJWT on a JakartaEE compliant application server, use
-`io.jsonwebtoken:jjwt-jsonb`.
+If you want to use POJOs and a JSON-B compliant specification _**or**_ you want to use JJWT on a JakartaEE compliant application server, use `io.jsonwebtoken:jjwt-jsonb`.
 
 <a name="json-custom"></a>
 ### Custom JSON Processor

--- a/README.md
+++ b/README.md
@@ -1269,10 +1269,26 @@ They are checked in order, and the first one found is used:
    Android applications _unless_ you want to use POJOs as claims.  The `org.json` library supports simple 
    Object-to-JSON marshaling, but it *does not* support JSON-to-Object unmarshalling.
 
+4. JSON-B: This will automatically be used if you specify `io.jsonwebtoken:jjwt-jsonb` as a project runtime dependency.
+   JSON-B also supports POJOs as claims with full marshaling/unmarshaling as necessary.
+
+   **NOTE**: `JSON-B` is just a specification and does not bring an implementation.
+   
+   * In Java-SE environments you will need to add three more dependencies:
+      1. `jakarta.json:jakarta.json-api`
+      2. `jakarta.json.bind:jakarta.json.bind-api`
+      3. A JSON-B compliant implementation like [Eclipse Yasson](https://github.com/eclipse-ee4j/yasson) or [Apache Johnzon](https://johnzon.apache.org/johnzon-jsonb/index.html).
+   * In Java/Jakarta EE environments, you might need to enable the following features:
+      1. json-p / json-api
+      2. json-b / json-bind
+
 **If you want to use POJOs as claim values, use either the `io.jsonwebtoken:jjwt-jackson` or 
 `io.jsonwebtoken:jjwt-gson` dependency** (or implement your own Serializer and Deserializer if desired). **But beware**, 
 Jackson will force a sizable (> 1 MB) dependency to an Android application thus increasing the app download size for 
 mobile users.
+
+If you want to use POJOs and a JSON-B compliant specification _**or**_ you want to use JJWT on a JakartaEE compliant application server, use
+`io.jsonwebtoken:jjwt-jsonb`.
 
 <a name="json-custom"></a>
 ### Custom JSON Processor

--- a/extensions/jsonb/bnd.bnd
+++ b/extensions/jsonb/bnd.bnd
@@ -1,0 +1,1 @@
+Fragment-Host: io.jsonwebtoken.jjwt-api 

--- a/extensions/jsonb/pom.xml
+++ b/extensions/jsonb/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-root</artifactId>
+        <version>0.11.3-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>jjwt-jsonb</artifactId>
+    <name>JJWT :: Extensions :: JSON-B</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <jjwt.root>${basedir}/../..</jjwt.root>
+        <!-- JSON-B uses static methods in interfaces. -->
+        <jdk.version>8</jdk.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependency -->
+        <dependency>
+            <groupId>org.apache.johnzon</groupId>
+            <artifactId>johnzon-jsonb</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions/jsonb/src/main/java/io/jsonwebtoken/jsonb/io/JsonbDeserializer.java
+++ b/extensions/jsonb/src/main/java/io/jsonwebtoken/jsonb/io/JsonbDeserializer.java
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
 import static java.util.Objects.requireNonNull;
 
 /**
- * @since 0.10.0
+ * @since JJWT_RELEASE_VERSION
  */
 public class JsonbDeserializer<T> implements Deserializer<T> {
 

--- a/extensions/jsonb/src/main/java/io/jsonwebtoken/jsonb/io/JsonbDeserializer.java
+++ b/extensions/jsonb/src/main/java/io/jsonwebtoken/jsonb/io/JsonbDeserializer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2014 jsonwebtoken.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.jsonwebtoken.jsonb.io;
+
+import io.jsonwebtoken.io.DeserializationException;
+import io.jsonwebtoken.io.Deserializer;
+
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbException;
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @since 0.10.0
+ */
+public class JsonbDeserializer<T> implements Deserializer<T> {
+
+    private final Class<T> returnType;
+    private final Jsonb jsonb;
+
+    @SuppressWarnings("unused") //used via reflection by RuntimeClasspathDeserializerLocator
+    public JsonbDeserializer() {
+        this(JsonbSerializer.DEFAULT_JSONB);
+    }
+
+    @SuppressWarnings({"unchecked", "WeakerAccess", "unused"}) // for end-users providing a custom ObjectMapper
+    public JsonbDeserializer(Jsonb jsonb) {
+        this(jsonb, (Class<T>) Object.class);
+    }
+
+    private JsonbDeserializer(Jsonb jsonb, Class<T> returnType) {
+        requireNonNull(jsonb, "ObjectMapper cannot be null.");
+        requireNonNull(returnType, "Return type cannot be null.");
+        this.jsonb = jsonb;
+        this.returnType = returnType;
+    }
+
+    @Override
+    public T deserialize(byte[] bytes) throws DeserializationException {
+        try {
+            return readValue(bytes);
+        } catch (JsonbException jsonbException) {
+            String msg = "Unable to deserialize bytes into a " + returnType.getName() + " instance: " + jsonbException.getMessage();
+            throw new DeserializationException(msg, jsonbException);
+        }
+    }
+
+    protected T readValue(byte[] bytes) {
+        return jsonb.fromJson(new String(bytes, StandardCharsets.UTF_8), returnType);
+    }
+
+}

--- a/extensions/jsonb/src/main/java/io/jsonwebtoken/jsonb/io/JsonbSerializer.java
+++ b/extensions/jsonb/src/main/java/io/jsonwebtoken/jsonb/io/JsonbSerializer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2014 jsonwebtoken.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.jsonwebtoken.jsonb.io;
+
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.io.SerializationException;
+import io.jsonwebtoken.io.Serializer;
+import io.jsonwebtoken.lang.Assert;
+
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+import javax.json.bind.JsonbException;
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @since 0.10.0
+ */
+public class JsonbSerializer<T> implements Serializer<T> {
+
+    static final Jsonb DEFAULT_JSONB = JsonbBuilder.create();
+
+    private final Jsonb jsonb;
+
+    @SuppressWarnings("unused") //used via reflection by RuntimeClasspathDeserializerLocator
+    public JsonbSerializer() {
+        this(DEFAULT_JSONB);
+    }
+
+    @SuppressWarnings("WeakerAccess") //intended for end-users to use when providing a custom ObjectMapper
+    public JsonbSerializer(Jsonb jsonb) {
+        requireNonNull(jsonb, "Jsonb cannot be null.");
+        this.jsonb = jsonb;
+    }
+
+    @Override
+    public byte[] serialize(T t) throws SerializationException {
+        Assert.notNull(t, "Object to serialize cannot be null.");
+        try {
+            return writeValueAsBytes(t);
+        } catch (JsonbException jsonbException) {
+            String msg = "Unable to serialize object: " + jsonbException.getMessage();
+            throw new SerializationException(msg, jsonbException);
+        }
+    }
+
+    @SuppressWarnings("WeakerAccess") //for testing
+    protected byte[] writeValueAsBytes(T t) {
+        final Object obj;
+
+        if (t instanceof byte[]) {
+            obj = Encoders.BASE64.encode((byte[]) t);
+        } else if (t instanceof char[]) {
+            obj = new String((char[]) t);
+        } else {
+            obj = t;
+        }
+
+        return this.jsonb.toJson(obj).getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/extensions/jsonb/src/main/java/io/jsonwebtoken/jsonb/io/JsonbSerializer.java
+++ b/extensions/jsonb/src/main/java/io/jsonwebtoken/jsonb/io/JsonbSerializer.java
@@ -28,7 +28,7 @@ import java.nio.charset.StandardCharsets;
 import static java.util.Objects.requireNonNull;
 
 /**
- * @since 0.10.0
+ * @since JJWT_RELEASE_VERSION
  */
 public class JsonbSerializer<T> implements Serializer<T> {
 
@@ -49,7 +49,7 @@ public class JsonbSerializer<T> implements Serializer<T> {
 
     @Override
     public byte[] serialize(T t) throws SerializationException {
-        Assert.notNull(t, "Object to serialize cannot be null.");
+        requireNonNull(t, "Object to serialize cannot be null.");
         try {
             return writeValueAsBytes(t);
         } catch (JsonbException jsonbException) {

--- a/extensions/jsonb/src/main/resources/META-INF/services/io.jsonwebtoken.io.Deserializer
+++ b/extensions/jsonb/src/main/resources/META-INF/services/io.jsonwebtoken.io.Deserializer
@@ -1,0 +1,1 @@
+io.jsonwebtoken.jsonb.io.JsonbDeserializer

--- a/extensions/jsonb/src/main/resources/META-INF/services/io.jsonwebtoken.io.Serializer
+++ b/extensions/jsonb/src/main/resources/META-INF/services/io.jsonwebtoken.io.Serializer
@@ -1,0 +1,1 @@
+io.jsonwebtoken.jsonb.io.JsonbSerializer

--- a/extensions/jsonb/src/test/groovy/io/jsonwebtoken/jsonb/io/JsonbDeserializerTest.groovy
+++ b/extensions/jsonb/src/test/groovy/io/jsonwebtoken/jsonb/io/JsonbDeserializerTest.groovy
@@ -1,0 +1,76 @@
+package io.jsonwebtoken.jsonb.io
+
+import io.jsonwebtoken.io.DeserializationException
+import io.jsonwebtoken.io.Deserializer
+import io.jsonwebtoken.lang.Strings
+import org.junit.Test
+
+import javax.json.bind.JsonbBuilder
+
+import static org.easymock.EasyMock.*
+import static org.hamcrest.CoreMatchers.instanceOf
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.junit.Assert.*
+
+class JsonbDeserializerTest {
+
+  @Test
+  void loadService() {
+    def deserializer = ServiceLoader.load(Deserializer).iterator().next()
+    assertThat(deserializer, instanceOf(JsonbDeserializer))
+  }
+
+
+  @Test
+  void testDefaultConstructor() {
+    def deserializer = new JsonbDeserializer()
+    assertNotNull deserializer.jsonb
+  }
+
+  @Test
+  void testObjectMapperConstructor() {
+    def customJsonb = JsonbBuilder.create()
+    def deserializer = new JsonbDeserializer(customJsonb)
+    assertSame customJsonb, deserializer.jsonb
+  }
+
+  @Test(expected = NullPointerException)
+  void testObjectMapperConstructorWithNullArgument() {
+    new JsonbDeserializer<>(null)
+  }
+
+  @Test
+  void testDeserialize() {
+    byte[] serialized = '{"hello":"世界"}'.getBytes(Strings.UTF_8)
+    def expected = [hello: '世界']
+    def result = new JsonbDeserializer().deserialize(serialized)
+    assertEquals expected, result
+  }
+
+  @Test
+  void testDeserializeFailsWithJsonProcessingException() {
+
+    def ex = createMock javax.json.bind.JsonbException
+
+    expect(ex.getMessage()).andReturn('foo')
+
+    def deserializer = new JsonbDeserializer() {
+      @Override
+      protected Object readValue(byte[] bytes) throws javax.json.bind.JsonbException {
+        throw ex
+      }
+    }
+
+    replay ex
+
+    try {
+      deserializer.deserialize('{"hello":"世界"}'.getBytes(Strings.UTF_8))
+      fail()
+    } catch (DeserializationException se) {
+      assertEquals 'Unable to deserialize bytes into a java.lang.Object instance: foo', se.getMessage()
+      assertSame ex, se.getCause()
+    }
+
+    verify ex
+  }
+}

--- a/extensions/jsonb/src/test/groovy/io/jsonwebtoken/jsonb/io/JsonbSerializerTest.groovy
+++ b/extensions/jsonb/src/test/groovy/io/jsonwebtoken/jsonb/io/JsonbSerializerTest.groovy
@@ -1,0 +1,111 @@
+package io.jsonwebtoken.jsonb.io
+
+import io.jsonwebtoken.io.SerializationException
+import io.jsonwebtoken.io.Serializer
+import io.jsonwebtoken.lang.Strings
+import org.junit.Test
+
+import javax.json.bind.JsonbBuilder
+import javax.json.bind.JsonbException
+
+import static org.easymock.EasyMock.*
+import static org.hamcrest.CoreMatchers.instanceOf
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.junit.Assert.*
+
+class JsonbSerializerTest {
+
+  @Test
+  void loadService() {
+    def serializer = ServiceLoader.load(Serializer).iterator().next()
+    assertThat(serializer, instanceOf(JsonbSerializer))
+  }
+
+  @Test
+  void testDefaultConstructor() {
+    def serializer = new JsonbSerializer()
+    assertNotNull serializer.jsonb
+  }
+
+  @Test
+  void testObjectMapperConstructor() {
+    def customJsonb = JsonbBuilder.create()
+    def serializer = new JsonbSerializer<>(customJsonb)
+    assertSame customJsonb, serializer.jsonb
+  }
+
+  @Test(expected = NullPointerException)
+  void testObjectMapperConstructorWithNullArgument() {
+    new JsonbSerializer<>(null)
+  }
+
+  @Test
+  void testByte() {
+    byte[] expected = "120".getBytes(Strings.UTF_8) //ascii("x") = 120
+    byte[] bytes = "x".getBytes(Strings.UTF_8)
+    byte[] result = new JsonbSerializer().serialize(bytes[0]) //single byte
+    assertTrue Arrays.equals(expected, result)
+  }
+
+  @Test
+  void testByteArray() { //expect Base64 string by default:
+    byte[] bytes = "hi".getBytes(Strings.UTF_8)
+    String expected = '"aGk="' as String //base64(hi) --> aGk=
+    byte[] result = new JsonbSerializer().serialize(bytes)
+    assertEquals expected, new String(result, Strings.UTF_8)
+  }
+
+  @Test
+  void testEmptyByteArray() { //expect Base64 string by default:
+    byte[] bytes = new byte[0]
+    byte[] result = new JsonbSerializer().serialize(bytes)
+    assertEquals '""', new String(result, Strings.UTF_8)
+  }
+
+  @Test
+  void testChar() { //expect Base64 string by default:
+    byte[] result = new JsonbSerializer().serialize('h' as char)
+    assertEquals "\"h\"", new String(result, Strings.UTF_8)
+  }
+
+  @Test
+  void testCharArray() { //expect Base64 string by default:
+    byte[] result = new JsonbSerializer().serialize("hi".toCharArray())
+    assertEquals "\"hi\"", new String(result, Strings.UTF_8)
+  }
+
+  @Test
+  void testSerialize() {
+    byte[] expected = '{"hello":"世界"}'.getBytes(Strings.UTF_8)
+    byte[] result = new JsonbSerializer().serialize([hello: '世界'])
+    assertTrue Arrays.equals(expected, result)
+  }
+
+
+  @Test
+  void testSerializeFailsWithJsonProcessingException() {
+
+    def ex = createMock(JsonbException)
+
+    expect(ex.getMessage()).andReturn('foo')
+
+    def serializer = new JsonbSerializer() {
+      @Override
+      protected byte[] writeValueAsBytes(Object o) throws JsonbException {
+        throw ex
+      }
+    }
+
+    replay ex
+
+    try {
+      serializer.serialize([hello: 'world'])
+      fail()
+    } catch (SerializationException se) {
+      assertEquals 'Unable to serialize object: foo', se.getMessage()
+      assertSame ex, se.getCause()
+    }
+
+    verify ex
+  }
+}

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -41,9 +41,9 @@
 
     <profiles>
         <profile>
-            <id>java8</id>
+            <id>nonJDK7</id>
             <activation>
-                <jdk>[8,)</jdk>
+                <jdk>[1.8,)</jdk>
             </activation>
             <modules>
                 <module>jsonb</module>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -37,6 +37,17 @@
         <module>jackson</module>
         <module>orgjson</module>
         <module>gson</module>
-        <module>jsonb</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>[8,)</jdk>
+            </activation>
+            <modules>
+                <module>jsonb</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -37,5 +37,6 @@
         <module>jackson</module>
         <module>orgjson</module>
         <module>gson</module>
+        <module>jsonb</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,9 @@
         <jackson.version>2.12.6</jackson.version>
         <orgjson.version>20180130</orgjson.version>
         <gson.version>2.8.9</gson.version>
+        <jsonp.version>1.1.6</jsonp.version>
+        <jsonb.version>1.0.2</jsonb.version>
+        <johnzon.version>1.2.16</johnzon.version>
 
         <!-- Optional Runtime Dependencies: -->
         <bouncycastle.version>1.67</bouncycastle.version>
@@ -137,6 +140,24 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
+                <version>${jsonp.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json.bind</groupId>
+                <artifactId>jakarta.json.bind-api</artifactId>
+                <version>${jsonb.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.johnzon</groupId>
+                <artifactId>johnzon-jsonb</artifactId>
+                <version>${johnzon.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <!-- Used only during testing for PS256, PS384 and PS512 since JDK <= 10 doesn't support them: -->


### PR DESCRIPTION
Fixes #719:

This commit will add a JSON-B extension based on [JSON-B specification](https://github.com/eclipse-ee4j/jsonb-api) 1.0.2.

## Noteworthy

* Since this specification uses Java 8 features (static methods in interfaces), the property `jdk.version` was set to `8`.
* Since we now use Java 8, there is little advantage in using custom assertions, this `null` input is validated by `java.util.Objcets.requireNonNull` and will throw a `NullPointerException` (which makes more sense anyway) instead of an `IllegalArgumentException`.
* Instead of `Strings.UTF_8` the JDK8-included `StandardCharsets.UTF_8` was used.
* I used Johnzon for testing, but only because it is an Apache project. It should work with Eclipse Yasson without any changes. If desirable, I could implement a maven profile for this – or even better, an IT project (e.g. `intergation-tests/json/jsonb-yasson` and `intergation-tests/json/jsonb-sth-else`).
* The (`provided`) dependency on json-api (aka json-p for JSON-Parser) is needed at least for Johnzon, but probably for some Exceptions as well. Johnzon fails because `javax.json.JsonException` is missing. But since json-api/json-p is a transitive dependency for json-bind-api (json-b) as well, this should be okay.

## Other notes

* The `provided` scope is because of JakarteEE Application Server usage. Tested on [OpenLiberty](https://openliberty.io/). But for JavaSE apps, users of this lib would need to include those by hand, as well as the implementation. This should go into the README.

## Tasks

- [X] Added implementation.
- [X] README.md updated.
- [X] Added notice about JavaSE vs JakartaEE environments and their ([not-]provided) dependencies.
- [X] Added "when-to-use" note.