### PR TITLE
Ensure softhsm worked with local build from source

### DIFF
--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pkcs11Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pkcs11Test.groovy
@@ -39,6 +39,7 @@ class Pkcs11Test {
             '/opt/homebrew/lib/softhsm/libsofthsm2.so', // macos: brew install softhsm
             '/usr/lib/softhsm/libsofthsm2.so',          // ubuntu: sudo apt-get install -y softhsm2
             '/usr/local/lib/libsofthsm2.so',            // other *nixes?
+            '/usr/local/lib/softhsm/libsofthsm2.so',
             'C:\\SoftHSM2\\lib\\softhsm2-x64.dll',      // https://github.com/disig/SoftHSM2-for-Windows
             'C:\\SoftHSM2\\lib\\softhsm2.dll'           // https://github.com/disig/SoftHSM2-for-Windows
     ]

--- a/impl/src/test/scripts/softhsm
+++ b/impl/src/test/scripts/softhsm
@@ -112,6 +112,9 @@ _setup() {
   platform='macos'
   globalconf='/opt/homebrew/etc/softhsm/softhsm2.conf'
   libsofthsm2='/opt/homebrew/lib/softhsm/libsofthsm2.so'
+  if [[ ! -f "${libsofthsm2}" ]]; then # backup (build softhsm from source)
+    libsofthsm2='/usr/local/lib/softhsm/libsofthsm2.so'
+  fi
   if [[ ! -f "${libsofthsm2}" ]]; then # assume CI (Ubuntu)
     platform='ubuntu'
     globalconf='/etc/softhsm/softhsm2.conf'


### PR DESCRIPTION
After upgrading homebrew to openssl 3, softhsm logins were failing on MacOS 10.14.  Upgrading to Sonoma (10.15.6), it still failed. Completely deleting and reinstalling XCode Command Line tools didn't work.  Finally, a custom build from source worked per https://github.com/parallaxsecond/rust-cryptoki/issues/191.

This PR updates the softhsm-related code to work on a system with a source build.