### PR TITLE
Add Java 21 to CI matrix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
   zulu:
     strategy:
       matrix:
-        java: [ '7', '8', '9', '11', '12', '13', '14', '15', '16', '17', '18' ]
+        java: [ '7', '8', '9', '11', '12', '13', '14', '15', '16', '17', '18', '21' ]
     runs-on: 'ubuntu-latest'
     env:
       JDK_MAJOR_VERSION: ${{ matrix.java }}

--- a/pom.xml
+++ b/pom.xml
@@ -656,7 +656,7 @@
             </activation>
             <properties>
                 <gmavenplus.version>1.13.1</gmavenplus.version>
-                <groovy.version>3.0.10</groovy.version>
+                <groovy.version>3.0.19</groovy.version>
                 <easymock.version>4.2</easymock.version>
                 <powermock.version>2.0.7</powermock.version>
                 <maven.japicmp.version>0.15.6</maven.japicmp.version>
@@ -681,6 +681,16 @@
             <properties>
                 <maven.javadoc.additionalOptions>-html5</maven.javadoc.additionalOptions>
                 <surefire.argLine>${test.addOpens}</surefire.argLine>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk21AndLater</id>
+            <activation>
+                <jdk>[21,)</jdk>
+            </activation>
+            <properties>
+                <!-- normally this is 1.7, but as of 21, JDK 8 is the lowest source/target -->
+                <jdk.version>8</jdk.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
* Update groovy patch version to support Java 21.

NOTE: This adds a Maven profile that ups the source/target version to Java 8, but ONLY when building with 21+
