### PR TITLE
ServiceLoaders are now cached.

### DIFF
--- a/impl/src/test/groovy/io/jsonwebtoken/impl/lang/ServicesTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/lang/ServicesTest.groovy
@@ -17,6 +17,7 @@ package io.jsonwebtoken.impl.lang
 
 import io.jsonwebtoken.StubService
 import io.jsonwebtoken.impl.DefaultStubService
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.powermock.api.easymock.PowerMock
@@ -71,6 +72,11 @@ class ServicesTest {
         assertEquals(Thread.currentThread().getContextClassLoader(), accessorList.get(0).getClassLoader())
         assertEquals(Services.class.getClassLoader(), accessorList.get(1).getClassLoader())
         assertEquals(ClassLoader.getSystemClassLoader(), accessorList.get(2).getClassLoader())
+    }
+
+    @After
+    void resetCache() {
+        Services.reload();
     }
 
     static class NoServicesClassLoader extends ClassLoader {


### PR DESCRIPTION
The first ServiceLoaders found when looking up a class will be cached. This cache can be reset by calling `Services.reload()`, to help
facilitate testing or instances where a classpaths are dynamically changed at runtime.

Fixes: #752
