### PR TITLE
Bump jackson dependency to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <jdk.version>1.7</jdk.version>
         <buildNumber>${user.name}-${maven.build.timestamp}</buildNumber>
 
-        <jackson.version>2.12.7</jackson.version>
+        <jackson.version>2.12.7.1</jackson.version>
         <orgjson.version>20220320</orgjson.version>
         <gson.version>2.9.0</gson.version>
 


### PR DESCRIPTION
This is important to get the latest security fixes from jackson.
Users of jjwt-jackson have to exclude and manually upgrade this dependency otherwise.