### PR TITLE
[#519] module-info for JDK9+ profile

### DIFF
--- a/api/src/main/java9/module-info.java
+++ b/api/src/main/java9/module-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2025 jsonwebtoken.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.jsonwebtoken {
 
 }

--- a/api/src/main/java9/module-info.java
+++ b/api/src/main/java9/module-info.java
@@ -1,0 +1,3 @@
+module io.jsonwebtoken {
+
+}

--- a/impl/src/main/java9/module-info.java
+++ b/impl/src/main/java9/module-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2025 jsonwebtoken.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.jsonwebtoken.impl {
     requires io.jsonwebtoken;
 }

--- a/impl/src/main/java9/module-info.java
+++ b/impl/src/main/java9/module-info.java
@@ -1,0 +1,3 @@
+module io.jsonwebtoken.impl {
+    requires io.jsonwebtoken;
+}

--- a/integration-tests/modular/pom.xml
+++ b/integration-tests/modular/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.jsonwebtoken.its</groupId>
+        <artifactId>jjwt-its</artifactId>
+        <version>0.14.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jjwt-its-modular</artifactId>
+    <version>0.14.0-SNAPSHOT</version>
+    <name>JJWT :: Integration-Tests</name>
+    
+</project>

--- a/integration-tests/modular/pom.xml
+++ b/integration-tests/modular/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2025 jsonwebtoken.io
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-root</artifactId>
+        <version>0.14.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.jsonwebtoken.its</groupId>
+    <artifactId>jjwt-its</artifactId>
+    <version>0.14.0-SNAPSHOT</version>
+
+    <name>JJWT :: Integration-Tests</name>
+    <packaging>pom</packaging>
+
+    <properties>
+        <!-- do not deploy ITs -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <profiles>
+        <profile>
+            <!-- Added profile to address https://github.com/jwtk/jjwt/issues/364 -->
+            <id>jdk9AndLater</id>
+            <activation>
+                <jdk>[1.9,)</jdk>
+            </activation>
+            <modules>
+                <module>modular</module>
+            </modules>
+        </profile>
+    </profiles>
+
+    
+</project>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2025 jsonwebtoken.io
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
         <module>api</module>
         <module>impl</module>
         <module>extensions</module>
+        <module>integration-tests</module>
         <module>tdjar</module>
         <module>bom</module>
     </modules>
@@ -649,6 +650,31 @@
                 <maven.javadoc.additionalOptions>-html5</maven.javadoc.additionalOptions>
                 <surefire.argLine>${test.addOpens}, --illegal-access=debug</surefire.argLine>
             </properties>
+            <build>
+                <plugins>
+                  <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <executions>
+                          <execution>
+                              <id>compile-java21</id>
+                              <phase>compile</phase>
+                              <goals>
+                                  <goal>compile</goal>
+                              </goals>
+                              <configuration>
+                                  <release>9</release>
+                                  <compileSourceRoots>
+                                      <compileSourceroot>${project.basedir}/src/main/java9</compileSourceroot>
+                                  </compileSourceRoots>
+                                  <!-- cannot use multireleaseOutput, because we are creating a Java 8 class file -->
+                                  <outputDirectory>${project.build.outputDirectory}/META-INF/versions/9</outputDirectory>
+                              </configuration>
+                          </execution>
+                      </executions>
+                  </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>jdk17AndLater</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2014-2023 jsonwebtoken.io
+  ~ Copyright (C) 2014-2025 jsonwebtoken.io
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <arguments/>
 
-        <jjwt.root>${basedir}</jjwt.root>
+        <jjwt.root>${maven.multiModuleProjectDirectory}</jjwt.root>
         <jjwt.previousVersion>0.11.2</jjwt.previousVersion>
 
         <maven.jar.version>3.4.2</maven.jar.version>


### PR DESCRIPTION
This is merely a starting point and a show-case where we can go.

I added a new integration-tests/modular project which activates on 9+.
It will be having only a test folder with `module-info.java` and tests, so the tests will run in a modular environment. 