### PR TITLE
Update gradle dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,8 +295,8 @@ If you're building a (non-Android) JDK project, you will want to define the foll
 
 ```groovy
 dependencies {
-    compile 'io.jsonwebtoken:jjwt-api:0.11.5'
-    runtime 'io.jsonwebtoken:jjwt-impl:0.11.5',
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5',
     // Uncomment the next line if you want to use RSASSA-PSS (PS256, PS384, PS512) algorithms:
     //'org.bouncycastle:bcprov-jdk15on:1.70',
     'io.jsonwebtoken:jjwt-jackson:0.11.5' // or 'io.jsonwebtoken:jjwt-gson:0.11.5' for gson


### PR DESCRIPTION
Using the outdated configurations `compile` and `runtime` like in README.md leads to gradle errors which are not trivial to understand.

Quoting [from StackOverflow](https://stackoverflow.com/a/66910991/39946):

> Note that the `compile`, `runtime`, `testCompile`, and `testRuntime`
> configurations introduced by the Java plugin have been deprecated
> since [Gradle 4.10][1] ([Aug 27, 2018][2]), and were finally removed
> in [Gradle 7.0][3] ([Apr 9, 2021][2]).
> 
> The aforementioned configurations should be replaced by
> `implementation`, `runtimeOnly`, `testImplementation`, and
> `testRuntimeOnly`, respectively.

I don't think that a special note for users of gradle below version 4.10 is needed.

  [1]: https://docs.gradle.org/4.10/userguide/java_plugin.html#sec:java_plugin_and_dependency_management
  [2]: https://gradle.org/releases/
  [3]: https://docs.gradle.org/7.0/userguide/java_library_plugin.html#sec:java_library_configurations_graph