### PR TITLE
Limit build matrix to remain under the max job concurrency limit for faster CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distribution: [ 'oracle', 'temurin', 'zulu', 'corretto', 'semeru' ]
+        distribution: [ 'oracle', 'zulu', 'corretto', 'semeru' ]
         java-version: [ 8, 11, 17, 21, 25 ]
         # Oracle only provides JDK 17+, so exclude earlier versions:
         exclude:


### PR DESCRIPTION
This PR drops temurin from the build matrix to ensure the CI build job count remains <= 20 (free tier concurrency limit) so that jobs don't queue and delay the build unnecessarily. See https://docs.github.com/en/enterprise-server@3.20/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners for more information.