### PR TITLE
Use GitHub setup-java for JDK 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: oracle-actions/setup-java@v1
+        uses: actions/setup-java@v4.7.0
         with:
-          release: ${{ matrix.java }}
+          distribution: oracle
+          java-version: ${{ matrix.java }}
       - name: Install softhsm2
         run: sudo apt-get install -y softhsm2
       - name: Install opensc


### PR DESCRIPTION
Changing JDK 17 build to use GitHub's `setup-java` action instead of Oracle's due to failing Oracle JDK 17 download.

Resolves #980.