### PR TITLE
#893 Disable Jackson ObjectMapper FAIL_ON_UNKNOWN_PROPERTIES Deserialization Feature by default

### DIFF
--- a/extensions/jackson/src/main/java/io/jsonwebtoken/jackson/io/JacksonSerializer.java
+++ b/extensions/jackson/src/main/java/io/jsonwebtoken/jackson/io/JacksonSerializer.java
@@ -17,6 +17,7 @@ package io.jsonwebtoken.jackson.io;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -46,17 +47,21 @@ public class JacksonSerializer<T> extends AbstractSerializer<T> {
 
     /**
      * Creates and returns a new ObjectMapper with the {@code jjwt-jackson} module registered and
-     * {@code JsonParser.Feature.STRICT_DUPLICATE_DETECTION} enabled (set to true).
+     * {@code JsonParser.Feature.STRICT_DUPLICATE_DETECTION} enabled (set to true) and
+     * {@code DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES} disabled (set to false).
      *
-     * @return and returns a new ObjectMapper with the {@code jjwt-jackson} module registered and
-     * {@code JsonParser.Feature.STRICT_DUPLICATE_DETECTION} enabled (set to true).
+     * @return a new ObjectMapper with the {@code jjwt-jackson} module registered and
+     * {@code JsonParser.Feature.STRICT_DUPLICATE_DETECTION} enabled (set to true) and
+     * {@code DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES} disabled (set to false).
+     *
      * @since 0.12.4
      */
     // package protected on purpose, do not expose to the public API
     static ObjectMapper newObjectMapper() {
         return new ObjectMapper()
                 .registerModule(MODULE)
-                .configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true); // https://github.com/jwtk/jjwt/issues/877
+                .configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true) // https://github.com/jwtk/jjwt/issues/877
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false); // https://github.com/jwtk/jjwt/issues/893
     }
 
     protected final ObjectMapper objectMapper;


### PR DESCRIPTION
In order to disable Jackson `ObjectMapper` `FAIL_ON_UNKNOWN_PROPERTIES` Deserialization Feature by default , Edit static `newObjectMapper` method of `JacksonSerializer`:
```
static ObjectMapper newObjectMapper() {
    return new ObjectMapper()
            .registerModule(MODULE)
            .configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true) // https://github.com/jwtk/jjwt/issues/877
            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false); // https://github.com/jwtk/jjwt/issues/893
}
```


**Also add specific test with `json` which has unknown field and must seserialize to custom data type.**


This PR fixs #893 


Note:
I close #894 PR and reopen this PR, because it has confilict with synchronous and same changes in #895 PR of @lhazlewood