### PR TITLE
Use SPDX identifier in POMs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: oracle-actions/setup-java@v1
+        uses: oracle-actions/setup-java@v1.1.0
         with:
           release: ${{ matrix.java }}
       - name: Install softhsm2

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <licenses>
         <license>
-            <name>Apache License, Version 2.0</name>
+            <name>Apache-2.0</name>
             <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
This replaces the custom name with an SPDX identifier to enable tooling to automatically detect the correct license. Using an SPDX identifier is recommended [by the official Maven documentation](https://maven.apache.org/pom.html#Licenses).

See https://spdx.org/licenses/Apache-2.0.html