### PR TITLE
Minor test change to reflect correct assertion for JWK Elliptic Curve 'd' byte array values

### DIFF
--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/AbstractEcJwkFactoryTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/AbstractEcJwkFactoryTest.groovy
@@ -63,14 +63,18 @@ class AbstractEcJwkFactoryTest {
             def y = Decoders.BASE64URL.decode(ys)
             def d = Decoders.BASE64URL.decode(ds)
 
-            // most important part of the test: the decoded byte arrays must have a length equal to the curve
-            // field size (in bytes):
+            // most important part of the test: 'x' and 'y' decoded byte arrays must have a length equal to the curve
+            // field size (in bytes) per https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.1.2 and
+            // https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.1.3
             int fieldSizeInBits = key.getParams().getCurve().getField().getFieldSize()
             int fieldSizeInBytes = Bytes.length(fieldSizeInBits)
-
             assertEquals fieldSizeInBytes, x.length
             assertEquals fieldSizeInBytes, y.length
-            assertEquals fieldSizeInBytes, d.length
+
+            // and 'd' must have a length equal to the curve order size in bytes per
+            // https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.2.1
+            int orderSizeInBytes = Bytes.length(key.params.order.bitLength())
+            assertEquals orderSizeInBytes, d.length
         }
     }
 }


### PR DESCRIPTION
to be based on the curve order (not the field size) per https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.2.1.  Minor addendum to #903