### PR TITLE
Enable JwtParser empty nested algorithm collections.

### DIFF
--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultHeader.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultHeader.java
@@ -17,8 +17,10 @@ package io.jsonwebtoken.impl;
 
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.impl.lang.CompactMediaTypeIdConverter;
+import io.jsonwebtoken.impl.lang.Nameable;
 import io.jsonwebtoken.impl.lang.Parameter;
 import io.jsonwebtoken.impl.lang.Parameters;
+import io.jsonwebtoken.lang.Assert;
 import io.jsonwebtoken.lang.Registry;
 import io.jsonwebtoken.lang.Strings;
 
@@ -52,6 +54,11 @@ public class DefaultHeader extends ParameterMap implements Header {
     @Override
     public String getName() {
         return "JWT header";
+    }
+
+    static String nameOf(Header header) {
+        return Assert.hasText(Assert.isInstanceOf(Nameable.class, header).getName(),
+                "Header name cannot be null or empty.");
     }
 
     @Override

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -275,7 +275,7 @@ public class DefaultJwtParser extends AbstractParser<Jwt<?, ?>> implements JwtPa
             algorithm = (SecureDigestAlgorithm<?, Key>) sigAlgs.apply(jwsHeader);
         } catch (UnsupportedJwtException e) {
             //For backwards compatibility.  TODO: remove this try/catch block for 1.0 and let UnsupportedJwtException propagate
-            String msg = "Unsupported signature algorithm '" + alg + "'";
+            String msg = "Unsupported signature algorithm '" + alg + "': " + e.getMessage();
             throw new SignatureException(msg, e);
         }
         Assert.stateNotNull(algorithm, "JWS Signature Algorithm cannot be null.");

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -241,11 +241,11 @@ public class DefaultJwtParser extends AbstractParser<Jwt<?, ?>> implements JwtPa
         this.expectedClaims = Jwts.claims().add(expectedClaims);
         this.decoder = Assert.notNull(base64UrlDecoder, "base64UrlDecoder cannot be null.");
         this.deserializer = Assert.notNull(deserializer, "JSON Deserializer cannot be null.");
-        this.sigAlgs = new IdLocator<>(DefaultHeader.ALGORITHM, sigAlgs, MISSING_JWS_ALG_MSG);
-        this.keyAlgs = new IdLocator<>(DefaultHeader.ALGORITHM, keyAlgs, MISSING_JWE_ALG_MSG);
-        this.encAlgs = new IdLocator<>(DefaultJweHeader.ENCRYPTION_ALGORITHM, encAlgs, MISSING_ENC_MSG);
+        this.sigAlgs = new IdLocator<>(DefaultHeader.ALGORITHM, sigAlgs, "mac or signature", "signature verification", MISSING_JWS_ALG_MSG);
+        this.keyAlgs = new IdLocator<>(DefaultHeader.ALGORITHM, keyAlgs, "key management", "decryption", MISSING_JWE_ALG_MSG);
+        this.encAlgs = new IdLocator<>(DefaultJweHeader.ENCRYPTION_ALGORITHM, encAlgs, "encryption", "decryption", MISSING_ENC_MSG);
         this.zipAlgs = compressionCodecResolver != null ? new CompressionCodecLocator(compressionCodecResolver) :
-                new IdLocator<>(DefaultHeader.COMPRESSION_ALGORITHM, zipAlgs, null);
+                new IdLocator<>(DefaultHeader.COMPRESSION_ALGORITHM, zipAlgs, "compression", "decompression", null);
     }
 
     @Override
@@ -459,7 +459,7 @@ public class DefaultJwtParser extends AbstractParser<Jwt<?, ?>> implements JwtPa
         final boolean payloadBase64UrlEncoded = !(header instanceof JwsHeader) || ((JwsHeader) header).isPayloadEncoded();
         if (payloadBase64UrlEncoded) {
             // standard encoding, so decode it:
-            byte[] data = decode(tokenized.getPayload(), "payload");
+            byte[] data = decode(payloadToken, "payload");
             payload = new Payload(data, header.getContentType());
         } else {
             // The JWT uses the b64 extension, and we already know the parser supports that extension at this point
@@ -492,6 +492,13 @@ public class DefaultJwtParser extends AbstractParser<Jwt<?, ?>> implements JwtPa
 
             TokenizedJwe tokenizedJwe = (TokenizedJwe) tokenized;
             JweHeader jweHeader = Assert.stateIsInstance(JweHeader.class, header, "Not a JweHeader. ");
+
+            // Ensure both an 'alg' and 'enc' header value exists and is supported before spending time/effort
+            // base64Url-decoding anything:
+            final AeadAlgorithm encAlg = this.encAlgs.apply(jweHeader);
+            Assert.stateNotNull(encAlg, "JWE Encryption Algorithm cannot be null.");
+            @SuppressWarnings("rawtypes") final KeyAlgorithm keyAlg = this.keyAlgs.apply(jweHeader);
+            Assert.stateNotNull(keyAlg, "JWE Key Algorithm cannot be null.");
 
             byte[] cekBytes = Bytes.EMPTY; //ignored unless using an encrypted key algorithm
             CharSequence base64Url = tokenizedJwe.getEncryptedKey();
@@ -528,16 +535,6 @@ public class DefaultJwtParser extends AbstractParser<Jwt<?, ?>> implements JwtPa
                 String msg = "Compact JWE strings must always contain an AAD Authentication Tag.";
                 throw new MalformedJwtException(msg);
             }
-
-            String enc = jweHeader.getEncryptionAlgorithm();
-            if (!Strings.hasText(enc)) {
-                throw new MalformedJwtException(MISSING_ENC_MSG);
-            }
-            final AeadAlgorithm encAlg = this.encAlgs.apply(jweHeader);
-            Assert.stateNotNull(encAlg, "JWE Encryption Algorithm cannot be null.");
-
-            @SuppressWarnings("rawtypes") final KeyAlgorithm keyAlg = this.keyAlgs.apply(jweHeader);
-            Assert.stateNotNull(keyAlg, "JWE Key Algorithm cannot be null.");
 
             Key key = this.keyLocator.locate(jweHeader);
             if (key == null) {

--- a/impl/src/main/java/io/jsonwebtoken/impl/IdLocator.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/IdLocator.java
@@ -17,11 +17,8 @@ package io.jsonwebtoken.impl;
 
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Identifiable;
-import io.jsonwebtoken.JweHeader;
-import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.Locator;
 import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.ProtectedHeader;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.impl.lang.Function;
 import io.jsonwebtoken.impl.lang.Parameter;
@@ -32,63 +29,27 @@ import io.jsonwebtoken.lang.Strings;
 public class IdLocator<H extends Header, R extends Identifiable> implements Locator<R>, Function<H, R> {
 
     private final Parameter<String> param;
-    private final String requiredMsg;
-    private final boolean valueRequired;
-
     private final Registry<String, R> registry;
+    private final String algType;
+    private final String behavior;
+    private final String requiredMsg;
 
-    public IdLocator(Parameter<String> param, Registry<String, R> registry, String requiredExceptionMessage) {
+    public IdLocator(Parameter<String> param, Registry<String, R> registry, String algType, String behavior, String requiredExceptionMessage) {
         this.param = Assert.notNull(param, "Header param cannot be null.");
-        this.requiredMsg = Strings.clean(requiredExceptionMessage);
-        this.valueRequired = Strings.hasText(this.requiredMsg);
         this.registry = Assert.notNull(registry, "Registry cannot be null.");
-    }
-
-    private static String type(Header header) {
-        if (header instanceof JweHeader) {
-            return "JWE";
-        } else if (header instanceof JwsHeader) {
-            return "JWS";
-        } else {
-            return "JWT";
-        }
-    }
-
-    private String emptyMsg(String algType, String behavior) {
-        return " (" + behavior + " is disabled: no " + algType + " algorithms have been configured).";
-    }
-
-    private String unsupportedMsg(Header header, String id) {
-        String msg = "Unsupported " + type(header) + " " + this.param + " header value '" + id + "'";
-        if (!this.registry.isEmpty()) {
-            msg += ".";
-            return msg;
-        }
-        // otherwise, the registry is empty, so indicate that this parser behavior has been disabled:
-        if (header instanceof JweHeader) {
-            if (DefaultJweHeader.ENCRYPTION_ALGORITHM.equals(this.param)) {
-                msg += emptyMsg("encryption", "decryption");
-            } else if (DefaultHeader.ALGORITHM.equals(this.param)) {
-                msg += emptyMsg("key management", "decryption");
-            }
-        } else if (header instanceof JwsHeader) {
-            msg += emptyMsg("mac or signature", "signature verification");
-        }
-        if (header instanceof ProtectedHeader && DefaultHeader.COMPRESSION_ALGORITHM.equals(this.param)) {
-            msg += emptyMsg("compression", "decompression");
-        }
-        return msg;
+        this.algType = Assert.hasText(algType, "algType cannot be null or empty.");
+        this.behavior = Assert.hasText(behavior, "behavior cannot be null or empty.");
+        this.requiredMsg = Strings.clean(requiredExceptionMessage);
     }
 
     @Override
     public R locate(Header header) {
-        Assert.notNull(header, "Header argument cannot be null.");
 
         Object val = header.get(this.param.getId());
         String id = val != null ? val.toString() : null;
 
         if (!Strings.hasText(id)) {
-            if (this.valueRequired) {
+            if (this.requiredMsg != null) { // a msg was provided, so the value is required:
                 throw new MalformedJwtException(requiredMsg);
             }
             return null; // otherwise header value not required, so short circuit
@@ -97,7 +58,20 @@ public class IdLocator<H extends Header, R extends Identifiable> implements Loca
         try {
             return registry.forKey(id);
         } catch (Exception e) {
-            String msg = unsupportedMsg(header, id);
+            StringBuilder sb = new StringBuilder("Unsupported ")
+                    .append(DefaultHeader.nameOf(header))
+                    .append(" ")
+                    .append(this.param)
+                    .append(" value '").append(id).append("'");
+            if (this.registry.isEmpty()) {
+                sb.append(": ")
+                        .append(this.behavior)
+                        .append(" is disabled (no ")
+                        .append(this.algType)
+                        .append(" algorithms have been configured)");
+            }
+            sb.append(".");
+            String msg = sb.toString();
             throw new UnsupportedJwtException(msg, e);
         }
     }

--- a/impl/src/main/java/io/jsonwebtoken/impl/lang/DefaultRegistry.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/lang/DefaultRegistry.java
@@ -29,9 +29,9 @@ public class DefaultRegistry<K, V> extends DelegatingMap<K, V, Map<K, V>> implem
     private final String qualifiedKeyName;
 
     private static <K, V> Map<K, V> toMap(Collection<? extends V> values, Function<V, K> keyFn) {
-        Assert.notEmpty(values, "Collection of values may not be null or empty.");
+        Assert.notNull(values, "Collection of values may not be null.");
         Assert.notNull(keyFn, "Key function cannot be null.");
-        Map<K, V> m = new LinkedHashMap<>(values.size());
+        Map<K, V> m = new LinkedHashMap<>(Collections.size(values));
         for (V value : values) {
             K key = Assert.notNull(keyFn.apply(value), "Key function cannot return a null value.");
             m.put(key, value);

--- a/impl/src/main/java/io/jsonwebtoken/impl/lang/IdRegistry.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/lang/IdRegistry.java
@@ -53,7 +53,7 @@ public class IdRegistry<T extends Identifiable> extends StringRegistry<T> {
 
     public IdRegistry(String name, Collection<T> instances, boolean caseSensitive) {
         super(name, "id",
-                Assert.notEmpty(instances, "Collection of Identifiable instances may not be null or empty."),
+                Assert.notNull(instances, "Collection of Identifiable instances may not be null."),
                 IdRegistry.<T>fn(),
                 caseSensitive);
     }

--- a/impl/src/main/java/io/jsonwebtoken/impl/lang/StringRegistry.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/lang/StringRegistry.java
@@ -37,7 +37,7 @@ public class StringRegistry<V> extends DefaultRegistry<String, V> {
     public StringRegistry(String name, String keyName, Collection<V> values, Function<V, String> keyFn, Function<String, String> caseFn) {
         super(name, keyName, values, keyFn);
         this.CASE_FN = Assert.notNull(caseFn, "Case function cannot be null.");
-        Map<String, V> m = new LinkedHashMap<>(values().size());
+        Map<String, V> m = new LinkedHashMap<>(Collections.size(values));
         for (V value : values) {
             String key = keyFn.apply(value);
             key = this.CASE_FN.apply(key);

--- a/impl/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
@@ -109,7 +109,7 @@ class JwtParserTest {
             fail()
         } catch (SignatureException se) {
             String msg = "Unsupported signature algorithm '$badAlgorithmName': " +
-                    "Unsupported JWS 'alg' (Algorithm) header value '$badAlgorithmName'."
+                    "Unsupported JWS header 'alg' (Algorithm) value '$badAlgorithmName'."
             assertEquals msg, se.getMessage()
         }
     }
@@ -1671,8 +1671,8 @@ class JwtParserTest {
         try {
             parser.parseEncryptedClaims(jwe)
         } catch (UnsupportedJwtException e) {
-            String expected = "Unsupported JWE 'zip' (Compression Algorithm) header value 'DEF' (decompression is " +
-                    "disabled: no compression algorithms have been configured)."
+            String expected = "Unsupported JWE header 'zip' (Compression Algorithm) value 'DEF': " +
+                    "decompression is disabled (no compression algorithms have been configured)."
             assertEquals expected, e.getMessage()
         }
     }
@@ -1698,9 +1698,10 @@ class JwtParserTest {
         try {
             parser.parseSignedClaims(jws)
         } catch (SignatureException e) {
-            String expected = "Unsupported signature algorithm 'HS256': Unsupported JWS 'alg' (Algorithm) header " +
-                    "value 'HS256' (signature verification is disabled: no mac or signature algorithms have been " +
+            String expected = "Unsupported signature algorithm 'HS256': Unsupported JWS header 'alg' (Algorithm) " +
+                    "value 'HS256': signature verification is disabled (no mac or signature algorithms have been " +
                     "configured)."
+            assertTrue e.getCause() instanceof UnsupportedJwtException
             assertEquals expected, e.getMessage()
         }
     }
@@ -1726,8 +1727,8 @@ class JwtParserTest {
         try {
             parser.parseEncryptedClaims(jwe)
         } catch (UnsupportedJwtException e) {
-            String expected = "Unsupported JWE 'enc' (Encryption Algorithm) header value 'A256GCM' " +
-                    "(decryption is disabled: no encryption algorithms have been configured)."
+            String expected = "Unsupported JWE header 'enc' (Encryption Algorithm) value 'A256GCM': " +
+                    "decryption is disabled (no encryption algorithms have been configured)."
             assertEquals expected, e.getMessage()
         }
     }
@@ -1753,8 +1754,8 @@ class JwtParserTest {
         try {
             parser.parseEncryptedClaims(jwe)
         } catch (UnsupportedJwtException e) {
-            String expected = "Unsupported JWE 'alg' (Algorithm) header value 'dir' (decryption is disabled: " +
-                    "no key management algorithms have been configured)."
+            String expected = "Unsupported JWE header 'alg' (Algorithm) value 'dir': decryption is disabled " +
+                    "(no key management algorithms have been configured)."
             assertEquals expected, e.getMessage()
         }
     }

--- a/impl/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
@@ -19,6 +19,7 @@ import io.jsonwebtoken.impl.DefaultJwtParser
 import io.jsonwebtoken.impl.FixedClock
 import io.jsonwebtoken.impl.JwtTokenizer
 import io.jsonwebtoken.impl.lang.JwtDateConverter
+import io.jsonwebtoken.impl.security.TestKeys
 import io.jsonwebtoken.io.Encoders
 import io.jsonwebtoken.lang.DateFormats
 import io.jsonwebtoken.lang.Strings
@@ -107,7 +108,9 @@ class JwtParserTest {
             Jwts.parser().setSigningKey(randomKey()).build().parse(bad)
             fail()
         } catch (SignatureException se) {
-            assertEquals se.getMessage(), "Unsupported signature algorithm '$badAlgorithmName'".toString()
+            String msg = "Unsupported signature algorithm '$badAlgorithmName': " +
+                    "Unsupported JWS 'alg' (Algorithm) header value '$badAlgorithmName'."
+            assertEquals msg, se.getMessage()
         }
     }
 
@@ -1643,6 +1646,116 @@ class JwtParserTest {
             fail()
         } catch (MalformedJwtException se) {
             assertEquals 'The JWS header references signature algorithm \'none\' yet the compact JWS string contains a signature. This is not permitted per https://tools.ietf.org/html/rfc7518#section-3.6.', se.message
+        }
+    }
+
+    /**
+     * Ensures that compression algorithms can be removed completely, thereby disabling compression entirely
+     * @see <a href="https://github.com/jwtk/jjwt/issues/996">Issue 996</a>
+     * @since 0.12.7
+     */
+    @Test
+    void testEmptyZipAlgCollection() {
+
+        // create a compressed JWE first:
+        def key = TestKeys.A256GCM
+        def jwe = Jwts.builder().claim("hello", "world")
+                .compressWith(Jwts.ZIP.DEF)
+                .encryptWith(key, Jwts.ENC.A256GCM)
+                .compact()
+
+        //now build a parser with no decompression algs (which should disable decompression)
+        def parser = Jwts.parser().zip().clear().and().decryptWith(key).build()
+
+        //parsing should fail since (de)compression is disabled:
+        try {
+            parser.parseEncryptedClaims(jwe)
+        } catch (UnsupportedJwtException e) {
+            String expected = "Unsupported JWE 'zip' (Compression Algorithm) header value 'DEF' (decompression is " +
+                    "disabled: no compression algorithms have been configured)."
+            assertEquals expected, e.getMessage()
+        }
+    }
+
+    /**
+     * Ensures that mac/signature algorithms can be removed completely, thereby disabling JWSs entirely
+     * @see <a href="https://github.com/jwtk/jjwt/issues/996">Issue 996</a>
+     * @since 0.12.7
+     */
+    @Test
+    void testEmptySigAlgCollection() {
+
+        // create a compressed JWE first:
+        def key = TestKeys.HS256
+        def jws = Jwts.builder().claim("hello", "world")
+                .signWith(key, Jwts.SIG.HS256)
+                .compact()
+
+        //now build a parser with no signature algs, which should completely disable signature verification
+        def parser = Jwts.parser().sig().clear().and().verifyWith(key).build()
+
+        //parsing should fail since signature verification is disabled:
+        try {
+            parser.parseSignedClaims(jws)
+        } catch (SignatureException e) {
+            String expected = "Unsupported signature algorithm 'HS256': Unsupported JWS 'alg' (Algorithm) header " +
+                    "value 'HS256' (signature verification is disabled: no mac or signature algorithms have been " +
+                    "configured)."
+            assertEquals expected, e.getMessage()
+        }
+    }
+
+    /**
+     * Ensures that encryption algorithms can be removed completely, thereby disabling JWEs entirely
+     * @see <a href="https://github.com/jwtk/jjwt/issues/996">Issue 996</a>
+     * @since 0.12.7
+     */
+    @Test
+    void testEmptyEncAlgCollection() {
+
+        // create a compressed JWE first:
+        def key = TestKeys.A256GCM
+        def jwe = Jwts.builder().claim("hello", "world")
+                .encryptWith(key, Jwts.ENC.A256GCM)
+                .compact()
+
+        //now build a parser with no encryption algs, which should completely disable decryption
+        def parser = Jwts.parser().enc().clear().and().decryptWith(key).build()
+
+        //parsing should fail since decryption is disabled:
+        try {
+            parser.parseEncryptedClaims(jwe)
+        } catch (UnsupportedJwtException e) {
+            String expected = "Unsupported JWE 'enc' (Encryption Algorithm) header value 'A256GCM' " +
+                    "(decryption is disabled: no encryption algorithms have been configured)."
+            assertEquals expected, e.getMessage()
+        }
+    }
+
+    /**
+     * Ensures that key management algorithms can be removed completely, thereby disabling JWEs entirely
+     * @see <a href="https://github.com/jwtk/jjwt/issues/996">Issue 996</a>
+     * @since 0.12.7
+     */
+    @Test
+    void testEmptyKeyAlgCollection() {
+
+        // create a compressed JWE first:
+        def key = TestKeys.A256GCM
+        def jwe = Jwts.builder().claim("hello", "world")
+                .encryptWith(key, Jwts.ENC.A256GCM)
+                .compact()
+
+        //now build a parser with no key management algs, which should completely disable decryption
+        def parser = Jwts.parser().key().clear().and().decryptWith(key).build()
+
+        //parsing should fail since key management is disabled:
+        try {
+            parser.parseEncryptedClaims(jwe)
+        } catch (UnsupportedJwtException e) {
+            String expected = "Unsupported JWE 'alg' (Algorithm) header value 'dir' (decryption is disabled: " +
+                    "no key management algorithms have been configured)."
+            assertEquals expected, e.getMessage()
         }
     }
 }

--- a/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
@@ -22,11 +22,7 @@ import io.jsonwebtoken.impl.io.Streams
 import io.jsonwebtoken.impl.lang.Bytes
 import io.jsonwebtoken.impl.lang.Services
 import io.jsonwebtoken.impl.security.*
-import io.jsonwebtoken.io.CompressionAlgorithm
-import io.jsonwebtoken.io.Decoders
-import io.jsonwebtoken.io.Deserializer
-import io.jsonwebtoken.io.Encoders
-import io.jsonwebtoken.io.Serializer
+import io.jsonwebtoken.io.*
 import io.jsonwebtoken.lang.Strings
 import io.jsonwebtoken.security.*
 import org.junit.Test
@@ -987,7 +983,7 @@ class JwtsTest {
             Jwts.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (UnsupportedJwtException e) {
-            String expected = "Unrecognized JWE 'enc' (Encryption Algorithm) header value: foo"
+            String expected = "Unsupported JWE 'enc' (Encryption Algorithm) header value 'foo'."
             assertEquals expected, e.getMessage()
         }
     }
@@ -1007,7 +1003,7 @@ class JwtsTest {
             Jwts.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (UnsupportedJwtException e) {
-            String expected = "Unrecognized JWE 'alg' (Algorithm) header value: bar"
+            String expected = "Unsupported JWE 'alg' (Algorithm) header value 'bar'."
             assertEquals expected, e.getMessage()
         }
     }
@@ -1025,7 +1021,8 @@ class JwtsTest {
             Jwts.parser().build().parseSignedClaims(compact)
             fail()
         } catch (io.jsonwebtoken.security.SignatureException e) {
-            String expected = "Unsupported signature algorithm 'bar'"
+            String expected = "Unsupported signature algorithm 'bar': " +
+                    "Unsupported JWS 'alg' (Algorithm) header value 'bar'."
             assertEquals expected, e.getMessage()
         }
     }

--- a/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
@@ -983,7 +983,7 @@ class JwtsTest {
             Jwts.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (UnsupportedJwtException e) {
-            String expected = "Unsupported JWE 'enc' (Encryption Algorithm) header value 'foo'."
+            String expected = "Unsupported JWE header 'enc' (Encryption Algorithm) value 'foo'."
             assertEquals expected, e.getMessage()
         }
     }
@@ -1003,7 +1003,7 @@ class JwtsTest {
             Jwts.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (UnsupportedJwtException e) {
-            String expected = "Unsupported JWE 'alg' (Algorithm) header value 'bar'."
+            String expected = "Unsupported JWE header 'alg' (Algorithm) value 'bar'."
             assertEquals expected, e.getMessage()
         }
     }
@@ -1022,7 +1022,7 @@ class JwtsTest {
             fail()
         } catch (io.jsonwebtoken.security.SignatureException e) {
             String expected = "Unsupported signature algorithm 'bar': " +
-                    "Unsupported JWS 'alg' (Algorithm) header value 'bar'."
+                    "Unsupported JWS header 'alg' (Algorithm) value 'bar'."
             assertEquals expected, e.getMessage()
         }
     }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserBuilderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserBuilderTest.groovy
@@ -225,7 +225,7 @@ class DefaultJwtParserBuilderTest {
             parser.zipAlgs.apply(nonStandard)
             fail()
         } catch (UnsupportedJwtException e) {
-            String msg = "Unsupported JWT ${DefaultHeader.COMPRESSION_ALGORITHM} header value 'def'."
+            String msg = "Unsupported JWT header ${DefaultHeader.COMPRESSION_ALGORITHM} value 'def'."
             assertEquals msg, e.getMessage()
         }
     }
@@ -268,7 +268,7 @@ class DefaultJwtParserBuilderTest {
             parser.encAlgs.apply(nonStandard) // non-standard id
             fail()
         } catch (UnsupportedJwtException e) {
-            String msg = "Unsupported JWE ${DefaultJweHeader.ENCRYPTION_ALGORITHM} header value '${alg.id.toLowerCase()}'."
+            String msg = "Unsupported JWE header ${DefaultJweHeader.ENCRYPTION_ALGORITHM} value '${alg.id.toLowerCase()}'."
             assertEquals msg, e.getMessage()
         }
     }
@@ -314,7 +314,7 @@ class DefaultJwtParserBuilderTest {
             parser.keyAlgs.apply(nonStandard) // non-standard id
             fail()
         } catch (UnsupportedJwtException e) {
-            String msg = "Unsupported JWE ${DefaultJweHeader.ALGORITHM} header value '${alg.id.toLowerCase()}'."
+            String msg = "Unsupported JWE header ${DefaultJweHeader.ALGORITHM} value '${alg.id.toLowerCase()}'."
             assertEquals msg, e.getMessage()
         }
     }
@@ -358,7 +358,7 @@ class DefaultJwtParserBuilderTest {
             parser.sigAlgs.apply(nonStandard) // non-standard id
             fail()
         } catch (UnsupportedJwtException e) {
-            String msg = "Unsupported JWS ${DefaultJwsHeader.ALGORITHM} header value '${alg.id.toLowerCase()}'."
+            String msg = "Unsupported JWS header ${DefaultJwsHeader.ALGORITHM} value '${alg.id.toLowerCase()}'."
             assertEquals msg, e.getMessage()
         }
     }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserBuilderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserBuilderTest.groovy
@@ -225,7 +225,7 @@ class DefaultJwtParserBuilderTest {
             parser.zipAlgs.apply(nonStandard)
             fail()
         } catch (UnsupportedJwtException e) {
-            String msg = "Unrecognized JWT ${DefaultHeader.COMPRESSION_ALGORITHM} header value: def"
+            String msg = "Unsupported JWT ${DefaultHeader.COMPRESSION_ALGORITHM} header value 'def'."
             assertEquals msg, e.getMessage()
         }
     }
@@ -268,7 +268,7 @@ class DefaultJwtParserBuilderTest {
             parser.encAlgs.apply(nonStandard) // non-standard id
             fail()
         } catch (UnsupportedJwtException e) {
-            String msg = "Unrecognized JWE ${DefaultJweHeader.ENCRYPTION_ALGORITHM} header value: ${alg.id.toLowerCase()}"
+            String msg = "Unsupported JWE ${DefaultJweHeader.ENCRYPTION_ALGORITHM} header value '${alg.id.toLowerCase()}'."
             assertEquals msg, e.getMessage()
         }
     }
@@ -314,7 +314,7 @@ class DefaultJwtParserBuilderTest {
             parser.keyAlgs.apply(nonStandard) // non-standard id
             fail()
         } catch (UnsupportedJwtException e) {
-            String msg = "Unrecognized JWE ${DefaultJweHeader.ALGORITHM} header value: ${alg.id.toLowerCase()}"
+            String msg = "Unsupported JWE ${DefaultJweHeader.ALGORITHM} header value '${alg.id.toLowerCase()}'."
             assertEquals msg, e.getMessage()
         }
     }
@@ -358,7 +358,7 @@ class DefaultJwtParserBuilderTest {
             parser.sigAlgs.apply(nonStandard) // non-standard id
             fail()
         } catch (UnsupportedJwtException e) {
-            String msg = "Unrecognized JWS ${DefaultJwsHeader.ALGORITHM} header value: ${alg.id.toLowerCase()}"
+            String msg = "Unsupported JWS ${DefaultJwsHeader.ALGORITHM} header value '${alg.id.toLowerCase()}'."
             assertEquals msg, e.getMessage()
         }
     }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/IdLocatorTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/IdLocatorTest.groovy
@@ -40,12 +40,12 @@ class IdLocatorTest {
         def a = new StringIdentifiable(value: 'A')
         def b = new StringIdentifiable(value: 'B')
         registry = new IdRegistry('Foo', [a, b], false)
-        locator = new IdLocator(TEST_PARAM, registry, exMsg)
+        locator = new IdLocator(TEST_PARAM, registry, 'foo', 'bar', exMsg)
     }
 
     @Test
     void unrequiredHeaderValueTest() {
-        locator = new IdLocator(TEST_PARAM, registry, null)
+        locator = new IdLocator(TEST_PARAM, registry, 'foo', 'bar', null)
         def header = Jwts.header().add('a', 'b').build()
         assertNull locator.apply(header)
     }
@@ -67,7 +67,7 @@ class IdLocatorTest {
         try {
             locator.apply(header)
         } catch (UnsupportedJwtException expected) {
-            String msg = "Unsupported JWT ${TEST_PARAM} header value 'foo'."
+            String msg = "Unsupported JWT header ${TEST_PARAM} value 'foo'."
             assertEquals msg, expected.getMessage()
         }
     }
@@ -78,7 +78,7 @@ class IdLocatorTest {
         try {
             locator.apply(header)
         } catch (UnsupportedJwtException expected) {
-            String msg = "Unsupported JWS ${TEST_PARAM} header value 'foo'."
+            String msg = "Unsupported JWS header ${TEST_PARAM} value 'foo'."
             assertEquals msg, expected.getMessage()
         }
     }
@@ -89,7 +89,7 @@ class IdLocatorTest {
         try {
             locator.apply(header)
         } catch (UnsupportedJwtException expected) {
-            String msg = "Unsupported JWE ${TEST_PARAM} header value 'foo'."
+            String msg = "Unsupported JWE header ${TEST_PARAM} value 'foo'."
             assertEquals msg, expected.getMessage()
         }
     }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/IdLocatorTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/IdLocatorTest.groovy
@@ -67,7 +67,7 @@ class IdLocatorTest {
         try {
             locator.apply(header)
         } catch (UnsupportedJwtException expected) {
-            String msg = "Unrecognized JWT ${TEST_PARAM} header value: foo"
+            String msg = "Unsupported JWT ${TEST_PARAM} header value 'foo'."
             assertEquals msg, expected.getMessage()
         }
     }
@@ -78,7 +78,7 @@ class IdLocatorTest {
         try {
             locator.apply(header)
         } catch (UnsupportedJwtException expected) {
-            String msg = "Unrecognized JWS ${TEST_PARAM} header value: foo"
+            String msg = "Unsupported JWS ${TEST_PARAM} header value 'foo'."
             assertEquals msg, expected.getMessage()
         }
     }
@@ -89,7 +89,7 @@ class IdLocatorTest {
         try {
             locator.apply(header)
         } catch (UnsupportedJwtException expected) {
-            String msg = "Unrecognized JWE ${TEST_PARAM} header value: foo"
+            String msg = "Unsupported JWE ${TEST_PARAM} header value 'foo'."
             assertEquals msg, expected.getMessage()
         }
     }


### PR DESCRIPTION
Resolves #996.

Allowed the `JwtParser` to have empty nested algorithm collections, effectively disabling the parser's associated feature:
 - Clearing the `zip()` nested collection means parser decompression is disabled
 - Clearing the `sig()` nested collection means parser signature verification is disabled (i.e. all JWSs will be unsupported/rejected)
 - Clearing the `enc()` or `key()` nested collections means parser decryption is disabled (i.e. all JWEs will be unsupported/rejected)