### PR TITLE
JSONTokener constructor fallback

### DIFF
--- a/extensions/orgjson/src/main/java/io/jsonwebtoken/orgjson/io/OrgJsonDeserializer.java
+++ b/extensions/orgjson/src/main/java/io/jsonwebtoken/orgjson/io/OrgJsonDeserializer.java
@@ -16,11 +16,13 @@
 package io.jsonwebtoken.orgjson.io;
 
 import io.jsonwebtoken.io.AbstractDeserializer;
+import io.jsonwebtoken.lang.Assert;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 
+import java.io.CharArrayReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
@@ -34,76 +36,25 @@ import java.util.Map;
  */
 public class OrgJsonDeserializer extends AbstractDeserializer<Object> {
 
+    private final JSONTokenerFactory TOKENER_FACTORY;
+
+    public OrgJsonDeserializer() {
+        this(JSONTokenerFactory.INSTANCE);
+    }
+
+    private OrgJsonDeserializer(JSONTokenerFactory factory) {
+        this.TOKENER_FACTORY = Assert.notNull(factory, "JSONTokenerFactory cannot be null.");
+    }
+
     @Override
     protected Object doDeserialize(Reader reader) {
         return parse(reader);
     }
 
-
-    // protected for testing override only
-
-    /**
-     * Returns a new {@link JSONTokener} instance using the {@link JSONTokener#JSONTokener(Reader) JSONTokener(Reader)}
-     * constructor, primarily exposed for unit testing.
-     *
-     * @param reader the reader to wrap
-     * @return a new JSONTokener
-     * @throws NoSuchMethodError if the {@link JSONTokener#JSONTokener(Reader) JSONTokener(Reader)} constructor is not
-     *                           available, for example, on Android.
-     * @since 0.12.4
-     */
-    protected JSONTokener newTokener(Reader reader) throws NoSuchMethodError {
-        return new JSONTokener(reader);
-    }
-
-    /**
-     * Reads all content from the specified reader and returns it as a single String.
-     *
-     * @param reader the reader to read characters from
-     * @return the reader content as a single string
-     * @since 0.12.4
-     */
-    private static String toString(Reader reader) throws IOException {
-        StringBuilder sb = new StringBuilder(4096);
-        char[] buf = new char[4096];
-        int n = 0;
-        while (EOF != n) {
-            n = reader.read(buf);
-            if (n > 0) sb.append(buf, 0, n);
-        }
-        return sb.toString();
-    }
-
-    /**
-     * Attempts to create a {@link JSONTokener} using the more efficient
-     * {@link JSONTokener#JSONTokener(Reader) JSONTokener(Reader)} constructor.  If that constructor is not available
-     * (for example, on Android), this method reads the {@code Reader} argument in its entirety to a {@code String}
-     * first, then falls back to using the {@link JSONTokener#JSONTokener(String) JSONTokener(String)} constructor
-     * (which is available on Android).
-     *
-     * @param reader the reader to convert to use when constructing a {@link JSONTokener}.
-     * @return the JSONTokener to use for parsing.
-     * @see <a href="https://github.com/jwtk/jjwt/issues/882">JJWT Issue 882</a>.
-     * @since 0.12.4
-     */
-    private JSONTokener toTokener(Reader reader) {
-        try {
-            return newTokener(reader);
-        } catch (NoSuchMethodError e) { // Reader constructor not available (Android), fall back to String ctor:
-            String s;
-            try {
-                s = toString(reader);
-            } catch (IOException ex) {
-                String msg = "Unable to obtain JSON String from Reader: " + ex.getMessage();
-                throw new JSONException(msg, ex);
-            }
-            return new JSONTokener(s);
-        }
-    }
-
     private Object parse(Reader reader) throws JSONException {
 
-        JSONTokener tokener = toTokener(reader);
+        JSONTokener tokener = this.TOKENER_FACTORY.newTokener(reader);
+        Assert.notNull(tokener, "JSONTokener cannot be null.");
 
         char c = tokener.nextClean(); //peak ahead
         tokener.back(); //revert
@@ -156,5 +107,68 @@ public class OrgJsonDeserializer extends AbstractDeserializer<Object> {
             value = toMap((JSONObject) value);
         }
         return value;
+    }
+
+    /**
+     * A factory to create {@link JSONTokener} instances from {@link Reader}s.
+     *
+     * @see <a href="https://github.com/jwtk/jjwt/issues/882">JJWT Issue 882</a>.
+     * @since 0.12.4
+     */
+    static class JSONTokenerFactory { // package-protected on purpose. Not to be exposed as part of public API
+
+        private static final Reader TEST_READER = new CharArrayReader("{}".toCharArray());
+
+        private static final JSONTokenerFactory INSTANCE = new JSONTokenerFactory();
+
+        private final boolean readerCtorAvailable;
+
+        // package protected visibility for testing only:
+        JSONTokenerFactory() {
+            boolean avail = true;
+            try {
+                testTokener(TEST_READER);
+            } catch (NoSuchMethodError err) {
+                avail = false;
+            }
+            this.readerCtorAvailable = avail;
+        }
+
+        // visible for testing only
+        protected void testTokener(@SuppressWarnings("SameParameterValue") Reader reader) throws NoSuchMethodError {
+            new JSONTokener(reader);
+        }
+
+        /**
+         * Reads all content from the specified reader and returns it as a single String.
+         *
+         * @param reader the reader to read characters from
+         * @return the reader content as a single string
+         */
+        private static String toString(Reader reader) throws IOException {
+            StringBuilder sb = new StringBuilder(4096);
+            char[] buf = new char[4096];
+            int n = 0;
+            while (EOF != n) {
+                n = reader.read(buf);
+                if (n > 0) sb.append(buf, 0, n);
+            }
+            return sb.toString();
+        }
+
+        private JSONTokener newTokener(Reader reader) {
+            if (this.readerCtorAvailable) {
+                return new JSONTokener(reader);
+            }
+            // otherwise not available, likely Android or earlier org.json version, fall back to String ctor:
+            String s;
+            try {
+                s = toString(reader);
+            } catch (IOException ex) {
+                String msg = "Unable to obtain JSON String from Reader: " + ex.getMessage();
+                throw new JSONException(msg, ex);
+            }
+            return new JSONTokener(s);
+        }
     }
 }

--- a/extensions/orgjson/src/test/groovy/io/jsonwebtoken/orgjson/io/OrgJsonDeserializerTest.groovy
+++ b/extensions/orgjson/src/test/groovy/io/jsonwebtoken/orgjson/io/OrgJsonDeserializerTest.groovy
@@ -20,7 +20,6 @@ import io.jsonwebtoken.io.DeserializationException
 import io.jsonwebtoken.io.Deserializer
 import io.jsonwebtoken.io.IOException
 import io.jsonwebtoken.lang.Strings
-import org.json.JSONTokener
 import org.junit.Before
 import org.junit.Test
 
@@ -209,12 +208,7 @@ class OrgJsonDeserializerTest {
         def json = '{"hello": "世界", "test": [1, 2]}'
         def expected = read(json) // 'normal' reading
 
-        des = new OrgJsonDeserializer() {
-            @Override
-            protected JSONTokener newTokener(Reader reader) throws NoSuchMethodError {
-                throw new NoSuchMethodError('Android says nope!')
-            }
-        }
+        des = new OrgJsonDeserializer(new NoReaderCtorTokenerFactory())
 
         def reader = reader('{"hello": "世界", "test": [1, 2]}')
 
@@ -242,12 +236,8 @@ class OrgJsonDeserializerTest {
             void close() throws IOException {
             }
         }
-        des = new OrgJsonDeserializer() {
-            @Override
-            protected JSONTokener newTokener(Reader r) throws NoSuchMethodError {
-                throw new NoSuchMethodError('Android says nope!')
-            }
-        }
+
+        des = new OrgJsonDeserializer(new NoReaderCtorTokenerFactory())
 
         try {
             des.deserialize(reader)
@@ -257,6 +247,13 @@ class OrgJsonDeserializerTest {
             String msg = "Unable to obtain JSON String from Reader: $causeMsg"
             assertEquals msg, jsonEx.getMessage()
             assertSame cause, jsonEx.getCause()
+        }
+    }
+
+    private static class NoReaderCtorTokenerFactory extends OrgJsonDeserializer.JSONTokenerFactory {
+        @Override
+        protected void testTokener(Reader reader) throws NoSuchMethodError {
+            throw new NoSuchMethodError('Android says nope!')
         }
     }
 


### PR DESCRIPTION
OrgJsonDeserializer: Added fallback implementation for Android when `JSONTokener(Reader)` constructor is not available.

Closes #882