### PR TITLE
Allow using GenericSecret for HmacSHA*

### DIFF
--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultMacAlgorithm.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultMacAlgorithm.java
@@ -136,11 +136,11 @@ final class DefaultMacAlgorithm extends AbstractSecureDigestAlgorithm<SecretKey,
         }
 
         // We can ignore key name assertions for generic secrets, because HSM module key algorithm names
-        // don't always align with JCA standard algorithm names:
-        boolean pkcs11Key = KeysBridge.isGenericSecret(key);
+        // don't always align with JCA standard algorithm names
+        boolean generic = KeysBridge.isGenericSecret(key);
 
         //assert key's jca name is valid if it's a JWA standard algorithm:
-        if (!pkcs11Key && isJwaStandard() && !isJwaStandardJcaName(name)) {
+        if (!generic && isJwaStandard() && !isJwaStandardJcaName(name)) {
             throw new InvalidKeyException("The " + keyType(signing) + " key's algorithm '" + name +
                     "' does not equal a valid HmacSHA* algorithm name or PKCS12 OID and cannot be used with " +
                     getId() + ".");

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultMacAlgorithm.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultMacAlgorithm.java
@@ -135,9 +135,9 @@ final class DefaultMacAlgorithm extends AbstractSecureDigestAlgorithm<SecretKey,
             throw new InvalidKeyException(msg);
         }
 
-        // We can ignore PKCS11 key name assertions because HSM module key algorithm names don't always align with
-        // JCA standard algorithm names:
-        boolean pkcs11Key = KeysBridge.isSunPkcs11GenericSecret(key);
+        // We can ignore key name assertions for generic secrets, because HSM module key algorithm names
+        // don't always align with JCA standard algorithm names:
+        boolean pkcs11Key = KeysBridge.isGenericSecret(key);
 
         //assert key's jca name is valid if it's a JWA standard algorithm:
         if (!pkcs11Key && isJwaStandard() && !isJwaStandardJcaName(name)) {

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/KeysBridge.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/KeysBridge.java
@@ -36,6 +36,7 @@ public final class KeysBridge {
 
     private static final String SUNPKCS11_GENERIC_SECRET_CLASSNAME = "sun.security.pkcs11.P11Key$P11SecretKey";
     private static final String SUNPKCS11_GENERIC_SECRET_ALGNAME = "Generic Secret"; // https://github.com/openjdk/jdk/blob/4f90abaf17716493bad740dcef76d49f16d69379/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java#L1292
+    private static final String GENERIC_SECRET_ALGNAME = "GenericSecret"; // AWS CloudHSM JCE provider and possibly other HSMs
 
     // prevent instantiation
     private KeysBridge() {
@@ -95,10 +96,15 @@ public final class KeysBridge {
         return encoded;
     }
 
-    public static boolean isSunPkcs11GenericSecret(Key key) {
-        return key instanceof SecretKey &&
-                key.getClass().getName().equals(SUNPKCS11_GENERIC_SECRET_CLASSNAME) &&
-                SUNPKCS11_GENERIC_SECRET_ALGNAME.equals(key.getAlgorithm());
+    public static boolean isGenericSecret(Key key) {
+        if (!(key instanceof SecretKey)) {
+            return false;
+        } else if (key.getClass().getName().equals(SUNPKCS11_GENERIC_SECRET_CLASSNAME) &&
+                SUNPKCS11_GENERIC_SECRET_ALGNAME.equals(key.getAlgorithm())) {
+            return true;
+        } else {
+            return GENERIC_SECRET_ALGNAME.equals(key.getAlgorithm());
+        }
     }
 
     /**

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/KeysBridge.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/KeysBridge.java
@@ -34,9 +34,9 @@ import java.security.interfaces.RSAKey;
 @SuppressWarnings({"unused"}) // reflection bridge class for the io.jsonwebtoken.security.Keys implementation
 public final class KeysBridge {
 
-    private static final String SUNPKCS11_GENERIC_SECRET_CLASSNAME = "sun.security.pkcs11.P11Key$P11SecretKey";
-    private static final String SUNPKCS11_GENERIC_SECRET_ALGNAME = "Generic Secret"; // https://github.com/openjdk/jdk/blob/4f90abaf17716493bad740dcef76d49f16d69379/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java#L1292
-    private static final String GENERIC_SECRET_ALGNAME = "GenericSecret"; // AWS CloudHSM JCE provider and possibly other HSMs
+     // Some HSMs use generic secrets. This prefix matches the generic secret algorithm name
+     // used by SUN PKCS#11 provider, AWS CloudHSM JCE provider and possibly other HSMs
+    private static final String GENERIC_SECRET_ALG_PREFIX = "Generic";
 
     // prevent instantiation
     private KeysBridge() {
@@ -99,12 +99,10 @@ public final class KeysBridge {
     public static boolean isGenericSecret(Key key) {
         if (!(key instanceof SecretKey)) {
             return false;
-        } else if (key.getClass().getName().equals(SUNPKCS11_GENERIC_SECRET_CLASSNAME) &&
-                SUNPKCS11_GENERIC_SECRET_ALGNAME.equals(key.getAlgorithm())) {
-            return true;
-        } else {
-            return GENERIC_SECRET_ALGNAME.equals(key.getAlgorithm());
         }
+
+        String algName = Assert.hasText(key.getAlgorithm(), "Key algorithm cannot be null or empty.");
+        return algName.startsWith(GENERIC_SECRET_ALG_PREFIX);
     }
 
     /**

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/DefaultMacAlgorithmTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/DefaultMacAlgorithmTest.groovy
@@ -19,6 +19,7 @@ import io.jsonwebtoken.impl.io.Streams
 import io.jsonwebtoken.security.*
 import org.junit.Test
 
+import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
 import java.nio.charset.StandardCharsets
 import java.security.Key
@@ -231,5 +232,30 @@ class DefaultMacAlgorithmTest {
             def oidKey = new TestSecretKey(algorithm: alg, format: 'RAW', encoded: key.getEncoded())
             assertSame mac, DefaultMacAlgorithm.findByKey(oidKey)
         }
+    }
+
+    /**
+     * Asserts that generic secrets are accepted
+     */
+    @Test
+    void testValidateKeyAcceptsGenericSecret() {
+        def genericSecret = new SecretKey() {
+            @Override
+            String getAlgorithm() {
+                return 'GenericSecret'
+            }
+
+            @Override
+            String getFormat() {
+                return "RAW"
+            }
+
+            @Override
+            byte[] getEncoded() {
+                return Randoms.secureRandom().nextBytes(new byte[32])
+            }
+        }
+
+        newAlg().validateKey(genericSecret, true)
     }
 }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/KeysBridgeTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/KeysBridgeTest.groovy
@@ -63,32 +63,34 @@ class KeysBridgeTest {
 
     @Test
     void testIsGenericSecret() {
-        def genericSecret = new SecretKey() {
+        def secretKeyWithAlg = { alg ->
+            new SecretKey() {
+                @Override
+                String getAlgorithm() {
+                    return alg
+                }
+
+                @Override
+                String getFormat() {
+                    return 'RAW'
+                }
+
+                @Override
+                byte[] getEncoded() {
+                    return new byte[0]
+                }
+            }
+        }
+
+        PrivateKey genericPrivateKey = new PrivateKey() {
             @Override
             String getAlgorithm() {
-                return "GenericSecret" ;
+                return "Generic"
             }
 
             @Override
             String getFormat() {
-                return null
-            }
-
-            @Override
-            byte[] getEncoded() {
-                return null;
-            }
-        };
-
-        def genericPrivateKey = new PrivateKey() {
-            @Override
-            String getAlgorithm() {
-                return "GenericSecret";
-            }
-
-            @Override
-            String getFormat() {
-                return null
+                return "RAW"
             }
 
             @Override
@@ -97,7 +99,9 @@ class KeysBridgeTest {
             }
         }
 
-        assertTrue KeysBridge.isGenericSecret(genericSecret)
+        assertTrue KeysBridge.isGenericSecret(secretKeyWithAlg("GenericSecret"))
+        assertTrue KeysBridge.isGenericSecret(secretKeyWithAlg("Generic Secret"))
+        assertFalse KeysBridge.isGenericSecret(secretKeyWithAlg(" Generic"))
         assertFalse KeysBridge.isGenericSecret(TestKeys.HS256)
         assertFalse KeysBridge.isGenericSecret(TestKeys.A256GCM)
         assertFalse KeysBridge.isGenericSecret(genericPrivateKey)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/KeysBridgeTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/KeysBridgeTest.groovy
@@ -17,9 +17,13 @@ package io.jsonwebtoken.impl.security
 
 import org.junit.Test
 
+import javax.crypto.SecretKey
 import java.security.Key
+import java.security.PrivateKey
 
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
 
 class KeysBridgeTest {
 
@@ -55,5 +59,47 @@ class KeysBridgeTest {
     @Test
     void testToStringPassword() {
         testFormattedOutput(new PasswordSpec("foo".toCharArray()))
+    }
+
+    @Test
+    void testIsGenericSecret() {
+        def genericSecret = new SecretKey() {
+            @Override
+            String getAlgorithm() {
+                return "GenericSecret" ;
+            }
+
+            @Override
+            String getFormat() {
+                return null
+            }
+
+            @Override
+            byte[] getEncoded() {
+                return null;
+            }
+        };
+
+        def genericPrivateKey = new PrivateKey() {
+            @Override
+            String getAlgorithm() {
+                return "GenericSecret";
+            }
+
+            @Override
+            String getFormat() {
+                return null
+            }
+
+            @Override
+            byte[] getEncoded() {
+                return new byte[0]
+            }
+        }
+
+        assertTrue KeysBridge.isGenericSecret(genericSecret)
+        assertFalse KeysBridge.isGenericSecret(TestKeys.HS256)
+        assertFalse KeysBridge.isGenericSecret(TestKeys.A256GCM)
+        assertFalse KeysBridge.isGenericSecret(genericPrivateKey)
     }
 }


### PR DESCRIPTION
Extend the pre-existing check for SUN PKCS11 generic secret to allow all SecretKeys where getAlgorithm() returns "GenericSecret" to bypass the algorithm validation.

This matches at least with AWS CloudHSM JCE provider, but likely others as well.

Relates to discussion https://github.com/jwtk/jjwt/discussions/934

Let me know if more tests are needed. I didn't find a test that would've tested the existing Sun PKCS#11 generic secret case, and not sure how to test that when the class doesn't exist in the classpath.