### PR TITLE
Default Gson instance number strategy

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3472,13 +3472,16 @@ If you're curious, JJWT will automatically create an internal default Gson insta
 ----
 new GsonBuilder()
     .registerTypeHierarchyAdapter(io.jsonwebtoken.lang.Supplier.class, GsonSupplierSerializer.INSTANCE)
-    .disableHtmlEscaping().create();
+    .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+    .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+    .disableHtmlEscaping()
+    .create();
 ----
 
 The `registerTypeHierarchyAdapter` builder call is required to serialize JWKs with secret or private values.
 
 However, if you prefer to use a different Gson instance instead of JJWT's default, you can configure JJWT to use your
-own - just don't forget to register the necessary JJWT type hierarchy adapter.
+own - just *don't forget to register the necessary JJWT type hierarchy adapter*.
 
 You do this by declaring the `io.jsonwebtoken:jjwt-gson` dependency with *compile* scope (not runtime
 scope which is the typical JJWT default).  That is:
@@ -3512,6 +3515,8 @@ And then you can specify the `GsonSerializer` using your own `Gson` instance on 
 Gson gson = new GsonBuilder()
     // don't forget this line!:
     .registerTypeHierarchyAdapter(io.jsonwebtoken.lang.Supplier.class, GsonSupplierSerializer.INSTANCE)
+    .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+    .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
     .disableHtmlEscaping().create();
 
 String jws = Jwts.builder()

--- a/extensions/gson/src/main/java/io/jsonwebtoken/gson/io/GsonSerializer.java
+++ b/extensions/gson/src/main/java/io/jsonwebtoken/gson/io/GsonSerializer.java
@@ -17,6 +17,7 @@ package io.jsonwebtoken.gson.io;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
 import io.jsonwebtoken.io.AbstractSerializer;
 import io.jsonwebtoken.io.Encoders;
 import io.jsonwebtoken.lang.Assert;
@@ -31,6 +32,8 @@ import java.nio.charset.StandardCharsets;
 public class GsonSerializer<T> extends AbstractSerializer<T> {
 
     static final Gson DEFAULT_GSON = new GsonBuilder()
+            .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+            .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
             .registerTypeHierarchyAdapter(Supplier.class, GsonSupplierSerializer.INSTANCE)
             .disableHtmlEscaping().create();
 

--- a/extensions/gson/src/test/groovy/io/jsonwebtoken/gson/io/GsonDeserializerTest.groovy
+++ b/extensions/gson/src/test/groovy/io/jsonwebtoken/gson/io/GsonDeserializerTest.groovy
@@ -91,4 +91,24 @@ class GsonDeserializerTest {
             assertSame ex, expected.cause
         }
     }
+
+    @Test
+    void testLong() {
+        def json = '{"hello":42}'
+        def m = deser(json) as Map
+        def val = m.hello
+        assertTrue val instanceof Long
+        assertEquals 42L, val
+    }
+
+    @Test
+    void testDouble() {
+        // one more than Long can handle:
+        def dval = 42.0 as double
+        def json = '{"hello":' + dval + '}'
+        def m = deser(json) as Map
+        def val = m.hello
+        assertTrue val instanceof Double
+        assertEquals(dval, ((Double) val).doubleValue(), 0)
+    }
 }


### PR DESCRIPTION
Ensured JJWT's Default `Gson` instance uses `ToNumberPolicy.LONG_OR_DOUBLE` for numeric conversion.