### PR TITLE
[#687] trim payload before try to parse it.

### DIFF
--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -42,6 +42,7 @@ import io.jsonwebtoken.impl.crypto.JwtSignatureValidator;
 import io.jsonwebtoken.impl.lang.LegacyServices;
 import io.jsonwebtoken.io.Decoder;
 import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.DeserializationException;
 import io.jsonwebtoken.io.Deserializer;
 import io.jsonwebtoken.lang.Assert;
 import io.jsonwebtoken.lang.DateFormats;
@@ -330,7 +331,7 @@ public class DefaultJwtParser implements JwtParser {
 
         Claims claims = null;
 
-        if (!payload.isEmpty() && payload.charAt(0) == '{' && payload.charAt(payload.length() - 1) == '}') { //likely to be json, parse it:
+        if (!payload.isEmpty() && payload.trim().charAt(0) == '{' && payload.trim().charAt(payload.length() - 1) == '}') { //likely to be json, parse it:
             Map<String, Object> claimsMap = (Map<String, Object>) readValue(payload);
             claims = new DefaultClaims(claimsMap);
         }

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -331,7 +331,8 @@ public class DefaultJwtParser implements JwtParser {
 
         Claims claims = null;
 
-        if (!payload.isEmpty() && payload.trim().charAt(0) == '{' && payload.trim().charAt(payload.length() - 1) == '}') { //likely to be json, parse it:
+        final String trimmedPayload = payload.trim();
+        if (!payload.isEmpty() && trimmedPayload.charAt(0) == '{' && trimmedPayload.charAt(payload.length() - 1) == '}') { //likely to be json, parse it:
             Map<String, Object> claimsMap = (Map<String, Object>) readValue(payload);
             claims = new DefaultClaims(claimsMap);
         }


### PR DESCRIPTION
fixes #687 

Hint: I really don't like your heuristics.
Imagine this scenario:

You have a binary payload which is by design not intended to be json, e.g. HOCON (typesafe config).
The parser won't parse it as either JSON nor as payload just because it starts and ends with `{` and `}`.

Better approach:
* Try to parse as JSON no matter what
* If it fails, just log info message and use the payload as-is.

If you are interested in this approach, I can create another PR. :) 