### PR TITLE
JWE arbitrary content compression

### DIFF
--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
@@ -687,7 +687,7 @@ public class DefaultJwtBuilder implements JwtBuilder {
         Assert.stateNotNull(keyAlgFunction, "KeyAlgorithm function cannot be null.");
         assertPayloadEncoding("JWE");
 
-        InputStream plaintext = toInputStream("JWE Unencoded Payload", content);
+        InputStream plaintext = toInputStream("JWE Payload", content);
 
         //only expose (mutable) JweHeader functionality to KeyAlgorithm instances, not the full headerBuilder
         // (which exposes this JwtBuilder and shouldn't be referenced by KeyAlgorithms):

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
@@ -595,14 +595,8 @@ public class DefaultJwtBuilder implements JwtBuilder {
 
             // Next, b64 extension requires the raw (non-encoded) payload to be included directly in the signing input,
             // so we ensure we have an input stream for that:
-            if (payload.isClaims() || payload.isCompressed()) {
-                ByteArrayOutputStream claimsOut = new ByteArrayOutputStream(8192);
-                writeAndClose("JWS Unencoded Payload", payload, claimsOut);
-                payloadStream = Streams.of(claimsOut.toByteArray());
-            } else {
-                // No claims and not compressed, so just get the direct InputStream:
-                payloadStream = Assert.stateNotNull(payload.toInputStream(), "Payload InputStream cannot be null.");
-            }
+            payloadStream = convertPayloadToInputStream(payload);
+
             if (!payload.isClaims()) {
                 payloadStream = new CountingInputStream(payloadStream); // we'll need to assert if it's empty later
             }
@@ -693,13 +687,7 @@ public class DefaultJwtBuilder implements JwtBuilder {
         Assert.stateNotNull(keyAlgFunction, "KeyAlgorithm function cannot be null.");
         assertPayloadEncoding("JWE");
 
-        ByteArrayOutputStream out = new ByteArrayOutputStream(4096);
-        if (content.isClaims()) {
-            writeAndClose("JWE Claims", content, out);
-        } else {
-            writeAndClose("JWE Content", content, out);
-        }
-        InputStream plaintext = Streams.of(out.toByteArray());
+        InputStream plaintext = convertPayloadToInputStream(content);
 
         //only expose (mutable) JweHeader functionality to KeyAlgorithm instances, not the full headerBuilder
         // (which exposes this JwtBuilder and shouldn't be referenced by KeyAlgorithms):
@@ -817,6 +805,17 @@ public class DefaultJwtBuilder implements JwtBuilder {
     private void encodeAndWrite(String name, byte[] data, OutputStream out) {
         out = encode(out, name);
         Streams.writeAndClose(out, data, "Unable to write bytes");
+    }
+
+    private InputStream convertPayloadToInputStream(Payload payload) {
+        if (payload.isClaims() || payload.isCompressed()) {
+            ByteArrayOutputStream claimsOut = new ByteArrayOutputStream(8192);
+            writeAndClose("JWS Unencoded Payload", payload, claimsOut);
+            return Streams.of(claimsOut.toByteArray());
+        } else {
+            // No claims and not compressed, so just get the direct InputStream:
+            return Assert.stateNotNull(payload.toInputStream(), "Payload InputStream cannot be null.");
+        }
     }
 
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
@@ -595,7 +595,7 @@ public class DefaultJwtBuilder implements JwtBuilder {
 
             // Next, b64 extension requires the raw (non-encoded) payload to be included directly in the signing input,
             // so we ensure we have an input stream for that:
-            payloadStream = convertPayloadToInputStream(payload);
+            payloadStream = toInputStream("JWS Unencoded Payload", payload);
 
             if (!payload.isClaims()) {
                 payloadStream = new CountingInputStream(payloadStream); // we'll need to assert if it's empty later
@@ -687,7 +687,7 @@ public class DefaultJwtBuilder implements JwtBuilder {
         Assert.stateNotNull(keyAlgFunction, "KeyAlgorithm function cannot be null.");
         assertPayloadEncoding("JWE");
 
-        InputStream plaintext = convertPayloadToInputStream(content);
+        InputStream plaintext = toInputStream("JWE Unencoded Payload", content);
 
         //only expose (mutable) JweHeader functionality to KeyAlgorithm instances, not the full headerBuilder
         // (which exposes this JwtBuilder and shouldn't be referenced by KeyAlgorithms):
@@ -807,10 +807,10 @@ public class DefaultJwtBuilder implements JwtBuilder {
         Streams.writeAndClose(out, data, "Unable to write bytes");
     }
 
-    private InputStream convertPayloadToInputStream(Payload payload) {
+    private InputStream toInputStream(final String name, Payload payload) {
         if (payload.isClaims() || payload.isCompressed()) {
             ByteArrayOutputStream claimsOut = new ByteArrayOutputStream(8192);
-            writeAndClose("JWS Unencoded Payload", payload, claimsOut);
+            writeAndClose(name, payload, claimsOut);
             return Streams.of(claimsOut.toByteArray());
         } else {
             // No claims and not compressed, so just get the direct InputStream:

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
@@ -693,14 +693,13 @@ public class DefaultJwtBuilder implements JwtBuilder {
         Assert.stateNotNull(keyAlgFunction, "KeyAlgorithm function cannot be null.");
         assertPayloadEncoding("JWE");
 
-        InputStream plaintext;
+        ByteArrayOutputStream out = new ByteArrayOutputStream(4096);
         if (content.isClaims()) {
-            ByteArrayOutputStream out = new ByteArrayOutputStream(4096);
             writeAndClose("JWE Claims", content, out);
-            plaintext = Streams.of(out.toByteArray());
         } else {
-            plaintext = content.toInputStream();
+            writeAndClose("JWE Content", content, out);
         }
+        InputStream plaintext = Streams.of(out.toByteArray());
 
         //only expose (mutable) JweHeader functionality to KeyAlgorithm instances, not the full headerBuilder
         // (which exposes this JwtBuilder and shouldn't be referenced by KeyAlgorithms):

--- a/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
@@ -22,6 +22,7 @@ import io.jsonwebtoken.impl.io.Streams
 import io.jsonwebtoken.impl.lang.Bytes
 import io.jsonwebtoken.impl.lang.Services
 import io.jsonwebtoken.impl.security.*
+import io.jsonwebtoken.io.CompressionAlgorithm
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.io.Deserializer
 import io.jsonwebtoken.io.Encoders
@@ -1394,6 +1395,97 @@ class JwtsTest {
                         .build()
                         .parseEncryptedClaims(jwe)
                 assertEquals 'bar', jwt.getPayload().get('foo')
+            }
+        }
+    }
+
+    @Test
+    void testJweCompressionWithArbitraryContentString() {
+        def codecs = [Jwts.ZIP.DEF, Jwts.ZIP.GZIP]
+
+        for (CompressionAlgorithm zip : codecs) {
+
+            for (AeadAlgorithm enc : Jwts.ENC.get().values()) {
+
+                SecretKey key = enc.key().build()
+
+                String payload = 'hello, world!'
+
+                // encrypt and compress:
+                String jwe = Jwts.builder()
+                    .content(payload)
+                    .compressWith(zip)
+                    .encryptWith(key, enc)
+                    .compact()
+
+                //decompress and decrypt:
+                def jwt = Jwts.parser()
+                    .decryptWith(key)
+                    .build()
+                    .parseEncryptedContent(jwe)
+                assertEquals payload, new String(jwt.getPayload(), StandardCharsets.UTF_8)
+            }
+        }
+    }
+
+    @Test
+    void testJweCompressionWithArbitraryContentByteArray() {
+        def codecs = [Jwts.ZIP.DEF, Jwts.ZIP.GZIP]
+
+        for (CompressionAlgorithm zip : codecs) {
+
+            for (AeadAlgorithm enc : Jwts.ENC.get().values()) {
+
+                SecretKey key = enc.key().build()
+
+                byte[] payload = new byte[14];
+                Randoms.secureRandom().nextBytes(payload)
+
+                // encrypt and compress:
+                String jwe = Jwts.builder()
+                        .content(payload)
+                        .compressWith(zip)
+                        .encryptWith(key, enc)
+                        .compact()
+
+                //decompress and decrypt:
+                def jwt = Jwts.parser()
+                        .decryptWith(key)
+                        .build()
+                        .parseEncryptedContent(jwe)
+                assertArrayEquals payload, jwt.getPayload()
+            }
+        }
+    }
+
+    @Test
+    void testJweCompressionWithArbitraryContentInputStream() {
+        def codecs = [Jwts.ZIP.DEF, Jwts.ZIP.GZIP]
+
+        for (CompressionAlgorithm zip : codecs) {
+
+            for (AeadAlgorithm enc : Jwts.ENC.get().values()) {
+
+                SecretKey key = enc.key().build()
+
+                byte[] payloadBytes = new byte[14];
+                Randoms.secureRandom().nextBytes(payloadBytes)
+
+                ByteArrayInputStream payload = new ByteArrayInputStream(payloadBytes)
+
+                // encrypt and compress:
+                String jwe = Jwts.builder()
+                        .content(payload)
+                        .compressWith(zip)
+                        .encryptWith(key, enc)
+                        .compact()
+
+                //decompress and decrypt:
+                def jwt = Jwts.parser()
+                        .decryptWith(key)
+                        .build()
+                        .parseEncryptedContent(jwe)
+                assertArrayEquals payloadBytes, jwt.getPayload()
             }
         }
     }


### PR DESCRIPTION
The JWE content was compressed only when claims was used as payload, but when using arbitrary content string/bytes/input stream, the compression was omitted, while keeping the "zip" header field, leading to un-parseable JWE as the decompression failed on non-compressed content.

I couldn't find any evidence that this was intended behavior from the documentation or the JWE spec, so made a fix for this.

See https://github.com/jwtk/jjwt/discussions/936

Note that people might have used a similar workaround as I presented in the discussion to manually compress the payload, so fixing this might result in some code breaking somewhere. Might be good to mention in the changelog.