### PR TITLE
Upgrade BC to 1.76

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,8 +555,8 @@ If you're building a (non-Android) JDK project, you will want to define the foll
      It is unnecessary for these algorithms on JDK 15 or later.
 <dependency>
     <groupId>org.bouncycastle</groupId>
-    <artifactId>bcprov-jdk15on</artifactId>
-    <version>1.70</version>
+    <artifactId>bcprov-jdk18on</artifactId> or bcprov-jdk15to18 on JDK 7
+    <version>1.76</version>
     <scope>runtime</scope>
 </dependency>
 -->
@@ -578,7 +578,7 @@ dependencies {
        - JDK 14 or earlier, and you want to use EdDSA (Ed25519 or Ed448) Elliptic Curve signature algorithms.
       It is unnecessary for these algorithms on JDK 15 or later.
     */
-    // runtimeOnly 'org.bouncycastle:bcprov-jdk15on:1.70'
+    // runtimeOnly 'org.bouncycastle:bcprov-jdk18on:1.76' // or bcprov-jdk15to18 on JDK 7
 }
 ```
 
@@ -607,7 +607,7 @@ dependencies {
        - EdDSA (Ed25519 or Ed448) Elliptic Curve signature algorithms.
       ** AND ALSO ensure you enable the BouncyCastle provider as shown below **
     */
-    //implementation('org.bouncycastle:bcprov-jdk15on:1.70')
+    //implementation('org.bouncycastle:bcprov-jdk18on:1.76') // or bcprov-jdk15to18 for JDK 7
 }
 ```
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -43,12 +44,12 @@
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>${bcprov.artifactId}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>${bcpkix.artifactId}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,9 @@
         <maven.javadoc.additionalOptions/>
 
         <!-- Optional Runtime Dependencies: -->
-        <bouncycastle.version>1.70</bouncycastle.version>
+        <bouncycastle.version>1.76</bouncycastle.version>
+        <bcprov.artifactId>bcprov-jdk18on</bcprov.artifactId>
+        <bcpkix.artifactId>bcpkix-jdk18on</bcpkix.artifactId>
 
         <!-- Test Dependencies: Only required for testing when building.  Not required by users at runtime: -->
         <groovy.version>2.5.16</groovy.version> <!-- higher version used in jdk8AndLater profile below -->
@@ -210,13 +212,13 @@
             <!-- Used only during testing for PS256, PS384 and PS512 since JDK <= 10 doesn't support them: -->
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
+                <artifactId>${bcprov.artifactId}</artifactId>
                 <version>${bouncycastle.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
+                <artifactId>${bcpkix.artifactId}</artifactId>
                 <version>${bouncycastle.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -637,6 +639,16 @@
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>jdk7</id>
+            <activation>
+                <jdk>1.7</jdk>
+            </activation>
+            <properties>
+                <bcprov.artifactId>bcprov-jdk15to18</bcprov.artifactId>
+                <bcpkix.artifactId>bcpkix-jdk15to18</bcpkix.artifactId>
+            </properties>
+        </profile>
         <profile>
             <id>jdk8AndLater</id>
             <activation>

--- a/tdjar/pom.xml
+++ b/tdjar/pom.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -27,7 +28,9 @@
 
     <artifactId>jjwt</artifactId>
     <name>JJWT :: Legacy Transitive Dependency Jar</name>
-    <description>Legacy dependency. Please update your dependencies as documented here: https://github.com/jwtk/jjwt#installation</description>
+    <description>Legacy dependency. Please update your dependencies as documented here:
+        https://github.com/jwtk/jjwt#installation
+    </description>
     <packaging>jar</packaging>
 
     <properties>
@@ -53,12 +56,12 @@
         <!-- Testing only: -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>${bcprov.artifactId}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>${bcpkix.artifactId}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Upgraded BC to 1.76
Also addressed Pkcs11Test that fails on Mac OS (arm64) with JDK 1.7 (x86_64)