### PR TITLE
Add upper bound to JCL exclusion rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
                                 <bannedDependencies>
                                     <searchTransitive>true</searchTransitive>
                                     <excludes>
-                                        <exclude>commons-logging</exclude>
+                                        <exclude>commons-logging:commons-logging:(,1.3)</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>


### PR DESCRIPTION
JCL now directly supports slf4j and log4j

We don't use JCL, nor do any of our dependencies, so we might want to consider removing this rule from the build. But, it looks like in the past year or so JCL has been updated to work with slf4j and log4j.

Opening this issue more for discussion than anything, commons-loggin 1.3+ also requires java 1.8, but again, we are not using this dep anyway.  My take is we should consider removing this rule 🤔 