### PR TITLE
Ensured *Builder instances are no longer created with reflection 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Release Notes
 
+### 0.12.7
+
+This patch release:
+
+* Improves performance slightly by ensuring all `jjwt-api` utility methods that create `*Builder` instances (`Jwts.builder()`, `Jwts.parserBuilder()`, `Jwks.builder()`, etc) no longer use reflection.
+ 
+  Instead,`static` factories are created via reflection only once during initial `jjwt-api` classloading, and then `*Builder`s are created via standard instantiation using the `new` operator thereafter.  This also benefits certain environments that may not have ideal `ClassLoader` implementations (e.g. Tomcat in some cases).
+ 
+  **NOTE: because this changes which classes are loaded via reflection, any environments that must explicitly reference reflective class names (e.g. GraalVM applications) will need to be updated to reflect the new factory class names**.
+  
+  See [Issue 988](https://github.com/jwtk/jjwt/issues/988).
+
 ### 0.12.6
 
 This patch release:

--- a/api/src/main/java/io/jsonwebtoken/Jwts.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwts.java
@@ -19,6 +19,7 @@ import io.jsonwebtoken.io.CompressionAlgorithm;
 import io.jsonwebtoken.lang.Builder;
 import io.jsonwebtoken.lang.Classes;
 import io.jsonwebtoken.lang.Registry;
+import io.jsonwebtoken.lang.Supplier;
 import io.jsonwebtoken.security.AeadAlgorithm;
 import io.jsonwebtoken.security.KeyAlgorithm;
 import io.jsonwebtoken.security.KeyPairBuilderSupplier;
@@ -1001,6 +1002,22 @@ public final class Jwts {
         }
     }
 
+    // @since JJWT_RELEASE_VERSION
+    private static final Supplier<JwtBuilder> JWT_BUILDER_SUPPLIER =
+            Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtBuilder$Supplier");
+
+    // @since JJWT_RELEASE_VERSION
+    private static final Supplier<JwtParserBuilder> JWT_PARSER_BUILDER_SUPPLIER =
+            Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtParserBuilder$Supplier");
+
+    // @since JJWT_RELEASE_VERSION
+    private static final Supplier<HeaderBuilder> HEADER_BUILDER_SUPPLIER =
+            Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtHeaderBuilder$Supplier");
+
+    // @since JJWT_RELEASE_VERSION
+    private static final Supplier<ClaimsBuilder> CLAIMS_BUILDER_SUPPLIER =
+            Classes.newInstance("io.jsonwebtoken.impl.DefaultClaimsBuilder$Supplier");
+
     /**
      * A {@link Builder} that dynamically determines the type of {@link Header} to create based on builder state.
      *
@@ -1018,7 +1035,7 @@ public final class Jwts {
      * @since 0.12.0
      */
     public static HeaderBuilder header() {
-        return Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtHeaderBuilder");
+        return HEADER_BUILDER_SUPPLIER.get();
     }
 
     /**
@@ -1029,7 +1046,7 @@ public final class Jwts {
      * the JWT payload.
      */
     public static ClaimsBuilder claims() {
-        return Classes.newInstance("io.jsonwebtoken.impl.DefaultClaimsBuilder");
+        return CLAIMS_BUILDER_SUPPLIER.get();
     }
 
     /**
@@ -1057,7 +1074,7 @@ public final class Jwts {
      * strings.
      */
     public static JwtBuilder builder() {
-        return Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtBuilder");
+        return JWT_BUILDER_SUPPLIER.get();
     }
 
     /**
@@ -1066,7 +1083,7 @@ public final class Jwts {
      * @return a new {@link JwtParser} instance that can be configured create an immutable/thread-safe {@link JwtParser}.
      */
     public static JwtParserBuilder parser() {
-        return Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtParserBuilder");
+        return JWT_PARSER_BUILDER_SUPPLIER.get();
     }
 
     /**

--- a/api/src/main/java/io/jsonwebtoken/security/Jwks.java
+++ b/api/src/main/java/io/jsonwebtoken/security/Jwks.java
@@ -44,19 +44,19 @@ public final class Jwks {
 
     private static final String JWKS_BRIDGE_FQCN = "io.jsonwebtoken.impl.security.JwksBridge";
 
-    // @since JJWT_RELEASE_VERSION
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     private static final Supplier<DynamicJwkBuilder<?, ?>> BUILDER_SUPPLIER =
             Classes.newInstance("io.jsonwebtoken.impl.security.DefaultDynamicJwkBuilder$Supplier");
 
-    // @since JJWT_RELEASE_VERSION
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     private static final Supplier<JwkParserBuilder> PARSER_BUILDER_SUPPLIER =
             Classes.newInstance("io.jsonwebtoken.impl.security.DefaultJwkParserBuilder$Supplier");
 
-    // @since JJWT_RELEASE_VERSION
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     private static final Supplier<JwkSetBuilder> SET_BUILDER_SUPPLIER =
             Classes.newInstance("io.jsonwebtoken.impl.security.DefaultJwkSetBuilder$Supplier");
 
-    // @since JJWT_RELEASE_VERSION
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     private static final Supplier<JwkSetParserBuilder> SET_PARSER_BUILDER_SUPPLIER =
             Classes.newInstance("io.jsonwebtoken.impl.security.DefaultJwkSetParserBuilder$Supplier");
 
@@ -383,9 +383,11 @@ public final class Jwks {
         private static final String IMPL_CLASSNAME = "io.jsonwebtoken.impl.security.StandardKeyOperations";
         private static final Registry<String, KeyOperation> REGISTRY = Classes.newInstance(IMPL_CLASSNAME);
 
+        // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
         private static final Supplier<KeyOperationBuilder> BUILDER_SUPPLIER =
                 Classes.newInstance("io.jsonwebtoken.impl.security.DefaultKeyOperationBuilder$Supplier");
 
+        // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
         private static final Supplier<KeyOperationPolicyBuilder> POLICY_BUILDER_SUPPLIER =
                 Classes.newInstance("io.jsonwebtoken.impl.security.DefaultKeyOperationPolicyBuilder$Supplier");
 

--- a/api/src/main/java/io/jsonwebtoken/security/Jwks.java
+++ b/api/src/main/java/io/jsonwebtoken/security/Jwks.java
@@ -19,6 +19,7 @@ import io.jsonwebtoken.Identifiable;
 import io.jsonwebtoken.io.Parser;
 import io.jsonwebtoken.lang.Classes;
 import io.jsonwebtoken.lang.Registry;
+import io.jsonwebtoken.lang.Supplier;
 
 /**
  * Utility methods for creating
@@ -42,10 +43,22 @@ public final class Jwks {
     } //prevent instantiation
 
     private static final String JWKS_BRIDGE_FQCN = "io.jsonwebtoken.impl.security.JwksBridge";
-    private static final String BUILDER_FQCN = "io.jsonwebtoken.impl.security.DefaultDynamicJwkBuilder";
-    private static final String PARSER_BUILDER_FQCN = "io.jsonwebtoken.impl.security.DefaultJwkParserBuilder";
-    private static final String SET_BUILDER_FQCN = "io.jsonwebtoken.impl.security.DefaultJwkSetBuilder";
-    private static final String SET_PARSER_BUILDER_FQCN = "io.jsonwebtoken.impl.security.DefaultJwkSetParserBuilder";
+
+    // @since JJWT_RELEASE_VERSION
+    private static final Supplier<DynamicJwkBuilder<?, ?>> BUILDER_SUPPLIER =
+            Classes.newInstance("io.jsonwebtoken.impl.security.DefaultDynamicJwkBuilder$Supplier");
+
+    // @since JJWT_RELEASE_VERSION
+    private static final Supplier<JwkParserBuilder> PARSER_BUILDER_SUPPLIER =
+            Classes.newInstance("io.jsonwebtoken.impl.security.DefaultJwkParserBuilder$Supplier");
+
+    // @since JJWT_RELEASE_VERSION
+    private static final Supplier<JwkSetBuilder> SET_BUILDER_SUPPLIER =
+            Classes.newInstance("io.jsonwebtoken.impl.security.DefaultJwkSetBuilder$Supplier");
+
+    // @since JJWT_RELEASE_VERSION
+    private static final Supplier<JwkSetParserBuilder> SET_PARSER_BUILDER_SUPPLIER =
+            Classes.newInstance("io.jsonwebtoken.impl.security.DefaultJwkSetParserBuilder$Supplier");
 
     /**
      * Return a new JWK builder instance, allowing for type-safe JWK builder coercion based on a specified key or key pair.
@@ -53,7 +66,7 @@ public final class Jwks {
      * @return a new JWK builder instance, allowing for type-safe JWK builder coercion based on a specified key or key pair.
      */
     public static DynamicJwkBuilder<?, ?> builder() {
-        return Classes.newInstance(BUILDER_FQCN);
+        return BUILDER_SUPPLIER.get();
     }
 
     /**
@@ -69,7 +82,7 @@ public final class Jwks {
      * @return a new builder used to create {@link Parser}s that parse JSON into {@link Jwk} instances.
      */
     public static JwkParserBuilder parser() {
-        return Classes.newInstance(PARSER_BUILDER_FQCN);
+        return PARSER_BUILDER_SUPPLIER.get();
     }
 
     /**
@@ -87,7 +100,7 @@ public final class Jwks {
      * @return a new builder used to create {@link JwkSet}s
      */
     public static JwkSetBuilder set() {
-        return Classes.newInstance(SET_BUILDER_FQCN);
+        return SET_BUILDER_SUPPLIER.get();
     }
 
     /**
@@ -103,7 +116,7 @@ public final class Jwks {
      * @return a new builder used to create {@link Parser}s that parse JSON into {@link JwkSet} instances.
      */
     public static JwkSetParserBuilder setParser() {
-        return Classes.newInstance(SET_PARSER_BUILDER_FQCN);
+        return SET_PARSER_BUILDER_SUPPLIER.get();
     }
 
     /**
@@ -370,11 +383,11 @@ public final class Jwks {
         private static final String IMPL_CLASSNAME = "io.jsonwebtoken.impl.security.StandardKeyOperations";
         private static final Registry<String, KeyOperation> REGISTRY = Classes.newInstance(IMPL_CLASSNAME);
 
-        private static final String BUILDER_CLASSNAME = "io.jsonwebtoken.impl.security.DefaultKeyOperationBuilder";
+        private static final Supplier<KeyOperationBuilder> BUILDER_SUPPLIER =
+                Classes.newInstance("io.jsonwebtoken.impl.security.DefaultKeyOperationBuilder$Supplier");
 
-
-        private static final String POLICY_BUILDER_CLASSNAME =
-                "io.jsonwebtoken.impl.security.DefaultKeyOperationPolicyBuilder";
+        private static final Supplier<KeyOperationPolicyBuilder> POLICY_BUILDER_SUPPLIER =
+                Classes.newInstance("io.jsonwebtoken.impl.security.DefaultKeyOperationPolicyBuilder$Supplier");
 
         /**
          * Creates a new {@link KeyOperationBuilder} for creating custom {@link KeyOperation} instances.
@@ -382,7 +395,7 @@ public final class Jwks {
          * @return a new {@link KeyOperationBuilder} for creating custom {@link KeyOperation} instances.
          */
         public static KeyOperationBuilder builder() {
-            return Classes.newInstance(BUILDER_CLASSNAME);
+            return BUILDER_SUPPLIER.get();
         }
 
         /**
@@ -391,7 +404,7 @@ public final class Jwks {
          * @return a new {@link KeyOperationPolicyBuilder} for creating custom {@link KeyOperationPolicy} instances.
          */
         public static KeyOperationPolicyBuilder policy() {
-            return Classes.newInstance(POLICY_BUILDER_CLASSNAME);
+            return POLICY_BUILDER_SUPPLIER.get();
         }
 
         /**

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultClaimsBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultClaimsBuilder.java
@@ -34,10 +34,7 @@ public final class DefaultClaimsBuilder extends DelegatingClaimsMutator<ClaimsBu
         return new DefaultClaims(this.DELEGATE);
     }
 
-    /**
-     * @since JJWT_RELEASE_VERSION
-     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
-     */
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<ClaimsBuilder> {
         @Override

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultClaimsBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultClaimsBuilder.java
@@ -21,7 +21,6 @@ import io.jsonwebtoken.ClaimsBuilder;
 /**
  * @since 0.12.0
  */
-@SuppressWarnings("unused") // used via reflection via Jwts.claims()
 public final class DefaultClaimsBuilder extends DelegatingClaimsMutator<ClaimsBuilder>
         implements ClaimsBuilder {
 
@@ -33,5 +32,16 @@ public final class DefaultClaimsBuilder extends DelegatingClaimsMutator<ClaimsBu
     public Claims build() {
         // ensure a new instance is returned so that the builder may be re-used:
         return new DefaultClaims(this.DELEGATE);
+    }
+
+    /**
+     * @since JJWT_RELEASE_VERSION
+     */
+    @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
+    public static final class Supplier implements io.jsonwebtoken.lang.Supplier<ClaimsBuilder> {
+        @Override
+        public ClaimsBuilder get() {
+            return new DefaultClaimsBuilder();
+        }
     }
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultClaimsBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultClaimsBuilder.java
@@ -36,6 +36,7 @@ public final class DefaultClaimsBuilder extends DelegatingClaimsMutator<ClaimsBu
 
     /**
      * @since JJWT_RELEASE_VERSION
+     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
      */
     @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<ClaimsBuilder> {

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
@@ -818,10 +818,7 @@ public class DefaultJwtBuilder implements JwtBuilder {
         }
     }
 
-    /**
-     * @since JJWT_RELEASE_VERSION
-     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
-     */
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwtBuilder> {
         @Override

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
@@ -824,7 +824,7 @@ public class DefaultJwtBuilder implements JwtBuilder {
     @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwtBuilder> {
         @Override
-        public JwtBuilder get() {
+        public JwtBuilder get() {   
             return new DefaultJwtBuilder();
         }
     }

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
@@ -820,11 +820,12 @@ public class DefaultJwtBuilder implements JwtBuilder {
 
     /**
      * @since JJWT_RELEASE_VERSION
+     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
      */
     @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwtBuilder> {
         @Override
-        public JwtBuilder get() {   
+        public JwtBuilder get() {
             return new DefaultJwtBuilder();
         }
     }

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtBuilder.java
@@ -818,4 +818,14 @@ public class DefaultJwtBuilder implements JwtBuilder {
         }
     }
 
+    /**
+     * @since JJWT_RELEASE_VERSION
+     */
+    @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
+    public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwtBuilder> {
+        @Override
+        public JwtBuilder get() {
+            return new DefaultJwtBuilder();
+        }
+    }
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtHeaderBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtHeaderBuilder.java
@@ -87,6 +87,7 @@ public class DefaultJwtHeaderBuilder extends DefaultJweHeaderBuilder<Jwts.Header
 
     /**
      * @since JJWT_RELEASE_VERSION
+     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
      */
     @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<Jwts.HeaderBuilder> {

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtHeaderBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtHeaderBuilder.java
@@ -84,4 +84,15 @@ public class DefaultJwtHeaderBuilder extends DefaultJweHeaderBuilder<Jwts.Header
             return new DefaultHeader(sanitizeCrit(m, false));
         }
     }
+
+    /**
+     * @since JJWT_RELEASE_VERSION
+     */
+    @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
+    public static final class Supplier implements io.jsonwebtoken.lang.Supplier<Jwts.HeaderBuilder> {
+        @Override
+        public Jwts.HeaderBuilder get() {
+            return new DefaultJwtHeaderBuilder();
+        }
+    }
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtHeaderBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtHeaderBuilder.java
@@ -85,10 +85,7 @@ public class DefaultJwtHeaderBuilder extends DefaultJweHeaderBuilder<Jwts.Header
         }
     }
 
-    /**
-     * @since JJWT_RELEASE_VERSION
-     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
-     */
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<Jwts.HeaderBuilder> {
         @Override

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParserBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParserBuilder.java
@@ -426,4 +426,15 @@ public class DefaultJwtParserBuilder implements JwtParserBuilder {
                 encAlgs
         );
     }
+
+    /**
+     * @since JJWT_RELEASE_VERSION
+     */
+    @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
+    public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwtParserBuilder> {
+        @Override
+        public JwtParserBuilder get() {
+            return new DefaultJwtParserBuilder();
+        }
+    }
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParserBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParserBuilder.java
@@ -427,10 +427,7 @@ public class DefaultJwtParserBuilder implements JwtParserBuilder {
         );
     }
 
-    /**
-     * @since JJWT_RELEASE_VERSION
-     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
-     */
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwtParserBuilder> {
         @Override

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParserBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParserBuilder.java
@@ -429,6 +429,7 @@ public class DefaultJwtParserBuilder implements JwtParserBuilder {
 
     /**
      * @since JJWT_RELEASE_VERSION
+     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
      */
     @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwtParserBuilder> {

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultDynamicJwkBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultDynamicJwkBuilder.java
@@ -209,4 +209,15 @@ public class DefaultDynamicJwkBuilder<K extends Key, J extends Jwk<K>>
         }
         return super.build();
     }
+
+    /**
+     * @since JJWT_RELEASE_VERSION
+     */
+    @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
+    public static final class Supplier implements io.jsonwebtoken.lang.Supplier<DynamicJwkBuilder<?, ?>> {
+        @Override
+        public DynamicJwkBuilder<?, ?> get() {
+            return new DefaultDynamicJwkBuilder<>();
+        }
+    }
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultDynamicJwkBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultDynamicJwkBuilder.java
@@ -212,6 +212,7 @@ public class DefaultDynamicJwkBuilder<K extends Key, J extends Jwk<K>>
 
     /**
      * @since JJWT_RELEASE_VERSION
+     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
      */
     @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
     public static final class Supplier<K extends Key, J extends Jwk<K>> implements io.jsonwebtoken.lang.Supplier<DynamicJwkBuilder<K, J>> {

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultDynamicJwkBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultDynamicJwkBuilder.java
@@ -214,9 +214,9 @@ public class DefaultDynamicJwkBuilder<K extends Key, J extends Jwk<K>>
      * @since JJWT_RELEASE_VERSION
      */
     @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
-    public static final class Supplier implements io.jsonwebtoken.lang.Supplier<DynamicJwkBuilder<?, ?>> {
+    public static final class Supplier<K extends Key, J extends Jwk<K>> implements io.jsonwebtoken.lang.Supplier<DynamicJwkBuilder<K, J>> {
         @Override
-        public DynamicJwkBuilder<?, ?> get() {
+        public DynamicJwkBuilder<K, J> get() {
             return new DefaultDynamicJwkBuilder<>();
         }
     }

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultDynamicJwkBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultDynamicJwkBuilder.java
@@ -210,10 +210,7 @@ public class DefaultDynamicJwkBuilder<K extends Key, J extends Jwk<K>>
         return super.build();
     }
 
-    /**
-     * @since JJWT_RELEASE_VERSION
-     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
-     */
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
     public static final class Supplier<K extends Key, J extends Jwk<K>> implements io.jsonwebtoken.lang.Supplier<DynamicJwkBuilder<K, J>> {
         @Override

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkParserBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkParserBuilder.java
@@ -29,4 +29,15 @@ public class DefaultJwkParserBuilder extends AbstractJwkParserBuilder<Jwk<?>, Jw
         JwkConverter<Jwk<?>> converter = new JwkConverter<>(supplier);
         return new ConvertingParser<>(deserializer, converter);
     }
+
+    /**
+     * @since JJWT_RELEASE_VERSION
+     */
+    @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
+    public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwkParserBuilder> {
+        @Override
+        public JwkParserBuilder get() {
+            return new DefaultJwkParserBuilder();
+        }
+    }
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkParserBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkParserBuilder.java
@@ -30,10 +30,7 @@ public class DefaultJwkParserBuilder extends AbstractJwkParserBuilder<Jwk<?>, Jw
         return new ConvertingParser<>(deserializer, converter);
     }
 
-    /**
-     * @since JJWT_RELEASE_VERSION
-     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
-     */
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwkParserBuilder> {
         @Override

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkParserBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkParserBuilder.java
@@ -32,6 +32,7 @@ public class DefaultJwkParserBuilder extends AbstractJwkParserBuilder<Jwk<?>, Jw
 
     /**
      * @since JJWT_RELEASE_VERSION
+     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
      */
     @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwkParserBuilder> {

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkSetBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkSetBuilder.java
@@ -130,10 +130,7 @@ public class DefaultJwkSetBuilder extends AbstractSecurityBuilder<JwkSet, JwkSet
         return converter.applyFrom(this.map);
     }
 
-    /**
-     * @since JJWT_RELEASE_VERSION
-     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
-     */
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwkSetBuilder> {
         @Override

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkSetBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkSetBuilder.java
@@ -132,6 +132,7 @@ public class DefaultJwkSetBuilder extends AbstractSecurityBuilder<JwkSet, JwkSet
 
     /**
      * @since JJWT_RELEASE_VERSION
+     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
      */
     @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwkSetBuilder> {

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkSetBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkSetBuilder.java
@@ -129,4 +129,15 @@ public class DefaultJwkSetBuilder extends AbstractSecurityBuilder<JwkSet, JwkSet
     public JwkSet build() {
         return converter.applyFrom(this.map);
     }
+
+    /**
+     * @since JJWT_RELEASE_VERSION
+     */
+    @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
+    public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwkSetBuilder> {
+        @Override
+        public JwkSetBuilder get() {
+            return new DefaultJwkSetBuilder();
+        }
+    }
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkSetParserBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkSetParserBuilder.java
@@ -38,4 +38,15 @@ public class DefaultJwkSetParserBuilder extends AbstractJwkParserBuilder<JwkSet,
         JwkSetConverter converter = new JwkSetConverter(supplier, this.ignoreUnsupported);
         return new ConvertingParser<>(deserializer, converter);
     }
+
+    /**
+     * @since JJWT_RELEASE_VERSION
+     */
+    @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
+    public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwkSetParserBuilder> {
+        @Override
+        public JwkSetParserBuilder get() {
+            return new DefaultJwkSetParserBuilder();
+        }
+    }
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkSetParserBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkSetParserBuilder.java
@@ -39,10 +39,7 @@ public class DefaultJwkSetParserBuilder extends AbstractJwkParserBuilder<JwkSet,
         return new ConvertingParser<>(deserializer, converter);
     }
 
-    /**
-     * @since JJWT_RELEASE_VERSION
-     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
-     */
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwkSetParserBuilder> {
         @Override

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkSetParserBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultJwkSetParserBuilder.java
@@ -41,6 +41,7 @@ public class DefaultJwkSetParserBuilder extends AbstractJwkParserBuilder<JwkSet,
 
     /**
      * @since JJWT_RELEASE_VERSION
+     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
      */
     @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<JwkSetParserBuilder> {

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultKeyOperationBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultKeyOperationBuilder.java
@@ -53,10 +53,7 @@ public class DefaultKeyOperationBuilder implements KeyOperationBuilder {
         return new DefaultKeyOperation(this.id, this.description, this.related);
     }
 
-    /**
-     * @since JJWT_RELEASE_VERSION
-     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
-     */
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<KeyOperationBuilder> {
         @Override

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultKeyOperationBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultKeyOperationBuilder.java
@@ -55,6 +55,7 @@ public class DefaultKeyOperationBuilder implements KeyOperationBuilder {
 
     /**
      * @since JJWT_RELEASE_VERSION
+     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
      */
     @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<KeyOperationBuilder> {

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultKeyOperationBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultKeyOperationBuilder.java
@@ -52,4 +52,15 @@ public class DefaultKeyOperationBuilder implements KeyOperationBuilder {
     public KeyOperation build() {
         return new DefaultKeyOperation(this.id, this.description, this.related);
     }
+
+    /**
+     * @since JJWT_RELEASE_VERSION
+     */
+    @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
+    public static final class Supplier implements io.jsonwebtoken.lang.Supplier<KeyOperationBuilder> {
+        @Override
+        public KeyOperationBuilder get() {
+            return new DefaultKeyOperationBuilder();
+        }
+    }
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultKeyOperationPolicyBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultKeyOperationPolicyBuilder.java
@@ -44,6 +44,7 @@ public class DefaultKeyOperationPolicyBuilder extends DefaultCollectionMutator<K
 
     /**
      * @since JJWT_RELEASE_VERSION
+     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
      */
     @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<KeyOperationPolicyBuilder> {

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultKeyOperationPolicyBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultKeyOperationPolicyBuilder.java
@@ -42,10 +42,7 @@ public class DefaultKeyOperationPolicyBuilder extends DefaultCollectionMutator<K
         return new DefaultKeyOperationPolicy(Collections.immutable(getCollection()), this.unrelated);
     }
 
-    /**
-     * @since JJWT_RELEASE_VERSION
-     * @see <a href="https://github.com/jwtk/jjwt/issues/988>Issue 988</a>
-     */
+    // @since JJWT_RELEASE_VERSION per https://github.com/jwtk/jjwt/issues/988
     @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
     public static final class Supplier implements io.jsonwebtoken.lang.Supplier<KeyOperationPolicyBuilder> {
         @Override

--- a/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultKeyOperationPolicyBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/security/DefaultKeyOperationPolicyBuilder.java
@@ -41,4 +41,15 @@ public class DefaultKeyOperationPolicyBuilder extends DefaultCollectionMutator<K
     public KeyOperationPolicy build() {
         return new DefaultKeyOperationPolicy(Collections.immutable(getCollection()), this.unrelated);
     }
+
+    /**
+     * @since JJWT_RELEASE_VERSION
+     */
+    @SuppressWarnings("unused") // used via reflection in the api module's Jwks class.
+    public static final class Supplier implements io.jsonwebtoken.lang.Supplier<KeyOperationPolicyBuilder> {
+        @Override
+        public KeyOperationPolicyBuilder get() {
+            return new DefaultKeyOperationPolicyBuilder();
+        }
+    }
 }


### PR DESCRIPTION
Ensured `*Builder` instances are no longer created with reflection using `Classes.newInstance`.  Instead, `Classes.newInstance` is used to create static/thread-safe Supplier singletons when the api module is loaded, and those singletons will directly instantiate `*Builder` instances at runtime using the `new` keyword`.

Resolves #988.