### PR TITLE
Fix imports in docs example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -737,7 +737,7 @@ code quickly.  Here's an example:
 ----
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import java.security.Key;
+import javax.crypto.SecretKey;
 
 // We need a signing key, so we'll create one just for this example. Usually
 // the key would be read from your application configuration instead.


### PR DESCRIPTION
The `java.security.Key` was imported, but actually the `javax.crypto.SecretKey` was then used in the example.