### PR TITLE
Onboard to the OSS Community Develocity Instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           distribution: oracle
           java-version: ${{ matrix.java }}
+      - name: Set up OSS Community Develocity Instance for Maven
+        uses: gradle/develocity-actions/setup-maven@v2.1
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Install softhsm2
         run: sudo apt-get install -y softhsm2
       - name: Install opensc
@@ -52,6 +56,10 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
           check-latest: true
+      - name: Set up OSS Community Develocity Instance for Maven
+        uses: gradle/develocity-actions/setup-maven@v2.1
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Install softhsm2
         run: sudo apt-get install -y softhsm2
       - name: Install opensc
@@ -82,6 +90,10 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
           check-latest: true
+      - name: Set up OSS Community Develocity Instance for Maven
+        uses: gradle/develocity-actions/setup-maven@v2.1
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Install softhsm2
         run: sudo apt-get install -y softhsm2
       - name: Install opensc
@@ -111,6 +123,10 @@ jobs:
           java-version: '8'
           cache: 'maven'
           check-latest: true
+      - name: Set up OSS Community Develocity Instance for Maven
+        uses: gradle/develocity-actions/setup-maven@v2.1
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: License Check
         # This adds about 1 minute to any build, which is why we don't want to do it on every other build:
         run: |
@@ -130,6 +146,10 @@ jobs:
           java-version: '8'
           cache: 'maven'
           check-latest: true
+      - name: Set up OSS Community Develocity Instance for Maven
+        uses: gradle/develocity-actions/setup-maven@v2.1
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Install softhsm2
         run: sudo apt-get install -y softhsm2
       - name: Install opensc

--- a/.mvn/.gitignore
+++ b/.mvn/.gitignore
@@ -1,0 +1,1 @@
+.develocity/

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+  ~ Copyright © 2026 jsonwebtoken.io
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<develocity
+    xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://community.develocity.cloud</url>
+    <allowUntrusted>false</allowUntrusted>
+  </server>
+  <projectId>jwtk</projectId>
+  <buildScan>
+    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+    <obfuscation>
+      <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
+    </obfuscation>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>true</enabled>
+    </local>
+    <remote>
+      <storeEnabled>#{isTrue(env['CI']) and isTrue(env['DEVELOCITY_ACCESS_KEY'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright © 2026 jsonwebtoken.io
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.1.0.xsd">
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>develocity-maven-extension</artifactId>
+    <version>2.4.0</version>
+  </extension>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>common-custom-user-data-maven-extension</artifactId>
+    <version>2.2.0</version>
+  </extension>
+</extensions>

--- a/README.adoc
+++ b/README.adoc
@@ -23,6 +23,7 @@ image:https://github.com/jwtk/jjwt/actions/workflows/ci.yml/badge.svg?branch=mas
 image:https://coveralls.io/repos/github/jwtk/jjwt/badge.svg?branch=master[Coverage Status,link=https://coveralls.io/github/jwtk/jjwt?branch=master]
 image:https://snyk-widget.herokuapp.com/badge/mvn/io.jsonwebtoken/jjwt-root/badge.svg[Vuln score,link=https://snyk-widget.herokuapp.com/badge/mvn/io.jsonwebtoken/jjwt-root/badge.svg]
 image:https://snyk.io/test/github/jwtk/jjwt/badge.svg[Known Vulns,link=https://snyk.io/test/github/jwtk/jjwt/badge.svg]
+image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A[link="https://community.develocity.cloud/scans?search.rootProjectNames=JJWT",title="Revved up by Develocity"]
 
 JJWT aims to be the easiest to use and understand library for creating and verifying JSON Web Tokens (JWTs) and
 JSON Web Keys (JWKs) on the JVM and Android.

--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,7 @@
                                     <exclude>**/genkeys</exclude>
                                     <exclude>**/softhsm</exclude>
                                     <exclude>**.adoc</exclude>
+                                    <exclude>.mvn/.develocity/**</exclude>
                                 </excludes>
                             </licenseSet>
                         </licenseSets>


### PR DESCRIPTION
# Onboard to the OSS Community Develocity Instance

This PR adds [Develocity](https://gradle.com/develocity) Build Scan® and Build Cache support
for this project, publishing to the **OSS Community Develocity Instance** at
<https://community.develocity.cloud> under project ID `jwtk`.

## What this PR adds

- The Develocity Maven extension/plugin and the Common Custom User Data Maven
  extension/plugin, applied at the latest released versions.
- .mvn/develocity.xml pointing the build at `https://community.develocity.cloud` and
  associating builds with project `jwtk`.
- A "Revved up by Develocity" badge in the README linking to the filtered Build Scan list
  for this project's root project name.
- A setup step in each GitHub Actions workflow that runs the build, so CI publishes Build
  Scans automatically using a short-lived access token.

## Required next step — set a GitHub Actions secret

Build Scan publishing **and** Build Cache writes from CI **will not work** until you create a
repository secret named `DEVELOCITY_ACCESS_KEY` on **this repository**. The value must
include the **host name** of the Develocity instance, in the form `<host>=<access-key>`:

```
DEVELOCITY_ACCESS_KEY = community.develocity.cloud=<your-access-key>
```

The hostname prefix is required — without it, the access key is silently ignored. This is
the most common point of failure when onboarding, so please double-check the format.

To get an access key: visit <https://community.develocity.cloud>, sign in, and use
"My settings" → "Access keys".

### Why the CI run on this PR doesn't prove the connection works

This PR was prepared from a fork. Forks can't read your repository's secrets, so the
workflow run on this PR cannot publish to `community.develocity.cloud` even after you set
the secret on the upstream repository.

If you want CI verification before merging, push the branch
`dv/onboard-oss-community-develocity-instance` to a temporary branch on **this** repo (not
the fork) and re-run the workflow there — it will pick up the secret and publish a Build
Scan.

After merging, every CI run **on this repository** will publish a Build Scan to
<https://community.develocity.cloud>. CI runs from forks of this repository will not (forks
don't have access to the secret either), and that's expected.

## Required next step - provision local access keys

Build Scan publishing from local builds **will not work** until you provision access keys. Authenticated users can create an access key automatically by invoking:

```
mvn develocity:provision-access-key
```