### PR TITLE
Deprecate JwtParser#isSigned

### DIFF
--- a/api/src/main/java/io/jsonwebtoken/JwtParser.java
+++ b/api/src/main/java/io/jsonwebtoken/JwtParser.java
@@ -39,7 +39,11 @@ public interface JwtParser extends Parser<Jwt<?, ?>> {
      * @param compact the compact serialized JWT to check
      * @return {@code true} if the specified JWT compact string represents a signed JWT (aka a 'JWS'), {@code false}
      * otherwise.
+     * @deprecated this performs only a structural (not cryptographic) check and is scheduled for removal in 1.0.
+     * If you need to read a signed JWT, parse it directly and handle the resulting exception when it is not the
+     * expected type, rather than checking with this method first and parsing afterwards.
      */
+    @Deprecated
     boolean isSigned(CharSequence compact);
 
     /**

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -248,6 +248,7 @@ public class DefaultJwtParser extends AbstractParser<Jwt<?, ?>> implements JwtPa
                 new IdLocator<>(DefaultHeader.COMPRESSION_ALGORITHM, zipAlgs, "compression", "decompression", null);
     }
 
+    @Deprecated
     @Override
     public boolean isSigned(CharSequence compact) {
         if (!Strings.hasText(compact)) {


### PR DESCRIPTION
Per the discussion on #582, `JwtParser#isSigned` is a structural-only check slated for removal in 1.0. This marks it `@Deprecated` (interface + impl) with a `@deprecated` Javadoc note steering callers to parse directly and handle the exception, so anyone still using it gets a compiler/IDE nudge before 1.0 removes it.

Notes:
- No behavior change; annotation and Javadoc only.
- Nothing in JJWT's own codebase or tests calls `isSigned`, so there is no internal fallout, and `failOnWarnings` is `false`.
- The Javadoc note is prose (no `@link`) so it is not coupled to a specific replacement method name.

Toward #582 (the actual removal would land in 1.0). Happy to adjust the wording or version note.
