### PR TITLE
GitHub Actions workflow cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     name: jdk-${{ matrix.java }}-oracle
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
         uses: oracle-actions/setup-java@v1
         with:
@@ -42,9 +42,9 @@ jobs:
     runs-on: 'ubuntu-latest'
     name: jdk-${{ matrix.java }}-temurin
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -72,9 +72,9 @@ jobs:
       JDK_MAJOR_VERSION: ${{ matrix.java }}
     name: jdk-${{ matrix.java }}-zulu
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -99,11 +99,11 @@ jobs:
   license-check:
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # avoid license plugin history warnings (plus it needs full history)
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '8'
@@ -120,9 +120,9 @@ jobs:
     #needs: zulu # wait until others finish so a coverage failure doesn't cancel others accidentally
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '8'


### PR DESCRIPTION
Updating to GitHub latest actions/checkout and actions/setup-java script versions due to Node.js 16 deprecation warnings in the GH Actions tab when viewing a build/run