### PR TITLE
Java8 interface cleanup work

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -735,15 +735,15 @@ code quickly.  Here's an example:
 
 [,java]
 ----
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.Jws;
 import javax.crypto.SecretKey;
 
 // We need a signing key, so we'll create one just for this example. Usually
 // the key would be read from your application configuration instead.
 SecretKey key = Jws.alg.HS256.key().build();
 
-String jws = Jwts.builder().subject("Joe").signWith(key).compact();
+String jws = Jwt.builder().subject("Joe").signWith(key).compact();
 ----
 
 How easy was that!?
@@ -803,7 +803,7 @@ Now that we've had a quickstart 'taste' of how to create and parse JWTs, let's c
 
 You create a JWT as follows:
 
-. Use the `Jwts.builder()` method to create a `JwtBuilder` instance.
+. Use the `Jwt.builder()` method to create a `JwtBuilder` instance.
 . Optionally set any <<jwt-header,`header` parameters>> as desired.
 . Call builder methods to set the payload <<jwt-content,content>> or <<jwt-claims,claims>>.
 . Optionally call `signWith` or `encryptWith` methods if you want to digitally sign or encrypt the JWT.
@@ -813,7 +813,7 @@ For example:
 
 [,java]
 ----
-String jwt = Jwts.builder()                     // (1)
+String jwt = Jwt.builder()                     // (1)
 
     .header()                                   // (2) optional
         .keyId("aKeyId")
@@ -859,7 +859,7 @@ to the `JwtBuilder` for further configuration. For example:
 
 [,java]
 ----
-String jwt = Jwts.builder()
+String jwt = Jwt.builder()
 
     .header()                        // <----
         .keyId("aKeyId")
@@ -892,7 +892,7 @@ arbitrary name/value pairs via the `add` method:
 
 [,java]
 ----
-Jwts.builder()
+Jwt.builder()
 
     .header()
         .add("aHeaderName", aValue)
@@ -911,7 +911,7 @@ The `add` method is also overloaded to support multiple parameters in a `Map`:
 
 [,java]
 ----
-Jwts.builder()
+Jwt.builder()
 
     .header()
         .add(multipleHeaderParamsMap)
@@ -921,16 +921,16 @@ Jwts.builder()
 // ... etc ...
 ----
 
-==== Jwts HeaderBuilder
+==== Jwt HeaderBuilder
 
-Using `Jwts.builder().header()` shown above is the preferred way to modify a header when using the `JwtBuilder`.
+Using `Jwt.builder().header()` shown above is the preferred way to modify a header when using the `JwtBuilder`.
 
 However, if you would like to create a 'standalone' `Header` outside of the context of using the `JwtBuilder`, you
-can use `Jwts.header()` instead to return an independent `Header` builder.  For example:
+can use `Jwt.header()` instead to return an independent `Header` builder.  For example:
 
 [,java]
 ----
-Header header = Jwts.header()
+Header header = Jwt.header()
 
         .keyId("aKeyId")
         .x509Url(aUri)
@@ -941,13 +941,13 @@ Header header = Jwts.header()
         .build()  // <---- not 'and()'
 ----
 
-There are only two differences between `Jwts.header()` and `Jwts.builder().header()`:
+There are only two differences between `Jwt.header()` and `Jwt.builder().header()`:
 
-. `Jwts.header()` builds a 'detached' `Header` that is not associated with any particular JWT, whereas
-`Jwts.builder().header()` always modifies the header of the immediate JWT being constructed by its parent
+. `Jwt.header()` builds a 'detached' `Header` that is not associated with any particular JWT, whereas
+`Jwt.builder().header()` always modifies the header of the immediate JWT being constructed by its parent
 `JwtBuilder`.
-. `Jwts.header()` has a `build()` method to produce an explicit `Header` instance and
-`Jwts.builder().header()` does not (it has an `and()` method instead) because its parent `JwtBuilder` will implicitly
+. `Jwt.header()` has a `build()` method to produce an explicit `Header` instance and
+`Jwt.builder().header()` does not (it has an `and()` method instead) because its parent `JwtBuilder` will implicitly
 create the header instance when necessary.
 
 A standalone header might be useful if you want to aggregate common header parameters in a single 'template'
@@ -957,7 +957,7 @@ populate `JwtBuilder` usages by just appending it to the `JwtBuilder` header, fo
 [,java]
 ----
 // perhaps somewhere in application configuration:
-Header commonHeaders = Jwts.header()
+Header commonHeaders = Jwt.header()
     .issuer("My Company")
     // ... etc ...
     .build();
@@ -965,7 +965,7 @@ Header commonHeaders = Jwts.header()
 // --------------------------------
 
 // somewhere else during actual Jwt construction:
-String jwt = Jwts.builder()
+String jwt = Jwt.builder()
 
     .header()
         .add(commonHeaders)                   // <----
@@ -1003,7 +1003,7 @@ For example:
 ----
 byte[] content = "Hello World".getBytes(StandardCharsets.UTF_8);
 
-String jwt = Jwts.builder()
+String jwt = Jwt.builder()
 
     .content(content, "text/plain") // <---
 
@@ -1058,7 +1058,7 @@ For example:
 [,java]
 ----
 
-String jws = Jwts.builder()
+String jws = Jwt.builder()
 
     .issuer("me")
     .subject("Bob")
@@ -1081,7 +1081,7 @@ can simply call the `JwtBuilder` `claim` method one or more times as needed:
 
 [,java]
 ----
-String jws = Jwts.builder()
+String jws = Jwt.builder()
 
     .claim("hello", "world")
 
@@ -1109,7 +1109,7 @@ If you want to add multiple claims at once, you can use `JwtBuilder` `claims(Map
 
 Map<String,?> claims = getMyClaimsMap(); //implement me
 
-String jws = Jwts.builder()
+String jws = Jwt.builder()
 
     .claims(claims)
 
@@ -1314,7 +1314,7 @@ Key key = getSigningKey(); // or getEncryptionKey() for JWE
 
 String keyId = getKeyId(key); //any mechanism you have to associate a key with an ID is fine
 
-String jws = Jwts.builder()
+String jws = Jwt.builder()
 
     .header().keyId(keyId).and()               // <--- add `kid` header
 
@@ -1765,7 +1765,7 @@ natively supported by the JDK.
 
 You create a JWS as follows:
 
-. Use the `Jwts.builder()` method to create a `JwtBuilder` instance.
+. Use the `Jwt.builder()` method to create a `JwtBuilder` instance.
 . Call `JwtBuilder` methods to set the `payload` content or claims and any header parameters as desired.
 . Specify the `SecretKey` or asymmetric `PrivateKey` you want to use to sign the JWT.
 . Finally, call the `compact()` method to compact and sign, producing the final jws.
@@ -1774,7 +1774,7 @@ For example:
 
 [,java]
 ----
-String jws = Jwts.builder() // (1)
+String jws = Jwt.builder() // (1)
 
     .subject("Bob")         // (2)
 
@@ -1792,7 +1792,7 @@ determine the most secure algorithm allowed for the specified key.:
 
 [,java]
 ----
-String jws = Jwts.builder()
+String jws = Jwt.builder()
 
    // ... etc ...
 
@@ -2070,7 +2070,7 @@ SecretKey testKey = Jws.alg.HS512.key().build();
 String message = "Hello World. It's a Beautiful Day!";
 byte[] content = message.getBytes(StandardCharsets.UTF_8);
 
-String jws = Jwts.builder().signWith(testKey) // #1
+String jws = Jwt.builder().signWith(testKey) // #1
         .content(content)                     // #2
         .encodePayload(false)                 // #3
         .compact();
@@ -2112,7 +2112,7 @@ SecretKey testKey = Jws.alg.HS512.key().build();
 
 String claimsString = "{\"sub\":\"joe\",\"iss\":\"me\"}";
 
-String jws = Jwts.builder().signWith(testKey) // #1
+String jws = Jwt.builder().signWith(testKey) // #1
         .content(claimsString)                // #2
         .encodePayload(false)                 // #3
         .compact();
@@ -2587,7 +2587,7 @@ them to encrypt a JWT?
 
 You create an encrypted JWT (called a 'JWE') as follows:
 
-. Use the `Jwts.builder()` method to create a `JwtBuilder` instance.
+. Use the `Jwt.builder()` method to create a `JwtBuilder` instance.
 . Call `JwtBuilder` methods to set the `payload` content or claims and any <<jws-create-header,header>> parameters as desired.
 . Call the `encryptWith` method, specifying the Key, Key Algorithm, and Encryption Algorithm you want to use.
 . Finally, call the `compact()` method to compact and encrypt, producing the final jwe.
@@ -2596,7 +2596,7 @@ For example:
 
 [,java]
 ----
-String jwe = Jwts.builder()                              // (1)
+String jwe = Jwt.builder()                              // (1)
 
     .subject("Bob")                                      // (2)
 
@@ -3154,7 +3154,7 @@ SecretJwk = JwkSet.builder()        // 1
 ----
 
 As shown, you can optionally configure the `.operationPolicy(KeyOperationPolicy)` method using a
-`Jwts.op.policy()` builder.  A `KeyOperationPolicy` allows you to control what operations are allowed for any JWK
+`Jwk.op.policy()` builder.  A `KeyOperationPolicy` allows you to control what operations are allowed for any JWK
 before being added to the JWK Set; any JWK that does not match the policy will be rejected and not added to the set.
 JJWT internally defaults to a standard RFC-compliant policy, but you can create a
 policy to override the default if desired using the `Jwk.op.policy()` builder method.
@@ -3208,14 +3208,14 @@ example:
 
 [,java]
 ----
-Jwts.builder()
+Jwt.builder()
 
-   .compressWith(Jwts.ZIP.DEF) // DEFLATE compression algorithm
+   .compressWith(Jwe.zip.DEF) // DEFLATE compression algorithm
 
    // .. etc ...
 ----
 
-If you use any of the algorithm constants in the `Jwts.ZIP` class, that's it, you're done.  You don't have to
+If you use any of the algorithm constants in the `Jwe.zip` class, that's it, you're done.  You don't have to
 do anything during parsing or configure the `JwtParserBuilder` for compression - JJWT will automatically decompress
 the payload as expected.
 
@@ -3223,7 +3223,7 @@ the payload as expected.
 
 === Custom Compression Algorithm
 
-If the default `Jwts.ZIP` compression algorithms are not suitable for your needs, you can create your own
+If the default `Jwe.zip` compression algorithms are not suitable for your needs, you can create your own
 `CompressionAlgorithm` implementation(s).
 
 Just as you would with the default algorithms, you may specify that you want a JWT compressed by calling the
@@ -3233,7 +3233,7 @@ Just as you would with the default algorithms, you may specify that you want a J
 ----
 CompressionAlgorithm myAlg = new MyCompressionAlgorithm();
 
-Jwts.builder()
+Jwt.builder()
 
    .compressWith(myAlg) // <----
 
@@ -3262,7 +3262,7 @@ Jwt.parser()
 ----
 
 This adds additional `CompressionAlgorithm` implementations to the parser's overall total set of supported compression
-algorithms (which already includes all of the `Jwts.ZIP` algorithms by default).
+algorithms (which already includes all of the `Jwe.zip` algorithms by default).
 
 The parser will then automatically check to see if the JWT `zip` header has been set to see if a compression
 algorithm has been used to compress the JWT.  If set, the parser will automatically look up your
@@ -3313,7 +3313,7 @@ When creating a JWT:
 ----
 Serializer<Map<String,?>> serializer = getMySerializer(); //implement me
 
-Jwts.builder()
+Jwt.builder()
 
     .json(serializer)
 
@@ -3378,7 +3378,7 @@ And then you can specify the `JacksonSerializer` using your own `ObjectMapper` o
 ----
 ObjectMapper objectMapper = getMyObjectMapper(); //implement me
 
-String jws = Jwts.builder()
+String jws = Jwt.builder()
 
     .json(new JacksonSerializer(objectMapper))
 
@@ -3515,7 +3515,7 @@ Gson gson = new GsonBuilder()
     .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
     .disableHtmlEscaping().create();
 
-String jws = Jwts.builder()
+String jws = Jwt.builder()
 
     .json(new GsonSerializer(gson))
 
@@ -3686,7 +3686,7 @@ If for some reason you want to specify your own Base64Url encoder and decoder, y
 ----
 Encoder<byte[], String> encoder = getMyBase64UrlEncoder(); //implement me
 
-String jws = Jwts.builder()
+String jws = Jwt.builder()
 
     .b64Url(encoder)
 
@@ -3750,7 +3750,7 @@ String message = "Hello World!";
 byte[] content = message.getBytes(StandardCharsets.UTF_8);
 
 // Create the compact JWS:
-String jws = Jwts.builder().content(content, "text/plain").signWith(key, alg).compact();
+String jws = Jwt.builder().content(content, "text/plain").signWith(key, alg).compact();
 
 // Parse the compact JWS:
 content = Jwt.parser().verifyWith(key).build().parseSignedContent(jws).getPayload();
@@ -3776,7 +3776,7 @@ SignatureAlgorithm alg = Jws.alg.RS512; //or PS512, RS256, etc...
 KeyPair pair = alg.keyPair().build();
 
 // Bob creates the compact JWS with his RSA private key:
-String jws = Jwts.builder().subject("Alice")
+String jws = Jwt.builder().subject("Alice")
     .signWith(pair.getPrivate(), alg) // <-- Bob's RSA private key
     .compact();
 
@@ -3809,7 +3809,7 @@ SignatureAlgorithm alg = Jws.alg.ES512; //or ES256 or ES384
 KeyPair pair = alg.keyPair().build();
 
 // Bob creates the compact JWS with his EC private key:
-String jws = Jwts.builder().subject("Alice")
+String jws = Jwt.builder().subject("Alice")
     .signWith(pair.getPrivate(), alg) // <-- Bob's EC private key
     .compact();
 
@@ -3856,7 +3856,7 @@ Curve curve = Jwk.crv.Ed25519; //or Ed448
 KeyPair pair = curve.keyPair().build();
 
 // Bob creates the compact JWS with his Edwards Curve private key:
-String jws = Jwts.builder().subject("Alice")
+String jws = Jwt.builder().subject("Alice")
     .signWith(pair.getPrivate(), Jws.alg.EdDSA) // <-- Bob's Edwards Curve private key w/ EdDSA
     .compact();
 
@@ -3901,7 +3901,7 @@ String message = "Live long and prosper.";
 byte[] content = message.getBytes(StandardCharsets.UTF_8);
 
 // Create the compact JWE:
-String jwe = Jwts.builder().content(content, "text/plain").encryptWith(key, enc).compact();
+String jwe = Jwt.builder().content(content, "text/plain").encryptWith(key, enc).compact();
 
 // Parse the compact JWE:
 content = Jwt.parser().decryptWith(key).build().parseEncryptedContent(jwe).getPayload();
@@ -3928,12 +3928,12 @@ decrypt the JWT using her RSA private key:
 KeyPair pair = Jws.alg.RS512.keyPair().build();
 
 // Choose the key algorithm used encrypt the payload key:
-KeyAlgorithm<PublicKey, PrivateKey> alg = Jwts.KEY.RSA_OAEP_256; //or RSA_OAEP or RSA1_5
+KeyAlgorithm<PublicKey, PrivateKey> alg = Jwe.alg.RSA_OAEP_256; //or RSA_OAEP or RSA1_5
 // Choose the Encryption Algorithm to encrypt the payload:
 AeadAlgorithm enc = Jwe.alg.A256GCM; //or A192GCM, A128GCM, A256CBC-HS512, etc...
 
 // Bob creates the compact JWE with Alice's RSA public key so only she may read it:
-String jwe = Jwts.builder().audience().add("Alice").and()
+String jwe = Jwt.builder().audience().add("Alice").and()
     .encryptWith(pair.getPublic(), alg, enc) // <-- Alice's RSA public key
     .compact();
 
@@ -3963,14 +3963,14 @@ efficient than the `A*KW` variants.
 [,java]
 ----
 // Create a test SecretKey suitable for the desired AES Key Wrap algorithm:
-SecretKeyAlgorithm alg = Jwts.KEY.A256GCMKW; //or A192GCMKW, A128GCMKW, A256KW, etc...
+SecretKeyAlgorithm alg = Jwe.alg.A256GCMKW; //or A192GCMKW, A128GCMKW, A256KW, etc...
 SecretKey key = alg.key().build();
 
 // Chooose the Encryption Algorithm used to encrypt the payload:
 AeadAlgorithm enc = Jwe.alg.A256GCM; //or A192GCM, A128GCM, A256CBC-HS512, etc...
 
 // Create the compact JWE:
-String jwe = Jwts.builder().issuer("me").encryptWith(key, alg, enc).compact();
+String jwe = Jwt.builder().issuer("me").encryptWith(key, alg, enc).compact();
 
 // Parse the compact JWE:
 String issuer = Jwt.parser().decryptWith(key).build()
@@ -4000,12 +4000,12 @@ Alice can then decrypt the JWT using her Elliptic Curve private key:
 KeyPair pair = Jws.alg.ES512.keyPair().build();
 
 // Choose the key algorithm used encrypt the payload key:
-KeyAlgorithm<PublicKey, PrivateKey> alg = Jwts.KEY.ECDH_ES_A256KW; //ECDH_ES_A192KW, etc...
+KeyAlgorithm<PublicKey, PrivateKey> alg = Jwe.alg.ECDH_ES_A256KW; //ECDH_ES_A192KW, etc...
 // Choose the Encryption Algorithm to encrypt the payload:
 AeadAlgorithm enc = Jwe.alg.A256GCM; //or A192GCM, A128GCM, A256CBC-HS512, etc...
 
 // Bob creates the compact JWE with Alice's EC public key so only she may read it:
-String jwe = Jwts.builder().audience().add("Alice").and()
+String jwe = Jwt.builder().audience().add("Alice").and()
     .encryptWith(pair.getPublic(), alg, enc) // <-- Alice's EC public key
     .compact();
 
@@ -4038,7 +4038,7 @@ String pw = "correct horse battery staple";
 Password password = Password.of(pw.toCharArray());
 
 // Choose the desired PBES2 key derivation algorithm:
-KeyAlgorithm<Password, Password> alg = Jwts.KEY.PBES2_HS512_A256KW; //or PBES2_HS384_A192KW or PBES2_HS256_A128KW
+KeyAlgorithm<Password, Password> alg = Jwe.alg.PBES2_HS512_A256KW; //or PBES2_HS384_A192KW or PBES2_HS256_A128KW
 
 // Optionally choose the number of PBES2 computational iterations to use to derive the key.
 // This is optional - if you do not specify a value, JJWT will automatically choose a value
@@ -4052,7 +4052,7 @@ KeyAlgorithm<Password, Password> alg = Jwts.KEY.PBES2_HS512_A256KW; //or PBES2_H
 AeadAlgorithm enc = Jwe.alg.A256GCM; //or A192GCM, A128GCM, A256CBC-HS512, etc...
 
 // Create the compact JWE:
-String jwe = Jwts.builder().issuer("me")
+String jwe = Jwt.builder().issuer("me")
     // Optional work factor is specified in the header:
     //.header().pbes2Count(pbkdf2Iterations)).and()
     .encryptWith(password, alg, enc)

--- a/README.adoc
+++ b/README.adoc
@@ -765,7 +765,7 @@ Now let's verify the JWT (you should always discard JWTs that don't match an exp
 
 [,java]
 ----
-assert Jwts.parser().verifyWith(key).build().parseSignedClaims(jws).getPayload().getSubject().equals("Joe");
+assert Jwt.parser().verifyWith(key).build().parseSignedClaims(jws).getPayload().getSubject().equals("Joe");
 ----
 
 There are two things going on here. The `key` from before is being used to verify the signature of the JWT. If it
@@ -785,7 +785,7 @@ But what if parsing or signature validation failed?  You can catch `JwtException
 ----
 try {
 
-    Jwts.parser().verifyWith(key).build().parseSignedClaims(compactJws);
+    Jwt.parser().verifyWith(key).build().parseSignedClaims(compactJws);
 
     //OK, we can trust this JWT
 
@@ -1133,7 +1133,7 @@ Please see the main <<compression,Compression>> section to see how to compress a
 
 You read (parse) a JWT as follows:
 
-. Use the `Jwts.parser()` method to create a `JwtParserBuilder` instance.
+. Use the `Jwt.parser()` method to create a `JwtParserBuilder` instance.
 . Optionally call `keyLocator`, `verifyWith` or `decryptWith` methods if you expect to parse <<jws,signed>> or <<jwe,encrypted>> JWTs.
 . Call the `build()` method on the `JwtParserBuilder` to create and return a thread-safe `JwtParser`.
 . Call one of the various `parse*` methods with your compact JWT string, depending on the type of JWT you expect.
@@ -1146,7 +1146,7 @@ For example:
 Jwt<?,?> jwt;
 
 try {
-    jwt = Jwts.parser()     // (1)
+    jwt = Jwt.parser()     // (1)
 
     .keyLocator(keyLocator) // (2) dynamically locate signing or encryption keys
     //.verifyWith(key)      //     or a constant key used to verify all signed JWTs
@@ -1189,7 +1189,7 @@ So which key do we use?
 +
 [,java]
 ----
-Jwts.parser()
+Jwt.parser()
 
   .verifyWith(secretKey) // <----
 
@@ -1202,7 +1202,7 @@ Jwts.parser()
 +
 [,java]
 ----
-Jwts.parser()
+Jwt.parser()
 
   .verifyWith(publicKey) // <---- publicKey, not privateKey
 
@@ -1215,7 +1215,7 @@ specified on the `JwtParserBuilder`. For example:
 +
 [,java]
 ----
-Jwts.parser()
+Jwt.parser()
 
   .decryptWith(secretKey) // <---- or a Password from Password.of(charArray)
 
@@ -1228,7 +1228,7 @@ Jwts.parser()
 +
 [,java]
 ----
-Jwts.parser()
+Jwt.parser()
 
   .decryptWith(privateKey) // <---- privateKey, not publicKey
 
@@ -1271,7 +1271,7 @@ example:
 ----
 Locator<Key> keyLocator = getMyKeyLocator();
 
-Jwts.parser()
+Jwt.parser()
 
     .keyLocator(keyLocator) // <----
 
@@ -1448,7 +1448,7 @@ otherwise you may not trust the token.  You can do that by using one of the vari
 [,java]
 ----
 try {
-    Jwts.parser().requireSubject("jsmith")/* etc... */.build().parse(s);
+    Jwt.parser().requireSubject("jsmith")/* etc... */.build().parse(s);
 } catch (InvalidClaimException ice) {
     // the sub claim was missing or did not have a 'jsmith' value
 }
@@ -1460,7 +1460,7 @@ you can catch either `MissingClaimException` or `IncorrectClaimException`:
 [,java]
 ----
 try {
-    Jwts.parser().requireSubject("jsmith")/* etc... */.build().parse(s);
+    Jwt.parser().requireSubject("jsmith")/* etc... */.build().parse(s);
 } catch(MissingClaimException mce) {
     // the parsed JWT did not have the sub claim
 } catch(IncorrectClaimException ice) {
@@ -1473,7 +1473,7 @@ You can also require custom claims by using the `require(claimName, requiredValu
 [,java]
 ----
 try {
-    Jwts.parser().require("myClaim", "myRequiredValue")/* etc... */.build().parse(s);
+    Jwt.parser().require("myClaim", "myRequiredValue")/* etc... */.build().parse(s);
 } catch(InvalidClaimException ice) {
     // the 'myClaim' claim was missing or did not have a 'myRequiredValue' value
 }
@@ -1501,7 +1501,7 @@ You can account for these differences (usually no more than a few minutes) when 
 ----
 long seconds = 3 * 60; //3 minutes
 
-Jwts.parser()
+Jwt.parser()
 
     .clockSkewSeconds(seconds) // <----
 
@@ -1527,7 +1527,7 @@ during parsing for timestamp comparisons can be obtained via a custom time sourc
 ----
 Clock clock = new MyClock();
 
-Jwts.parser().clock(myClock) //... etc ...
+Jwt.parser().clock(myClock) //... etc ...
 ----
 
 The ``JwtParser``'s default `Clock` implementation simply returns `new Date()` to reflect the time when parsing occurs,
@@ -1912,7 +1912,7 @@ Please see the main <<compression,Compression>> section to see how to compress a
 
 You read (parse) a JWS as follows:
 
-. Use the `Jwts.parser()` method to create a `JwtParserBuilder` instance.
+. Use the `Jwt.parser()` method to create a `JwtParserBuilder` instance.
 . Call either <<key-locator,keyLocator>> or `verifyWith` methods to determine the key used to verify the JWS signature.
 . Call the `build()` method on the `JwtParserBuilder` to return a thread-safe `JwtParser`.
 . Finally, call the `parseSignedClaims(String)` method with your jws `String`, producing the original JWS.
@@ -1926,7 +1926,7 @@ For example:
 Jws<Claims> jws;
 
 try {
-    jws = Jwts.parser()            // (1)
+    jws = Jwt.parser()            // (1)
 
     .keyLocator(keyLocator)        // (2) dynamically lookup verification keys based on each JWS
     //.verifyWith(key)             //     or a static key used to verify all encountered JWSs
@@ -1965,7 +1965,7 @@ For example:
 +
 [,java]
 ----
-Jwts.parser()
+Jwt.parser()
 
   .verifyWith(secretKey) // <----
 
@@ -1978,7 +1978,7 @@ specified on the `JwtParserBuilder`.  For example:
 +
 [,java]
 ----
-Jwts.parser()
+Jwt.parser()
 
   .verifyWith(publicKey) // <---- publicKey, not privateKey
 
@@ -2083,7 +2083,7 @@ To parse the resulting `jws` string, we need to do two things when creating the 
 
 [,java]
 ----
-Jws<byte[]> parsed = Jwts.parser().verifyWith(testKey) // 1
+Jws<byte[]> parsed = Jwt.parser().verifyWith(testKey) // 1
         .build()
         .parseSignedContent(jws, content);             // 2
 
@@ -2135,7 +2135,7 @@ To parse the resulting `jws` string, we need to do two things when creating the 
 
 [,java]
 ----
-Jws<Claims> parsed = Jwts.parser().verifyWith(testKey) // 1
+Jws<Claims> parsed = Jwt.parser().verifyWith(testKey) // 1
         .critical().add("b64").and()                   // 2
         .build()
         .parseSignedClaims(jws);
@@ -2157,7 +2157,7 @@ payload String's UTF-8 bytes instead:
 
 [,java]
 ----
-parsed = Jwts.parser().verifyWith(testKey)
+parsed = Jwt.parser().verifyWith(testKey)
         .build()
         .parseSignedClaims(jws, claimsString.getBytes(StandardCharsets.UTF_8)); // <---
 ----
@@ -2621,7 +2621,7 @@ its size.  Please see the main <<compression,Compression>> section to see how to
 
 You read (parse) a JWE as follows:
 
-. Use the `Jwts.parser()` method to create a `JwtParserBuilder` instance.
+. Use the `Jwt.parser()` method to create a `JwtParserBuilder` instance.
 . Call either <<key-locator,keyLocator>> or `decryptWith` methods to determine the key used to decrypt the JWE.
 . Call the ``JwtParserBuilder``'s `build()` method to create a thread-safe `JwtParser`.
 . Parse the jwe string with the ``JwtParser``'s `parseEncryptedClaims` or `parseEncryptedContent` method.
@@ -2634,7 +2634,7 @@ For example:
 Jwe<Claims> jwe;
 
 try {
-    jwe = Jwts.parser()               // (1)
+    jwe = Jwt.parser()               // (1)
 
     .keyLocator(keyLocator)           // (2) dynamically lookup decryption keys based on each JWE
     //.decryptWith(key)               //     or a static key used to decrypt all encountered JWEs
@@ -2672,7 +2672,7 @@ So which key do we use for decryption?
 +
 [,java]
 ----
-Jwts.parser()
+Jwt.parser()
 
   .decryptWith(secretKey) // <----
 
@@ -2687,7 +2687,7 @@ Jwts.parser()
 ----
 Password password = Password.of(passwordChars);
 
-Jwts.parser()
+Jwt.parser()
 
   .decryptWith(password) // <---- an `io.jsonwebtoken.security.Password` instance
 
@@ -2700,7 +2700,7 @@ the `PublicKey`) must be specified on the `JwtParserBuilder`.  For example:
 +
 [,java]
 ----
-Jwts.parser()
+Jwt.parser()
 
   .decryptWith(privateKey) // <---- a `PrivateKey`, not a `PublicKey`
 
@@ -2753,7 +2753,7 @@ the return value from a custom <<key-locator,Key Locator>> implementation.  For 
 ----
 PrivateKey decryptionKey = Keys.builder(pkcs11PrivateKey).publicKey(pkcs11PublicKey).build();
 
-Jwts.parser()
+Jwt.parser()
     .decryptWith(decryptionKey) // <----
     .build()
     .parseEncryptedClaims(jweString);
@@ -2763,7 +2763,7 @@ Or as the return value from your key locator:
 
 [,java]
 ----
-Jwts.parser()
+Jwt.parser()
     .keyLocator(keyLocator) // your keyLocator.locate(header) would return Keys.builder...
     .build()
     .parseEncryptedClaims(jweString);
@@ -3254,7 +3254,7 @@ by modifying the ``JwtParserBuilder``'s `zip()` collection.  For example:
 ----
 CompressionAlgorithm myAlg = new MyCompressionAlgorithm();
 
-Jwts.parser()
+Jwt.parser()
 
     .zip().add(myAlg).and() // <----
 
@@ -3326,7 +3326,7 @@ When reading a JWT:
 ----
 Deserializer<Map<String,?>> deserializer = getMyDeserializer(); //implement me
 
-Jwts.parser()
+Jwt.parser()
 
     .json(deserializer)
 
@@ -3391,7 +3391,7 @@ and the `JacksonDeserializer` using your `ObjectMapper` on the `JwtParserBuilder
 ----
 ObjectMapper objectMapper = getMyObjectMapper(); //implement me
 
-Jwts.parser()
+Jwt.parser()
 
     .json(new JacksonDeserializer(objectMapper))
 
@@ -3429,7 +3429,7 @@ The `User` object could be retrieved from the `user` claim with the following co
 
 [,java]
 ----
-Jwts.parser()
+Jwt.parser()
 
     .json(new JacksonDeserializer(Maps.of("user", User.class).build())) // <-----
 
@@ -3528,7 +3528,7 @@ and the `GsonDeserializer` using your `Gson` instance on the `JwtParser`:
 ----
 Gson gson = getGson(); //implement me
 
-Jwts.parser()
+Jwt.parser()
 
     .json(new GsonDeserializer(gson))
 
@@ -3699,7 +3699,7 @@ and the ``JwtParserBuilder``'s `decoder` method to set the decoder:
 ----
 Decoder<String, byte[]> decoder = getMyBase64UrlDecoder(); //implement me
 
-Jwts.parser()
+Jwt.parser()
 
     .b64Url(decoder)
 
@@ -3753,7 +3753,7 @@ byte[] content = message.getBytes(StandardCharsets.UTF_8);
 String jws = Jwts.builder().content(content, "text/plain").signWith(key, alg).compact();
 
 // Parse the compact JWS:
-content = Jwts.parser().verifyWith(key).build().parseSignedContent(jws).getPayload();
+content = Jwt.parser().verifyWith(key).build().parseSignedContent(jws).getPayload();
 
 assert message.equals(new String(content, StandardCharsets.UTF_8));
 ----
@@ -3781,7 +3781,7 @@ String jws = Jwts.builder().subject("Alice")
     .compact();
 
 // Alice receives and verifies the compact JWS came from Bob:
-String subject = Jwts.parser()
+String subject = Jwt.parser()
     .verifyWith(pair.getPublic()) // <-- Bob's RSA public key
     .build().parseSignedClaims(jws).getPayload().getSubject();
 
@@ -3814,7 +3814,7 @@ String jws = Jwts.builder().subject("Alice")
     .compact();
 
 // Alice receives and verifies the compact JWS came from Bob:
-String subject = Jwts.parser()
+String subject = Jwt.parser()
     .verifyWith(pair.getPublic()) // <-- Bob's EC public key
     .build().parseSignedClaims(jws).getPayload().getSubject();
 
@@ -3861,7 +3861,7 @@ String jws = Jwts.builder().subject("Alice")
     .compact();
 
 // Alice receives and verifies the compact JWS came from Bob:
-String subject = Jwts.parser()
+String subject = Jwt.parser()
     .verifyWith(pair.getPublic()) // <-- Bob's Edwards Curve public key
     .build().parseSignedClaims(jws).getPayload().getSubject();
 
@@ -3904,7 +3904,7 @@ byte[] content = message.getBytes(StandardCharsets.UTF_8);
 String jwe = Jwts.builder().content(content, "text/plain").encryptWith(key, enc).compact();
 
 // Parse the compact JWE:
-content = Jwts.parser().decryptWith(key).build().parseEncryptedContent(jwe).getPayload();
+content = Jwt.parser().decryptWith(key).build().parseEncryptedContent(jwe).getPayload();
 
 assert message.equals(new String(content, StandardCharsets.UTF_8));
 ----
@@ -3938,7 +3938,7 @@ String jwe = Jwts.builder().audience().add("Alice").and()
     .compact();
 
 // Alice receives and decrypts the compact JWE:
-Set<String> audience = Jwts.parser()
+Set<String> audience = Jwt.parser()
     .decryptWith(pair.getPrivate()) // <-- Alice's RSA private key
     .build().parseEncryptedClaims(jwe).getPayload().getAudience();
 
@@ -3973,7 +3973,7 @@ AeadAlgorithm enc = Jwe.alg.A256GCM; //or A192GCM, A128GCM, A256CBC-HS512, etc..
 String jwe = Jwts.builder().issuer("me").encryptWith(key, alg, enc).compact();
 
 // Parse the compact JWE:
-String issuer = Jwts.parser().decryptWith(key).build()
+String issuer = Jwt.parser().decryptWith(key).build()
     .parseEncryptedClaims(jwe).getPayload().getIssuer();
 
 assert "me".equals(issuer);
@@ -4010,7 +4010,7 @@ String jwe = Jwts.builder().audience().add("Alice").and()
     .compact();
 
 // Alice receives and decrypts the compact JWE:
-Set<String> audience = Jwts.parser()
+Set<String> audience = Jwt.parser()
     .decryptWith(pair.getPrivate()) // <-- Alice's EC private key
     .build().parseEncryptedClaims(jwe).getPayload().getAudience();
 
@@ -4059,7 +4059,7 @@ String jwe = Jwts.builder().issuer("me")
     .compact();
 
 // Parse the compact JWE:
-String issuer = Jwts.parser().decryptWith(password)
+String issuer = Jwt.parser().decryptWith(password)
     .build().parseEncryptedClaims(jwe).getPayload().getIssuer();
 
 assert "me".equals(issuer);

--- a/api/src/main/java/io/jsonwebtoken/Claims.java
+++ b/api/src/main/java/io/jsonwebtoken/Claims.java
@@ -15,6 +15,8 @@
  */
 package io.jsonwebtoken;
 
+import io.jsonwebtoken.lang.MapMutator;
+
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
@@ -163,4 +165,35 @@ public interface Claims extends Map<String, Object>, Identifiable {
      * @see <a href="https://github.com/jwtk/jjwt#json-support">JJWT JSON Support</a>
      */
     <T> T get(String claimName, Class<T> requiredType);
+
+    /**
+     * Parameters that may be modified to construct a {@link Claims} instance.
+     *
+     * @param <T> the claims params type, for method chaining
+     * @since JJWT_RELEASE_VERSION
+     */
+    interface Params<T extends Params<T>> extends MapMutator<String, Object, T>, ClaimsMutator<T> {
+    }
+
+    /**
+     * Builder used to create an immutable {@link Claims} instance.
+     *
+     * @see Claims
+     * @see Claims#builder()
+     * @since JJWT_RELEASE_VERSION
+     */
+    interface Builder extends Params<Builder>, io.jsonwebtoken.lang.Builder<Claims> {
+    }
+
+    /**
+     * Returns a new {@link Claims} builder instance to be used to populate JWT claims, which in aggregate will be
+     * a JWT payload.
+     *
+     * @return a new {@link Claims} builder instance to be used to populate JWT claims, which in aggregate will be
+     * a JWT payload.
+     * @since JJWT_RELEASE_VERSION
+     */
+    static ClaimsBuilder builder() {
+        return Suppliers.CLAIMS_BUILDER_SUPPLIER.get();
+    }
 }

--- a/api/src/main/java/io/jsonwebtoken/ClaimsBuilder.java
+++ b/api/src/main/java/io/jsonwebtoken/ClaimsBuilder.java
@@ -16,7 +16,6 @@
 package io.jsonwebtoken;
 
 import io.jsonwebtoken.lang.Builder;
-import io.jsonwebtoken.lang.MapMutator;
 
 /**
  * {@link Builder} used to create an immutable {@link Claims} instance.
@@ -25,5 +24,5 @@ import io.jsonwebtoken.lang.MapMutator;
  * @see Claims
  * @since 0.12.0
  */
-public interface ClaimsBuilder extends MapMutator<String, Object, ClaimsBuilder>, ClaimsMutator<ClaimsBuilder>, Builder<Claims> {
+public interface ClaimsBuilder extends Claims.Params<ClaimsBuilder>, Builder<Claims> {
 }

--- a/api/src/main/java/io/jsonwebtoken/ClaimsMutator.java
+++ b/api/src/main/java/io/jsonwebtoken/ClaimsMutator.java
@@ -99,7 +99,7 @@ public interface ClaimsMutator<T extends ClaimsMutator<T>> {
      * <p>When finished, the {@code audience} collection's {@link AudienceCollection#and() and()} method may be used
      * to continue configuration. For example:</p>
      * <blockquote><pre>
-     *  Jwts.builder() // or Jwts.claims()
+     *  Jwt.builder() // or Jwt.claims()
      *
      *     .audience().add("anAudience")<b>.and() // return parent</b>
      *
@@ -235,7 +235,7 @@ public interface ClaimsMutator<T extends ClaimsMutator<T>> {
      * <p>Because this interface extends {@link NestedCollection}, the {@link #and()} method may be used to continue
      * parent configuration. For example:</p>
      * <blockquote><pre>
-     *  Jwts.builder() // or Jwts.claims()
+     *  Jwt.builder() // or Jwt.claims()
      *
      *     .audience().add("anAudience")<b>.and() // return parent</b>
      *

--- a/api/src/main/java/io/jsonwebtoken/HeaderMutator.java
+++ b/api/src/main/java/io/jsonwebtoken/HeaderMutator.java
@@ -26,7 +26,7 @@ import io.jsonwebtoken.lang.MapMutator;
 public interface HeaderMutator<T extends HeaderMutator<T>> extends MapMutator<String, Object, T> {
 
     //IMPLEMENTOR NOTE: if this `algorithm` method ever needs to be exposed in the public API, it might be better to
-    //                  have it in the Jwts.HeaderBuilder interface and NOT this one: in the context of
+    //                  have it in the Jwt.HeaderBuilder interface and NOT this one: in the context of
     //                  JwtBuilder.Header, there is never a reason for an application developer to call algorithm(id)
     //                  directly because the KeyAlgorithm or SecureDigestAlgorithm instance must always be provided
     //                  via the signWith or encryptWith methods.  The JwtBuilder will always set the algorithm

--- a/api/src/main/java/io/jsonwebtoken/Jwe.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwe.java
@@ -82,7 +82,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
      * Web Signature and Encryption Algorithms Registry</a>. Each standard algorithm is available as a
      * ({@code public static final}) constant for direct type-safe reference in application code. For example:
      * <blockquote><pre>
-     * Jwts.builder()
+     * Jwt.builder()
      *    // ... etc ...
      *    .encryptWith(aKey, <b>Jwe.enc.A256GCM</b>) // or A128GCM, A192GCM, etc...
      *    .build();</pre></blockquote>
@@ -160,7 +160,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
      * Cryptographic Algorithms for Key Management</a>. Each standard algorithm is available as a
      * ({@code public static final}) constant for direct type-safe reference in application code. For example:
      * <blockquote><pre>
-     * Jwts.builder()
+     * Jwt.builder()
      *    // ... etc ...
      *    .encryptWith(aKey, <b>Jwe.alg.ECDH_ES_A256KW</b>, Jwe.enc.A256GCM)
      *    .build();</pre></blockquote>
@@ -788,7 +788,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
      * Registry</a>. Each algorithm is available as a ({@code public static final}) constant for
      * direct type-safe reference in application code. For example:
      * <blockquote><pre>
-     * Jwts.builder()
+     * Jwt.builder()
      *    // ... etc ...
      *    .compressWith(<b>Jwe.zip.DEF</b>)
      *    .build();</pre></blockquote>

--- a/api/src/main/java/io/jsonwebtoken/Jwe.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwe.java
@@ -176,7 +176,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
 
         /**
          * Returns all standard JWA standard <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-4">Cryptographic
-         * Algorithms for Key Management</a>..
+         * Algorithms for Key Management</a>.
          *
          * @return all standard JWA Key Management algorithms.
          */
@@ -189,7 +189,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          * by <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-4.5">RFC 7518 (JWA), Section 4.5</a>.  This
          * algorithm does not produce encrypted key ciphertext.
          */
-        public static final KeyAlgorithm<SecretKey, SecretKey> DIRECT = Jwts.get(REGISTRY, "dir");
+        public static final KeyAlgorithm<SecretKey, SecretKey> DIRECT = Suppliers.get(REGISTRY, "dir");
 
         /**
          * AES Key Wrap algorithm with default initial value using a 128-bit key, as defined by
@@ -213,7 +213,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *     JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}.</li>
          * </ol>
          */
-        public static final SecretKeyAlgorithm A128KW = Jwts.get(REGISTRY, "A128KW");
+        public static final SecretKeyAlgorithm A128KW = Suppliers.get(REGISTRY, "A128KW");
 
         /**
          * AES Key Wrap algorithm with default initial value using a 192-bit key, as defined by
@@ -237,7 +237,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *     JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}.</li>
          * </ol>
          */
-        public static final SecretKeyAlgorithm A192KW = Jwts.get(REGISTRY, "A192KW");
+        public static final SecretKeyAlgorithm A192KW = Suppliers.get(REGISTRY, "A192KW");
 
         /**
          * AES Key Wrap algorithm with default initial value using a 256-bit key, as defined by
@@ -261,7 +261,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *     JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}.</li>
          * </ol>
          */
-        public static final SecretKeyAlgorithm A256KW = Jwts.get(REGISTRY, "A256KW");
+        public static final SecretKeyAlgorithm A256KW = Suppliers.get(REGISTRY, "A256KW");
 
         /**
          * Key wrap algorithm with AES GCM using a 128-bit key, as defined by
@@ -300,7 +300,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *     JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}.</li>
          * </ol>
          */
-        public static final SecretKeyAlgorithm A128GCMKW = Jwts.get(REGISTRY, "A128GCMKW");
+        public static final SecretKeyAlgorithm A128GCMKW = Suppliers.get(REGISTRY, "A128GCMKW");
 
         /**
          * Key wrap algorithm with AES GCM using a 192-bit key, as defined by
@@ -339,7 +339,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *     JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}.</li>
          * </ol>
          */
-        public static final SecretKeyAlgorithm A192GCMKW = Jwts.get(REGISTRY, "A192GCMKW");
+        public static final SecretKeyAlgorithm A192GCMKW = Suppliers.get(REGISTRY, "A192GCMKW");
 
         /**
          * Key wrap algorithm with AES GCM using a 256-bit key, as defined by
@@ -378,7 +378,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *     JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}.</li>
          * </ol>
          */
-        public static final SecretKeyAlgorithm A256GCMKW = Jwts.get(REGISTRY, "A256GCMKW");
+        public static final SecretKeyAlgorithm A256GCMKW = Suppliers.get(REGISTRY, "A256GCMKW");
 
         /**
          * Key encryption algorithm using <code>PBES2 with HMAC SHA-256 and &quot;A128KW&quot; wrapping</code>
@@ -423,7 +423,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *     JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}.</li>
          * </ol>
          */
-        public static final KeyAlgorithm<Password, Password> PBES2_HS256_A128KW = Jwts.get(REGISTRY, "PBES2-HS256+A128KW");
+        public static final KeyAlgorithm<Password, Password> PBES2_HS256_A128KW = Suppliers.get(REGISTRY, "PBES2-HS256+A128KW");
 
         /**
          * Key encryption algorithm using <code>PBES2 with HMAC SHA-384 and &quot;A192KW&quot; wrapping</code>
@@ -468,7 +468,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *     JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}.</li>
          * </ol>
          */
-        public static final KeyAlgorithm<Password, Password> PBES2_HS384_A192KW = Jwts.get(REGISTRY, "PBES2-HS384+A192KW");
+        public static final KeyAlgorithm<Password, Password> PBES2_HS384_A192KW = Suppliers.get(REGISTRY, "PBES2-HS384+A192KW");
 
         /**
          * Key encryption algorithm using <code>PBES2 with HMAC SHA-512 and &quot;A256KW&quot; wrapping</code>
@@ -513,7 +513,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *     JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}.</li>
          * </ol>
          */
-        public static final KeyAlgorithm<Password, Password> PBES2_HS512_A256KW = Jwts.get(REGISTRY, "PBES2-HS512+A256KW");
+        public static final KeyAlgorithm<Password, Password> PBES2_HS512_A256KW = Suppliers.get(REGISTRY, "PBES2-HS512+A256KW");
 
         /**
          * Key Encryption with {@code RSAES-PKCS1-v1_5}, as defined by
@@ -538,7 +538,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *     JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}. </li>
          * </ol>
          */
-        public static final KeyAlgorithm<PublicKey, PrivateKey> RSA1_5 = Jwts.get(REGISTRY, "RSA1_5");
+        public static final KeyAlgorithm<PublicKey, PrivateKey> RSA1_5 = Suppliers.get(REGISTRY, "RSA1_5");
 
         /**
          * Key Encryption with {@code RSAES OAEP using default parameters}, as defined by
@@ -563,7 +563,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *     JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}. </li>
          * </ol>
          */
-        public static final KeyAlgorithm<PublicKey, PrivateKey> RSA_OAEP = Jwts.get(REGISTRY, "RSA-OAEP");
+        public static final KeyAlgorithm<PublicKey, PrivateKey> RSA_OAEP = Suppliers.get(REGISTRY, "RSA-OAEP");
 
         /**
          * Key Encryption with {@code RSAES OAEP using SHA-256 and MGF1 with SHA-256}, as defined by
@@ -588,7 +588,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *     JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}. </li>
          * </ol>
          */
-        public static final KeyAlgorithm<PublicKey, PrivateKey> RSA_OAEP_256 = Jwts.get(REGISTRY, "RSA-OAEP-256");
+        public static final KeyAlgorithm<PublicKey, PrivateKey> RSA_OAEP_256 = Suppliers.get(REGISTRY, "RSA-OAEP-256");
 
         /**
          * Key Agreement with {@code ECDH-ES using Concat KDF} as defined by
@@ -629,7 +629,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *      JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}.</li>
          * </ol>
          */
-        public static final KeyAlgorithm<PublicKey, PrivateKey> ECDH_ES = Jwts.get(REGISTRY, "ECDH-ES");
+        public static final KeyAlgorithm<PublicKey, PrivateKey> ECDH_ES = Suppliers.get(REGISTRY, "ECDH-ES");
 
         /**
          * Key Agreement with Key Wrapping via
@@ -677,7 +677,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *      JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}.</li>
          * </ol>
          */
-        public static final KeyAlgorithm<PublicKey, PrivateKey> ECDH_ES_A128KW = Jwts.get(REGISTRY, "ECDH-ES+A128KW");
+        public static final KeyAlgorithm<PublicKey, PrivateKey> ECDH_ES_A128KW = Suppliers.get(REGISTRY, "ECDH-ES+A128KW");
 
         /**
          * Key Agreement with Key Wrapping via
@@ -726,7 +726,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *      JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}.</li>
          * </ol>
          */
-        public static final KeyAlgorithm<PublicKey, PrivateKey> ECDH_ES_A192KW = Jwts.get(REGISTRY, "ECDH-ES+A192KW");
+        public static final KeyAlgorithm<PublicKey, PrivateKey> ECDH_ES_A192KW = Suppliers.get(REGISTRY, "ECDH-ES+A192KW");
 
         /**
          * Key Agreement with Key Wrapping via
@@ -775,7 +775,7 @@ public interface Jwe<B> extends ProtectedJwt<JweHeader, B> {
          *      JWE using the JWE's identified &quot;enc&quot; {@link AeadAlgorithm}.</li>
          * </ol>
          */
-        public static final KeyAlgorithm<PublicKey, PrivateKey> ECDH_ES_A256KW = Jwts.get(REGISTRY, "ECDH-ES+A256KW");
+        public static final KeyAlgorithm<PublicKey, PrivateKey> ECDH_ES_A256KW = Suppliers.get(REGISTRY, "ECDH-ES+A256KW");
 
         //prevent instantiation
         private alg() {

--- a/api/src/main/java/io/jsonwebtoken/JweHeader.java
+++ b/api/src/main/java/io/jsonwebtoken/JweHeader.java
@@ -169,9 +169,8 @@ public interface JweHeader extends ProtectedHeader {
      */
     byte[] getPbes2Salt();
 
-
     /**
-     * Parameters used that may be used to build a JWE Header.
+     * Parameters that may be used to build a JWE Header.
      *
      * @param <T> the params subtype for method chaining.
      * @since JJWT_RELEASE_VERSION

--- a/api/src/main/java/io/jsonwebtoken/JweHeader.java
+++ b/api/src/main/java/io/jsonwebtoken/JweHeader.java
@@ -18,6 +18,7 @@ package io.jsonwebtoken;
 import io.jsonwebtoken.security.AeadAlgorithm;
 import io.jsonwebtoken.security.KeyAlgorithm;
 import io.jsonwebtoken.security.PublicJwk;
+import io.jsonwebtoken.security.X509Builder;
 
 import javax.crypto.SecretKey;
 import java.security.Key;
@@ -167,4 +168,14 @@ public interface JweHeader extends ProtectedHeader {
      * @see Jwe.alg#PBES2_HS512_A256KW
      */
     byte[] getPbes2Salt();
+
+
+    /**
+     * Parameters used that may be used to build a JWE Header.
+     *
+     * @param <T> the params subtype for method chaining.
+     * @since JJWT_RELEASE_VERSION
+     */
+    interface BuilderParams<T extends BuilderParams<T>> extends JweHeaderMutator<T>, X509Builder<T> {
+    }
 }

--- a/api/src/main/java/io/jsonwebtoken/Jws.java
+++ b/api/src/main/java/io/jsonwebtoken/Jws.java
@@ -115,49 +115,49 @@ public interface Jws<P> extends ProtectedJwt<JwsHeader, P> {
          * is used only when creating unsecured (not integrity protected) JWSs and is not usable in any other scenario.
          * Any attempt to call its methods will result in an exception being thrown.
          */
-        public static final SecureDigestAlgorithm<Key, Key> NONE = Jwts.get(REGISTRY, "none");
+        public static final SecureDigestAlgorithm<Key, Key> NONE = Suppliers.get(REGISTRY, "none");
 
         /**
          * {@code HMAC using SHA-256} message authentication algorithm as defined by
          * <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-3.2">RFC 7518, Section 3.2</a>.  This algorithm
          * requires a 256-bit (32 byte) key.
          */
-        public static final MacAlgorithm HS256 = Jwts.get(REGISTRY, "HS256");
+        public static final MacAlgorithm HS256 = Suppliers.get(REGISTRY, "HS256");
 
         /**
          * {@code HMAC using SHA-384} message authentication algorithm as defined by
          * <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-3.2">RFC 7518, Section 3.2</a>.  This algorithm
          * requires a 384-bit (48 byte) key.
          */
-        public static final MacAlgorithm HS384 = Jwts.get(REGISTRY, "HS384");
+        public static final MacAlgorithm HS384 = Suppliers.get(REGISTRY, "HS384");
 
         /**
          * {@code HMAC using SHA-512} message authentication algorithm as defined by
          * <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-3.2">RFC 7518, Section 3.2</a>.  This algorithm
          * requires a 512-bit (64 byte) key.
          */
-        public static final MacAlgorithm HS512 = Jwts.get(REGISTRY, "HS512");
+        public static final MacAlgorithm HS512 = Suppliers.get(REGISTRY, "HS512");
 
         /**
          * {@code RSASSA-PKCS1-v1_5 using SHA-256} signature algorithm as defined by
          * <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-3.3">RFC 7518, Section 3.3</a>.  This algorithm
          * requires a 2048-bit key.
          */
-        public static final io.jsonwebtoken.security.SignatureAlgorithm RS256 = Jwts.get(REGISTRY, "RS256");
+        public static final io.jsonwebtoken.security.SignatureAlgorithm RS256 = Suppliers.get(REGISTRY, "RS256");
 
         /**
          * {@code RSASSA-PKCS1-v1_5 using SHA-384} signature algorithm as defined by
          * <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-3.3">RFC 7518, Section 3.3</a>.  This algorithm
          * requires a 2048-bit key, but the JJWT team recommends a 3072-bit key.
          */
-        public static final io.jsonwebtoken.security.SignatureAlgorithm RS384 = Jwts.get(REGISTRY, "RS384");
+        public static final io.jsonwebtoken.security.SignatureAlgorithm RS384 = Suppliers.get(REGISTRY, "RS384");
 
         /**
          * {@code RSASSA-PKCS1-v1_5 using SHA-512} signature algorithm as defined by
          * <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-3.3">RFC 7518, Section 3.3</a>.  This algorithm
          * requires a 2048-bit key, but the JJWT team recommends a 4096-bit key.
          */
-        public static final io.jsonwebtoken.security.SignatureAlgorithm RS512 = Jwts.get(REGISTRY, "RS512");
+        public static final io.jsonwebtoken.security.SignatureAlgorithm RS512 = Suppliers.get(REGISTRY, "RS512");
 
         /**
          * {@code RSASSA-PSS using SHA-256 and MGF1 with SHA-256} signature algorithm as defined by
@@ -168,7 +168,7 @@ public interface Jws<P> extends ProtectedJwt<JwsHeader, P> {
          * classpath. If on Java 10 or earlier, BouncyCastle will be used automatically if found in the runtime
          * classpath.</p>
          */
-        public static final io.jsonwebtoken.security.SignatureAlgorithm PS256 = Jwts.get(REGISTRY, "PS256");
+        public static final io.jsonwebtoken.security.SignatureAlgorithm PS256 = Suppliers.get(REGISTRY, "PS256");
 
         /**
          * {@code RSASSA-PSS using SHA-384 and MGF1 with SHA-384} signature algorithm as defined by
@@ -179,7 +179,7 @@ public interface Jws<P> extends ProtectedJwt<JwsHeader, P> {
          * classpath. If on Java 10 or earlier, BouncyCastle will be used automatically if found in the runtime
          * classpath.</p>
          */
-        public static final io.jsonwebtoken.security.SignatureAlgorithm PS384 = Jwts.get(REGISTRY, "PS384");
+        public static final io.jsonwebtoken.security.SignatureAlgorithm PS384 = Suppliers.get(REGISTRY, "PS384");
 
         /**
          * {@code RSASSA-PSS using SHA-512 and MGF1 with SHA-512} signature algorithm as defined by
@@ -190,28 +190,28 @@ public interface Jws<P> extends ProtectedJwt<JwsHeader, P> {
          * classpath. If on Java 10 or earlier, BouncyCastle will be used automatically if found in the runtime
          * classpath.</p>
          */
-        public static final io.jsonwebtoken.security.SignatureAlgorithm PS512 = Jwts.get(REGISTRY, "PS512");
+        public static final io.jsonwebtoken.security.SignatureAlgorithm PS512 = Suppliers.get(REGISTRY, "PS512");
 
         /**
          * {@code ECDSA using P-256 and SHA-256} signature algorithm as defined by
          * <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-3.4">RFC 7518, Section 3.4</a>.  This algorithm
          * requires a 256-bit key.
          */
-        public static final io.jsonwebtoken.security.SignatureAlgorithm ES256 = Jwts.get(REGISTRY, "ES256");
+        public static final io.jsonwebtoken.security.SignatureAlgorithm ES256 = Suppliers.get(REGISTRY, "ES256");
 
         /**
          * {@code ECDSA using P-384 and SHA-384} signature algorithm as defined by
          * <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-3.4">RFC 7518, Section 3.4</a>.  This algorithm
          * requires a 384-bit key.
          */
-        public static final io.jsonwebtoken.security.SignatureAlgorithm ES384 = Jwts.get(REGISTRY, "ES384");
+        public static final io.jsonwebtoken.security.SignatureAlgorithm ES384 = Suppliers.get(REGISTRY, "ES384");
 
         /**
          * {@code ECDSA using P-521 and SHA-512} signature algorithm as defined by
          * <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-3.4">RFC 7518, Section 3.4</a>.  This algorithm
          * requires a 521-bit key.
          */
-        public static final io.jsonwebtoken.security.SignatureAlgorithm ES512 = Jwts.get(REGISTRY, "ES512");
+        public static final io.jsonwebtoken.security.SignatureAlgorithm ES512 = Suppliers.get(REGISTRY, "ES512");
 
         /**
          * {@code EdDSA} signature algorithm defined by
@@ -232,6 +232,6 @@ public interface Jws<P> extends ProtectedJwt<JwsHeader, P> {
          * <p><b><sup>1</sup>This algorithm requires at least JDK 15 or a compatible JCA Provider (like BouncyCastle) in the runtime
          * classpath.</b></p>
          */
-        public static final io.jsonwebtoken.security.SignatureAlgorithm EdDSA = Jwts.get(REGISTRY, "EdDSA");
+        public static final io.jsonwebtoken.security.SignatureAlgorithm EdDSA = Suppliers.get(REGISTRY, "EdDSA");
     }
 }

--- a/api/src/main/java/io/jsonwebtoken/Jws.java
+++ b/api/src/main/java/io/jsonwebtoken/Jws.java
@@ -79,7 +79,7 @@ public interface Jws<P> extends ProtectedJwt<JwsHeader, P> {
      * Registry</a>. Each standard algorithm is available as a ({@code public static final}) constant for
      * direct type-safe reference in application code. For example:
      * <blockquote><pre>
-     * Jwts.builder()
+     * Jwt.builder()
      *    // ... etc ...
      *    .signWith(aKey, <b>Jws.alg.HS512</b>) // or RS512, PS256, EdDSA, etc...
      *    .build();</pre></blockquote>

--- a/api/src/main/java/io/jsonwebtoken/Jwt.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwt.java
@@ -15,6 +15,8 @@
  */
 package io.jsonwebtoken;
 
+import io.jsonwebtoken.lang.Builder;
+
 /**
  * An expanded (not compact/serialized) JSON Web Token.
  *
@@ -51,6 +53,28 @@ public interface Jwt<H extends Header, P> {
             return jwt;
         }
     };
+
+    /**
+     * Returns a new {@link HeaderBuilder} that can build any type of {@link Header} instance depending on
+     * which builder properties are set.
+     *
+     * @return a new {@link HeaderBuilder} that can build any type of {@link Header} instance depending on
+     * which builder properties are set.
+     * @since JJWT_RELEASE_VERSION
+     */
+    static HeaderBuilder header() {
+        return Suppliers.HEADER_BUILDER_SUPPLIER.get();
+    }
+
+    /**
+     * Returns a new {@link JwtParserBuilder} instance that can be configured to create an immutable/thread-safe {@link JwtParser}.
+     *
+     * @return a new {@link JwtParserBuilder} instance that can be configured create an immutable/thread-safe {@link JwtParser}.
+     * @since JJWT_RELEASE_VERSION
+     */
+    static JwtParserBuilder parser() {
+        return Suppliers.JWT_PARSER_BUILDER_SUPPLIER.get();
+    }
 
     /**
      * Returns the JWT {@link Header} or {@code null} if not present.
@@ -93,12 +117,10 @@ public interface Jwt<H extends Header, P> {
     <T> T accept(JwtVisitor<T> visitor);
 
     /**
-     * Returns a new {@link JwtParserBuilder} instance that can be configured to create an immutable/thread-safe {@link JwtParser}.
+     * A {@link Builder} that dynamically determines the type of {@link Header} to create based on builder state.
      *
-     * @return a new {@link JwtParserBuilder} instance that can be configured create an immutable/thread-safe {@link JwtParser}.
      * @since JJWT_RELEASE_VERSION
      */
-    static JwtParserBuilder parser() {
-        return Suppliers.JWT_PARSER_BUILDER_SUPPLIER.get();
+    interface HeaderBuilder extends JweHeader.BuilderParams<HeaderBuilder>, Builder<Header> {
     }
 }

--- a/api/src/main/java/io/jsonwebtoken/Jwt.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwt.java
@@ -91,4 +91,14 @@ public interface Jwt<H extends Header, P> {
      * @return the value returned from visitor's {@code visit} method implementation.
      */
     <T> T accept(JwtVisitor<T> visitor);
+
+    /**
+     * Returns a new {@link JwtParserBuilder} instance that can be configured to create an immutable/thread-safe {@link JwtParser}.
+     *
+     * @return a new {@link JwtParserBuilder} instance that can be configured create an immutable/thread-safe {@link JwtParser}.
+     * @since JJWT_RELEASE_VERSION
+     */
+    static JwtParserBuilder parser() {
+        return Suppliers.JWT_PARSER_BUILDER_SUPPLIER.get();
+    }
 }

--- a/api/src/main/java/io/jsonwebtoken/Jwt.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwt.java
@@ -77,6 +77,17 @@ public interface Jwt<H extends Header, P> {
     }
 
     /**
+     * Returns a new {@link JwtBuilder} instance that can be configured and then used to create JWT compact serialized
+     * strings.
+     *
+     * @return a new {@link JwtBuilder} instance that can be configured and then used to create JWT compact serialized
+     * strings.
+     */
+    static JwtBuilder builder() {
+        return Suppliers.JWT_BUILDER_SUPPLIER.get();
+    }
+
+    /**
      * Returns the JWT {@link Header} or {@code null} if not present.
      *
      * @return the JWT {@link Header} or {@code null} if not present.

--- a/api/src/main/java/io/jsonwebtoken/JwtBuilder.java
+++ b/api/src/main/java/io/jsonwebtoken/JwtBuilder.java
@@ -56,7 +56,7 @@ public interface JwtBuilder extends Providable<JwtBuilder>, Randomizable<JwtBuil
      * For example:
      *
      * <blockquote><pre>
-     * String jwt = Jwts.builder()
+     * String jwt = Jwt.builder()
      *
      *     <b>.header()
      *         .keyId("keyId")
@@ -82,7 +82,7 @@ public interface JwtBuilder extends Providable<JwtBuilder>, Randomizable<JwtBuil
      * Modifies the JWT's header name/value pairs as desired, allowing for in-line configuration. For example:
      *
      * <blockquote><pre>
-     * String jwt = Jwts.builder()
+     * String jwt = Jwt.builder()
      *     .header(<b>header -> header
      *         .keyId("keyId")
      *         .add("aName", aValue)
@@ -411,7 +411,7 @@ public interface JwtBuilder extends Providable<JwtBuilder>, Randomizable<JwtBuil
      * For example:
      *
      * <blockquote><pre>
-     * String jwt = Jwts.builder()
+     * String jwt = Jwt.builder()
      *
      *     <b>.claims()
      *         .issuer("me")
@@ -439,7 +439,7 @@ public interface JwtBuilder extends Providable<JwtBuilder>, Randomizable<JwtBuil
      * Modifies the JWT {@code Claims} payload, allowing for in-line configuration. For example:
      *
      * <blockquote><pre>
-     * String jwt = Jwts.builder()
+     * String jwt = Jwt.builder()
      *
      *     <b>.claims(claims -> claims
      *         .issuer("me")

--- a/api/src/main/java/io/jsonwebtoken/JwtBuilder.java
+++ b/api/src/main/java/io/jsonwebtoken/JwtBuilder.java
@@ -31,7 +31,6 @@ import io.jsonwebtoken.security.Providable;
 import io.jsonwebtoken.security.Randomizable;
 import io.jsonwebtoken.security.SecureDigestAlgorithm;
 import io.jsonwebtoken.security.WeakKeyException;
-import io.jsonwebtoken.security.X509Builder;
 
 import javax.crypto.SecretKey;
 import java.io.InputStream;
@@ -70,7 +69,11 @@ public interface JwtBuilder extends Providable<JwtBuilder>, Randomizable<JwtBuil
      *     // ... etc ...
      *     .compact();</pre></blockquote>
      *
+     * <p>If you wish to use Java8+ lambda-style inline configuration instead of using the
+     * {@link BuilderHeader#and() and()} method, consider using the {@link #header(Consumer)} method.</p>
+     *
      * @return the {@link BuilderHeader} to use for header construction.
+     * @see #header(Consumer)
      * @since 0.12.0
      */
     BuilderHeader header();
@@ -89,11 +92,16 @@ public interface JwtBuilder extends Providable<JwtBuilder>, Randomizable<JwtBuil
      *     // ... etc ...
      *     .compact();</pre></blockquote>
      *
-     * @param header the consumer used to configure the JWT header
+     * <p>Note that, although the consumer argument accepts a {@link JweHeader.BuilderParams} instance, a
+     * {@code JweHeader} will not necessarily be created; the params instance only reflects all possible header
+     * parameters that <em>may</em> be configured, but the builder will dynamically create a JWT, JWS, or JWE header
+     * based on which parameters have actually been set.</p>
+     *
+     * @param header the consumer used to configure the JWT header.
      * @return the {@code JwtBuilder} for method chaining.
      * @since JJWT_RELEASE_VERSION
      */
-    default JwtBuilder header(Consumer<BuilderHeader> header) {
+    default JwtBuilder header(Consumer<JweHeader.BuilderParams<?>> header) {
         BuilderHeader h = header();
         header.accept(h);
         return h.and();
@@ -418,7 +426,11 @@ public interface JwtBuilder extends Providable<JwtBuilder>, Randomizable<JwtBuil
      *     // ... etc ...
      *     .compact();</pre></blockquote>
      *
+     * <p>If you wish to use Java8+ lambda-style inline configuration instead of using the
+     * {@link BuilderClaims#and() and()} method, consider using the {@link #claims(Consumer)} method.</p>
+     *
      * @return the {@link BuilderClaims} to use for Claims construction.
+     * @see #claims(Consumer)
      * @since 0.12.0
      */
     BuilderClaims claims();
@@ -444,7 +456,7 @@ public interface JwtBuilder extends Providable<JwtBuilder>, Randomizable<JwtBuil
      * @return the {@code JwtBuilder} for method chaining.
      * @since JJWT_RELEASE_VERSION
      */
-    default JwtBuilder claims(Consumer<BuilderClaims> claims) {
+    default JwtBuilder claims(Consumer<Claims.Params<?>> claims) {
         BuilderClaims c = claims();
         claims.accept(c);
         return c.and();
@@ -1069,8 +1081,7 @@ public interface JwtBuilder extends Providable<JwtBuilder>, Randomizable<JwtBuil
      *
      * @since 0.12.0
      */
-    interface BuilderClaims extends MapMutator<String, Object, BuilderClaims>, ClaimsMutator<BuilderClaims>,
-            Conjunctor<JwtBuilder> {
+    interface BuilderClaims extends Claims.Params<BuilderClaims>, Conjunctor<JwtBuilder> {
     }
 
     /**
@@ -1080,7 +1091,6 @@ public interface JwtBuilder extends Providable<JwtBuilder>, Randomizable<JwtBuil
      *
      * @since 0.12.0
      */
-    interface BuilderHeader extends JweHeaderMutator<BuilderHeader>, X509Builder<BuilderHeader>,
-            Conjunctor<JwtBuilder> {
+    interface BuilderHeader extends JweHeader.BuilderParams<BuilderHeader>, Conjunctor<JwtBuilder> {
     }
 }

--- a/api/src/main/java/io/jsonwebtoken/JwtParserBuilder.java
+++ b/api/src/main/java/io/jsonwebtoken/JwtParserBuilder.java
@@ -38,7 +38,7 @@ import java.util.Map;
 /**
  * A builder to construct a {@link JwtParser}. Example usage:
  * <pre>{@code
- *     Jwts.parser()
+ *     Jwt.parser()
  *         .requireIssuer("https://issuer.example.com")
  *         .verifyWith(...)
  *         .build()
@@ -117,7 +117,7 @@ public interface JwtParserBuilder extends Providable<JwtParserBuilder>, Builder<
      * <p>When finished, use the collection's
      * {@link Conjunctor#and() and()} method to continue parser configuration, for example:
      * <blockquote><pre>
-     * Jwts.parser()
+     * Jwt.parser()
      *     .critical().add("headerName").<b>{@link Conjunctor#and() and()} // return parent</b>
      * // resume parser configuration...</pre></blockquote>
      *
@@ -460,7 +460,7 @@ public interface JwtParserBuilder extends Providable<JwtParserBuilder>, Builder<
      * verify the JWS signature or decrypt the JWE payload with the returned key.  For example:</p>
      *
      * <pre>
-     * Jws&lt;Claims&gt; jws = Jwts.parser().keyLocator(new Locator&lt;Key&gt;() {
+     * Jws&lt;Claims&gt; jws = Jwt.parser().keyLocator(new Locator&lt;Key&gt;() {
      *         &#64;Override
      *         public Key locate(Header&lt;?&gt; header) {
      *             if (header instanceof JwsHeader) {
@@ -532,7 +532,7 @@ public interface JwtParserBuilder extends Providable<JwtParserBuilder>, Builder<
      * returned key.  For example:</p>
      *
      * <pre>
-     * Jws&lt;Claims&gt; jws = Jwts.parser().setSigningKeyResolver(new SigningKeyResolverAdapter() {
+     * Jws&lt;Claims&gt; jws = Jwt.parser().setSigningKeyResolver(new SigningKeyResolverAdapter() {
      *         &#64;Override
      *         public byte[] resolveSigningKeyBytes(JwsHeader header, Claims claims) {
      *             //inspect the header or claims, lookup and return the signing key

--- a/api/src/main/java/io/jsonwebtoken/Jwts.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwts.java
@@ -1103,10 +1103,13 @@ public final class Jwts {
     }
 
     /**
-     * A {@link Builder} that dynamically determines the type of {@link Header} to create based on builder state.
+     * A builder that dynamically determines the type of {@link Header} to create based on builder state.
      *
      * @since 0.12.0
+     * @deprecated since JJWT_RELEASE_VERSION in favor of {@link Jwt.HeaderBuilder}
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated
     public interface HeaderBuilder extends JweHeader.BuilderParams<HeaderBuilder>, Builder<Header> {
     }
 
@@ -1117,9 +1120,11 @@ public final class Jwts {
      * @return a new {@link HeaderBuilder} that can build any type of {@link Header} instance depending on
      * which builder properties are set.
      * @since 0.12.0
+     * @deprecated since JJWT_RELEASE_VERSION in favor of {@link Jwt#header()}.
      */
+    @Deprecated
     public static HeaderBuilder header() {
-        return Suppliers.HEADER_BUILDER_SUPPLIER.get();
+        return Suppliers.JWTS_HEADER_BUILDER_SUPPLIER.get();
     }
 
     /**

--- a/api/src/main/java/io/jsonwebtoken/Jwts.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwts.java
@@ -1102,8 +1102,6 @@ public final class Jwts {
         }
     }
 
-
-
     /**
      * A {@link Builder} that dynamically determines the type of {@link Header} to create based on builder state.
      *
@@ -1173,7 +1171,7 @@ public final class Jwts {
      */
     @Deprecated
     public static JwtParserBuilder parser() {
-        return Suppliers.JWT_PARSER_BUILDER_SUPPLIER.get();
+        return Jwt.parser();
     }
 
     /**

--- a/api/src/main/java/io/jsonwebtoken/Jwts.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwts.java
@@ -1163,9 +1163,11 @@ public final class Jwts {
      *
      * @return a new {@link JwtBuilder} instance that can be configured and then used to create JWT compact serialized
      * strings.
+     * @deprecated since JJWT_RELEASE_VERSION in favor of {@link Jwt#builder()}
      */
+    @Deprecated
     public static JwtBuilder builder() {
-        return Suppliers.JWT_BUILDER_SUPPLIER.get();
+        return Jwt.builder();
     }
 
     /**

--- a/api/src/main/java/io/jsonwebtoken/Jwts.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwts.java
@@ -42,12 +42,15 @@ import java.util.Map;
  * algorithm type. Each organized collection of algorithms is available via a constant to allow
  * for easy code-completion in IDEs, showing available algorithm instances.  For example, when typing:</p>
  * <blockquote><pre>
- * Jwts.// press code-completion hotkeys to suggest available algorithm registry fields
  * {@link Jws.alg Jws.alg}.// press hotkeys to suggest individual Digital Signature or MAC algorithms or utility methods
  * {@link Jwe.alg Jwe.alg}.// press hotkeys to suggest individual key management algorithms or utility methods
- * {@link Jwe.enc Jwe.enc}.// press hotkeys to suggest individual encryption algorithms or utility methods</pre></blockquote>
+ * {@link Jwe.enc Jwe.enc}.// press hotkeys to suggest individual encryption algorithms or utility methods
+ * {@link Jwe.zip Jwe.zip}.// press hotkeys to suggest individual compression algorithms or utility methods</pre></blockquote>
  *
  * @since 0.1
+ * @deprecated since JJWT_RELEASE_VERSION in favor of respective interface static registries
+ * ({@link Jws.alg}, {@link Jwe.alg}, {@link Jwe.enc}, {@link Jwe.zip}) and static factory methods
+ * ({@link Jwt#builder()}, {@link Jwt#parser()}, {@link Jwt#header()}, {@link Claims#builder()}).
  */
 public final class Jwts {
 
@@ -58,7 +61,7 @@ public final class Jwts {
      * Web Signature and Encryption Algorithms Registry</a>. Each standard algorithm is available as a
      * ({@code public static final}) constant for direct type-safe reference in application code. For example:
      * <blockquote><pre>
-     * Jwts.builder()
+     * Jwt.builder()
      *    // ... etc ...
      *    .encryptWith(aKey, <b>Jwe.enc.A256GCM</b>) // or A128GCM, A192GCM, etc...
      *    .build();</pre></blockquote>
@@ -158,7 +161,7 @@ public final class Jwts {
      * Registry</a>. Each standard algorithm is available as a ({@code public static final}) constant for
      * direct type-safe reference in application code. For example:
      * <blockquote><pre>
-     * Jwts.builder()
+     * Jwt.builder()
      *    // ... etc ...
      *    .signWith(aKey, <b>Jws.alg.HS512</b>) // or RS512, PS256, EdDSA, etc...
      *    .build();</pre></blockquote>
@@ -363,7 +366,7 @@ public final class Jwts {
      * Cryptographic Algorithms for Key Management</a>. Each standard algorithm is available as a
      * ({@code public static final}) constant for direct type-safe reference in application code. For example:
      * <blockquote><pre>
-     * Jwts.builder()
+     * Jwt.builder()
      *    // ... etc ...
      *    .encryptWith(aKey, <b>Jwe.alg.ECDH_ES_A256KW</b>, Jwe.enc.A256GCM)
      *    .build();</pre></blockquote>
@@ -1043,7 +1046,7 @@ public final class Jwts {
      * Registry</a>. Each algorithm is available as a ({@code public static final}) constant for
      * direct type-safe reference in application code. For example:
      * <blockquote><pre>
-     * Jwts.builder()
+     * Jwt.builder()
      *    // ... etc ...
      *    .compressWith(<b>Jwe.zip.DEF</b>)
      *    .build();</pre></blockquote>

--- a/api/src/main/java/io/jsonwebtoken/Jwts.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwts.java
@@ -52,6 +52,7 @@ import java.util.Map;
  * ({@link Jws.alg}, {@link Jwe.alg}, {@link Jwe.enc}, {@link Jwe.zip}) and static factory methods
  * ({@link Jwt#builder()}, {@link Jwt#parser()}, {@link Jwt#header()}, {@link Claims#builder()}).
  */
+@Deprecated
 public final class Jwts {
 
     /**

--- a/api/src/main/java/io/jsonwebtoken/Jwts.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwts.java
@@ -51,12 +51,6 @@ import java.util.Map;
  */
 public final class Jwts {
 
-    // do not change this visibility.  Raw type method signature must not be publicly exposed:
-    @SuppressWarnings("unchecked")
-    static <T> T get(Registry<String, ?> registry, String id) {
-        return (T) registry.forKey(id);
-    }
-
     /**
      * Constants for all standard JWA
      * <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-5">Cryptographic Algorithms for Content

--- a/api/src/main/java/io/jsonwebtoken/Jwts.java
+++ b/api/src/main/java/io/jsonwebtoken/Jwts.java
@@ -17,7 +17,6 @@ package io.jsonwebtoken;
 
 import io.jsonwebtoken.io.CompressionAlgorithm;
 import io.jsonwebtoken.lang.Builder;
-import io.jsonwebtoken.lang.Classes;
 import io.jsonwebtoken.lang.Registry;
 import io.jsonwebtoken.security.AeadAlgorithm;
 import io.jsonwebtoken.security.KeyAlgorithm;
@@ -27,14 +26,12 @@ import io.jsonwebtoken.security.Password;
 import io.jsonwebtoken.security.SecretKeyAlgorithm;
 import io.jsonwebtoken.security.SecureDigestAlgorithm;
 import io.jsonwebtoken.security.SignatureAlgorithm;
-import io.jsonwebtoken.security.X509Builder;
 
 import javax.crypto.SecretKey;
 import java.security.Key;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.Map;
-import java.util.function.Supplier;
 
 /**
  * Factory class useful for creating instances of JWT interfaces.  Using this factory class can be a good
@@ -1111,28 +1108,14 @@ public final class Jwts {
         }
     }
 
-    // @since 0.12.7
-    private static final Supplier<JwtBuilder> JWT_BUILDER_SUPPLIER =
-            Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtBuilder$Supplier");
 
-    // @since 0.12.7
-    private static final Supplier<JwtParserBuilder> JWT_PARSER_BUILDER_SUPPLIER =
-            Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtParserBuilder$Supplier");
-
-    // @since 0.12.7
-    private static final Supplier<HeaderBuilder> HEADER_BUILDER_SUPPLIER =
-            Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtHeaderBuilder$Supplier");
-
-    // @since 0.12.7
-    private static final Supplier<ClaimsBuilder> CLAIMS_BUILDER_SUPPLIER =
-            Classes.newInstance("io.jsonwebtoken.impl.DefaultClaimsBuilder$Supplier");
 
     /**
      * A {@link Builder} that dynamically determines the type of {@link Header} to create based on builder state.
      *
      * @since 0.12.0
      */
-    public interface HeaderBuilder extends JweHeaderMutator<HeaderBuilder>, X509Builder<HeaderBuilder>, Builder<Header> {
+    public interface HeaderBuilder extends JweHeader.BuilderParams<HeaderBuilder>, Builder<Header> {
     }
 
     /**
@@ -1144,7 +1127,7 @@ public final class Jwts {
      * @since 0.12.0
      */
     public static HeaderBuilder header() {
-        return HEADER_BUILDER_SUPPLIER.get();
+        return Suppliers.HEADER_BUILDER_SUPPLIER.get();
     }
 
     /**
@@ -1153,26 +1136,28 @@ public final class Jwts {
      *
      * @return a new {@link Claims} builder instance to be used to populate JWT claims, which in aggregate will be
      * the JWT payload.
+     * @deprecated since JJWT_RELEASE_VERSION in favor of {@link Claims#builder()}
      */
+    @Deprecated
     public static ClaimsBuilder claims() {
-        return CLAIMS_BUILDER_SUPPLIER.get();
+        return Claims.builder();
     }
 
     /**
      * <p><b>Deprecated since 0.12.0 in favor of
-     * {@code Jwts.}{@link #claims()}{@code .add(map).build()}</b>.
+     * {@link Claims#builder()}{@code .add(map).build()}</b>.
      * This method will be removed before 1.0.</p>
      *
      * <p>Returns a new {@link Claims} instance populated with the specified name/value pairs.</p>
      *
      * @param claims the name/value pairs to populate the new Claims instance.
      * @return a new {@link Claims} instance populated with the specified name/value pairs.
-     * @deprecated since 0.12.0 in favor of {@code Jwts.}{@link #claims()}{@code .putAll(map).build()}.
+     * @deprecated since 0.12.0 in favor of {@link Claims#builder()}{@code .add(map).build()}.
      * This method will be removed before 1.0.
      */
     @Deprecated
     public static Claims claims(Map<String, Object> claims) {
-        return claims().add(claims).build();
+        return Claims.builder().add(claims).build();
     }
 
     /**
@@ -1183,16 +1168,18 @@ public final class Jwts {
      * strings.
      */
     public static JwtBuilder builder() {
-        return JWT_BUILDER_SUPPLIER.get();
+        return Suppliers.JWT_BUILDER_SUPPLIER.get();
     }
 
     /**
      * Returns a new {@link JwtParserBuilder} instance that can be configured to create an immutable/thread-safe {@link JwtParser}.
      *
      * @return a new {@link JwtParserBuilder} instance that can be configured create an immutable/thread-safe {@link JwtParser}.
+     * @deprecated since JJWT_RELEASE_VERSION in favor of {@link Jwt#parser()}.
      */
+    @Deprecated
     public static JwtParserBuilder parser() {
-        return JWT_PARSER_BUILDER_SUPPLIER.get();
+        return Suppliers.JWT_PARSER_BUILDER_SUPPLIER.get();
     }
 
     /**

--- a/api/src/main/java/io/jsonwebtoken/SigningKeyResolver.java
+++ b/api/src/main/java/io/jsonwebtoken/SigningKeyResolver.java
@@ -27,7 +27,7 @@ import java.security.Key;
  * example:</p>
  *
  * <pre>
- * Jws&lt;Claims&gt; jws = Jwts.parser().setSigningKeyResolver(new SigningKeyResolverAdapter() {
+ * Jws&lt;Claims&gt; jws = Jwt.parser().setSigningKeyResolver(new SigningKeyResolverAdapter() {
  *         &#64;Override
  *         public byte[] resolveSigningKeyBytes(JwsHeader header, Claims claims) {
  *             //inspect the header or claims, lookup and return the signing key

--- a/api/src/main/java/io/jsonwebtoken/Suppliers.java
+++ b/api/src/main/java/io/jsonwebtoken/Suppliers.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2026 jsonwebtoken.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.jsonwebtoken;
+
+import io.jsonwebtoken.lang.Classes;
+
+import java.util.function.Supplier;
+
+/**
+ * Package-private on purpose - this is for internal utility use only, see
+ * <a href="https://github.com/jwtk/jjwt/issues/988">Issue 988</a> for why this class is necessary.
+ *
+ * @see <a href="https://github.com/jwtk/jjwt/issues/988">Issue 988</a>.
+ * @since JJWT_RELEASE_VERSION
+ */
+// MAINTAINER NOTE: Do not change this class's visibility modifiers - it is not to be exposed in the public API.
+final class Suppliers {
+
+    static final Supplier<JwtBuilder> JWT_BUILDER_SUPPLIER =
+            Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtBuilder$Supplier");
+
+    static final Supplier<JwtParserBuilder> JWT_PARSER_BUILDER_SUPPLIER =
+            Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtParserBuilder$Supplier");
+
+    static final Supplier<Jwts.HeaderBuilder> HEADER_BUILDER_SUPPLIER =
+            Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtHeaderBuilder$Supplier");
+
+    static final Supplier<ClaimsBuilder> CLAIMS_BUILDER_SUPPLIER =
+            Classes.newInstance("io.jsonwebtoken.impl.DefaultClaimsBuilder$Supplier");
+
+    private Suppliers() { // for coverage
+    }
+}

--- a/api/src/main/java/io/jsonwebtoken/Suppliers.java
+++ b/api/src/main/java/io/jsonwebtoken/Suppliers.java
@@ -16,6 +16,7 @@
 package io.jsonwebtoken;
 
 import io.jsonwebtoken.lang.Classes;
+import io.jsonwebtoken.lang.Registry;
 
 import java.util.function.Supplier;
 
@@ -42,5 +43,11 @@ final class Suppliers {
             Classes.newInstance("io.jsonwebtoken.impl.DefaultClaimsBuilder$Supplier");
 
     private Suppliers() { // for coverage
+    }
+
+    // do not change this visibility.  Raw type method signature must not be publicly exposed:
+    @SuppressWarnings("unchecked")
+    static <T> T get(Registry<String, ?> registry, String id) {
+        return (T) registry.forKey(id);
     }
 }

--- a/api/src/main/java/io/jsonwebtoken/Suppliers.java
+++ b/api/src/main/java/io/jsonwebtoken/Suppliers.java
@@ -36,8 +36,12 @@ final class Suppliers {
     static final Supplier<JwtParserBuilder> JWT_PARSER_BUILDER_SUPPLIER =
             Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtParserBuilder$Supplier");
 
-    static final Supplier<Jwts.HeaderBuilder> HEADER_BUILDER_SUPPLIER =
+    static final Supplier<Jwt.HeaderBuilder> HEADER_BUILDER_SUPPLIER =
             Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtHeaderBuilder$Supplier");
+
+    @SuppressWarnings("deprecation")
+    static final Supplier<Jwts.HeaderBuilder> JWTS_HEADER_BUILDER_SUPPLIER =
+            Classes.newInstance("io.jsonwebtoken.impl.DefaultJwtsHeaderBuilder$Supplier");
 
     static final Supplier<ClaimsBuilder> CLAIMS_BUILDER_SUPPLIER =
             Classes.newInstance("io.jsonwebtoken.impl.DefaultClaimsBuilder$Supplier");

--- a/api/src/main/java/io/jsonwebtoken/security/Keys.java
+++ b/api/src/main/java/io/jsonwebtoken/security/Keys.java
@@ -288,9 +288,11 @@ public final class Keys {
      * @return a new {@code SecretKeyBuilder} that produces the specified key, potentially associated with any
      * specified provider.
      * @since 0.12.0
+     * @deprecated since JJWT_RELEASE_VERSION in favor of {@link SecretKeyBuilder#with(SecretKey)}
      */
+    @Deprecated
     public static SecretKeyBuilder builder(SecretKey key) {
-        return Suppliers.SECRET_KEY_BUILDER_FACTORY.apply(key);
+        return SecretKeyBuilder.with(key);
     }
 
     /**
@@ -314,7 +316,9 @@ public final class Keys {
      * @return a new {@code PrivateKeyBuilder} that produces the specified private key, potentially associated with any
      * specified provider or {@code PublicKey}
      * @since 0.12.0
+     * @deprecated since JJWT_RELEASE_VERSION in favor of {@link PrivateKeyBuilder#with(PrivateKey)}
      */
+    @Deprecated
     public static PrivateKeyBuilder builder(PrivateKey key) {
         return Suppliers.PRIVATE_KEY_BUILDER_FACTORY.apply(key);
     }

--- a/api/src/main/java/io/jsonwebtoken/security/PrivateKeyBuilder.java
+++ b/api/src/main/java/io/jsonwebtoken/security/PrivateKeyBuilder.java
@@ -28,6 +28,32 @@ import java.security.PublicKey;
 public interface PrivateKeyBuilder extends KeyBuilder<PrivateKey, PrivateKeyBuilder> {
 
     /**
+     * Returns a {@code PrivateKeyBuilder} that produces the specified key, allowing association with a
+     * {@link PrivateKeyBuilder#publicKey(PublicKey) publicKey} to obtain public key data if necessary, or a
+     * {@link SecretKeyBuilder#provider(Provider) provider} that must be used with the key during cryptographic
+     * operations.  For example:
+     *
+     * <blockquote><pre>
+     * PrivateKey key = Keys.builder(privateKey).publicKey(publicKey).provider(mandatoryProvider).build();</pre></blockquote>
+     *
+     * <p>Cryptographic algorithm implementations can inspect the resulting {@code key} instance and obtain its
+     * mandatory {@code Provider} or {@code PublicKey} if necessary.</p>
+     *
+     * <p>This method is primarily only useful for keys that cannot expose key material, such as PKCS11 or HSM
+     * (Hardware Security Module) keys, and require a specific {@code Provider} or public key data to be used
+     * during cryptographic operations.</p>
+     *
+     * @param key the private key to use for cryptographic operations, potentially associated with a configured
+     *            {@link Provider} or {@link PublicKey}.
+     * @return a new {@code PrivateKeyBuilder} that produces the specified private key, potentially associated with any
+     * specified provider or {@code PublicKey}
+     * @since JJWT_RELEASE_VERSION
+     */
+    static PrivateKeyBuilder with(PrivateKey key) {
+        return Suppliers.PRIVATE_KEY_BUILDER_FACTORY.apply(key);
+    }
+
+    /**
      * Sets the private key's corresponding {@code PublicKey} so that its public key material will be available to
      * algorithms that require it.
      *

--- a/api/src/main/java/io/jsonwebtoken/security/SecretKeyBuilder.java
+++ b/api/src/main/java/io/jsonwebtoken/security/SecretKeyBuilder.java
@@ -16,6 +16,7 @@
 package io.jsonwebtoken.security;
 
 import javax.crypto.SecretKey;
+import java.security.Provider;
 
 /**
  * A {@link KeyBuilder} that creates new secure-random {@link SecretKey}s with a length sufficient to be used by
@@ -24,4 +25,29 @@ import javax.crypto.SecretKey;
  * @since 0.12.0
  */
 public interface SecretKeyBuilder extends KeyBuilder<SecretKey, SecretKeyBuilder> {
+
+    /**
+     * Returns a {@code SecretKeyBuilder} that produces the specified key, allowing association with a
+     * {@link SecretKeyBuilder#provider(Provider) provider} that must be used with the key during cryptographic
+     * operations.  For example:
+     *
+     * <blockquote><pre>
+     * SecretKey key = SecretKeyBuilder.with(key).provider(mandatoryProvider).build();</pre></blockquote>
+     *
+     * <p>Cryptographic algorithm implementations can inspect the resulting {@code key} instance and obtain its
+     * mandatory {@code Provider} if necessary.</p>
+     *
+     * <p>This method is primarily only useful for keys that cannot expose key material, such as PKCS11 or HSM
+     * (Hardware Security Module) keys, and require a specific {@code Provider} to be used during cryptographic
+     * operations.</p>
+     *
+     * @param key the secret key to use for cryptographic operations, potentially associated with a configured
+     *            {@link Provider}
+     * @return a new {@code SecretKeyBuilder} that produces the specified key, potentially associated with any
+     * specified provider.
+     * @since JJWT_RELEASE_VERSION
+     */
+    static SecretKeyBuilder with(SecretKey key) {
+        return Suppliers.SECRET_KEY_BUILDER_FACTORY.apply(key);
+    }
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/AbstractJwtHeaderBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/AbstractJwtHeaderBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2026 jsonwebtoken.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.jsonwebtoken.impl;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.JweHeader;
+import io.jsonwebtoken.lang.Builder;
+import io.jsonwebtoken.lang.Collections;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+abstract class AbstractJwtHeaderBuilder<T extends JweHeader.BuilderParams<T>> extends DefaultJweHeaderBuilder<T>
+        implements JweHeader.BuilderParams<T>, Builder<Header> {
+
+    public AbstractJwtHeaderBuilder() {
+        super();
+    }
+
+    public AbstractJwtHeaderBuilder(DefaultJweHeaderMutator<?> src) {
+        super(src);
+    }
+
+    // Per https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.11 and
+    // https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.13, 'crit' values MUST NOT include:
+    //
+    // 1. Any header parameter names defined in the JWS or JWE specifications
+    // 2. Any header parameter names that are not included in the final header
+    private static ParameterMap sanitizeCrit(ParameterMap m, boolean protectedHeader) {
+        Set<String> crit = m.get(DefaultProtectedHeader.CRIT);
+        if (crit == null) return m; // nothing to do
+
+        //Use a copy constructor to ensure subsequent changes to builder state do not change the constructed header:
+        m = new ParameterMap(DefaultJweHeader.PARAMS, m, true);
+        m.remove(DefaultProtectedHeader.CRIT.getId()); // remove the unsanitized value
+
+        // Per https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.11, non-protected headers are not allowed to
+        // have a 'crit' header parameter, so we're done, exit early:
+        if (!protectedHeader) return m;
+
+        //otherwise we have a protected header (JWS or JWE), so remove unnecessary entries per the RFC sections above:
+        Set<String> newCrit = new LinkedHashSet<>(crit);
+        for (String val : crit) {
+            if (DefaultJweHeader.PARAMS.containsKey(val) || // Defined in JWS or JWE spec, can't be in crit set (#1)
+                    !m.containsKey(val)) { // not in the actual header, can't be in crit set either (#2)
+                newCrit.remove(val);
+            }
+        }
+        if (!Collections.isEmpty(newCrit)) { // we have a sanitized result per the RFC, so apply it:
+            m.put(DefaultProtectedHeader.CRIT, newCrit);
+        }
+        return m;
+    }
+
+    @Override
+    public Header build() {
+
+        this.x509.apply(); // apply any X.509 values as necessary based on builder state
+
+        ParameterMap m = this.DELEGATE;
+
+        // Note: conditional sequence matters here: JWE has more specific requirements than JWS, so check that first:
+        if (DefaultJweHeader.isCandidate(m)) {
+            return new DefaultJweHeader(sanitizeCrit(m, true));
+        } else if (DefaultProtectedHeader.isCandidate(m)) {
+            return new DefaultJwsHeader(sanitizeCrit(m, true));
+        } else {
+            // Per https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.11, 'crit' header is not allowed in
+            // non-protected headers:
+            return new DefaultHeader(sanitizeCrit(m, false));
+        }
+    }
+}

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParser.java
@@ -30,7 +30,6 @@ import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.JwtHandler;
 import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.Locator;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.MissingClaimException;
@@ -235,7 +234,7 @@ public class DefaultJwtParser extends AbstractParser<Jwt<?, ?>> implements JwtPa
         this.clock = Assert.notNull(clock, "Clock cannot be null.");
         this.critical = Collections.nullSafe(critical);
         this.allowedClockSkewMillis = allowedClockSkewMillis;
-        this.expectedClaims = Jwts.claims().add(expectedClaims);
+        this.expectedClaims = Claims.builder().add(expectedClaims);
         this.decoder = Assert.notNull(base64UrlDecoder, "base64UrlDecoder cannot be null.");
         this.deserializer = Assert.notNull(deserializer, "JSON Deserializer cannot be null.");
         this.sigAlgs = new IdLocator<>(DefaultHeader.ALGORITHM, sigAlgs, "mac or signature", "signature verification", MISSING_JWS_ALG_MSG);

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParserBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParserBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.jsonwebtoken.impl;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ClaimsBuilder;
 import io.jsonwebtoken.Clock;
 import io.jsonwebtoken.CompressionCodecResolver;
@@ -22,7 +23,6 @@ import io.jsonwebtoken.Jwe;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.JwtParserBuilder;
-import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.Locator;
 import io.jsonwebtoken.SigningKeyResolver;
 import io.jsonwebtoken.impl.io.DelegateStringDecoder;
@@ -103,7 +103,7 @@ public class DefaultJwtParserBuilder implements JwtParserBuilder {
 
     private Deserializer<Map<String, ?>> deserializer;
 
-    private final ClaimsBuilder expectedClaims = Jwts.claims();
+    private final ClaimsBuilder expectedClaims = Claims.builder();
 
     private Clock clock = DefaultClock.INSTANCE;
 

--- a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtsHeaderBuilder.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtsHeaderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 jsonwebtoken.io
+ * Copyright © 2026 jsonwebtoken.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,28 +15,22 @@
  */
 package io.jsonwebtoken.impl;
 
-import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.Jwts;
 
-/**
- * @since 0.12.0
- */
-public class DefaultJwtHeaderBuilder extends AbstractJwtHeaderBuilder<Jwt.HeaderBuilder>
-        implements Jwt.HeaderBuilder {
+@SuppressWarnings({"unused", "deprecation"})
+public class DefaultJwtsHeaderBuilder extends AbstractJwtHeaderBuilder<Jwts.HeaderBuilder>
+        implements Jwts.HeaderBuilder {
 
-    public DefaultJwtHeaderBuilder() {
+    public DefaultJwtsHeaderBuilder() {
         super();
     }
 
-    public DefaultJwtHeaderBuilder(DefaultJweHeaderMutator<?> src) {
-        super(src);
-    }
-
     // @since 0.12.7 per https://github.com/jwtk/jjwt/issues/988
-    @SuppressWarnings("unused") // used via reflection in the api module's Jwts class.
-    public static final class Supplier implements java.util.function.Supplier<Jwt.HeaderBuilder> {
+    @SuppressWarnings("unused") // used via reflection in io.jsonwebtoken.Suppliers.
+    public static final class Supplier implements java.util.function.Supplier<Jwts.HeaderBuilder> {
         @Override
-        public Jwt.HeaderBuilder get() {
-            return new DefaultJwtHeaderBuilder();
+        public Jwts.HeaderBuilder get() {
+            return new DefaultJwtsHeaderBuilder();
         }
     }
 }

--- a/impl/src/main/java/io/jsonwebtoken/impl/io/StandardCompressionAlgorithms.java
+++ b/impl/src/main/java/io/jsonwebtoken/impl/io/StandardCompressionAlgorithms.java
@@ -21,7 +21,7 @@ import io.jsonwebtoken.impl.lang.IdRegistry;
 import io.jsonwebtoken.io.CompressionAlgorithm;
 import io.jsonwebtoken.lang.Collections;
 
-@SuppressWarnings("unused") // used via reflection in io.jsonwebtoken.Jwts.ZIP
+@SuppressWarnings("unused") // used via reflection in io.jsonwebtoken.security.Suppliers
 public final class StandardCompressionAlgorithms extends IdRegistry<CompressionAlgorithm> {
 
     public static final String NAME = "Compression Algorithm";

--- a/impl/src/test/groovy/io/jsonwebtoken/CustomObjectDeserializationTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/CustomObjectDeserializationTest.groovy
@@ -33,7 +33,7 @@ class CustomObjectDeserializationTest {
         customBean.key1 = "value1"
         customBean.key2 = 42
 
-        String jwtString = Jwts.builder().claim("cust", customBean).compact()
+        String jwtString = Jwt.builder().claim("cust", customBean).compact()
 
         // no custom deserialization, object is a map
         Jwt<Header, Claims> jwt = Jwt.parser().unsecured().build().parseUnsecuredClaims(jwtString)

--- a/impl/src/test/groovy/io/jsonwebtoken/CustomObjectDeserializationTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/CustomObjectDeserializationTest.groovy
@@ -36,13 +36,13 @@ class CustomObjectDeserializationTest {
         String jwtString = Jwts.builder().claim("cust", customBean).compact()
 
         // no custom deserialization, object is a map
-        Jwt<Header, Claims> jwt = Jwts.parser().unsecured().build().parseUnsecuredClaims(jwtString)
+        Jwt<Header, Claims> jwt = Jwt.parser().unsecured().build().parseUnsecuredClaims(jwtString)
         assertNotNull jwt
         assertEquals jwt.getPayload().get('cust'), [key1: 'value1', key2: 42]
 
         // custom type for 'cust' claim
         def des = new JacksonDeserializer([cust: CustomBean])
-        jwt = Jwts.parser().unsecured().json(des).build().parseUnsecuredClaims(jwtString)
+        jwt = Jwt.parser().unsecured().json(des).build().parseUnsecuredClaims(jwtString)
         assertNotNull jwt
         CustomBean result = jwt.getPayload().get("cust", CustomBean)
         assertEquals customBean, result

--- a/impl/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
@@ -55,12 +55,12 @@ class JwtParserTest {
 
     @Test
     void testIsSignedWithNullArgument() {
-        assertFalse Jwts.parser().build().isSigned(null)
+        assertFalse Jwt.parser().build().isSigned(null)
     }
 
     @Test
     void testIsSignedWithJunkArgument() {
-        assertFalse Jwts.parser().build().isSigned('hello')
+        assertFalse Jwt.parser().build().isSigned('hello')
     }
 
     @Test
@@ -72,7 +72,7 @@ class JwtParserTest {
         String bad = base64Url('{"alg":"none"}') + '.' + base64Url(junkPayload) + '.'
 
         // Can't be treated as claims, so payload must be treated as a byte array:
-        assertArrayEquals bytes, Jwts.parser().unsecured().build().parse(bad).getPayload() as byte[]
+        assertArrayEquals bytes, Jwt.parser().unsecured().build().parse(bad).getPayload() as byte[]
     }
 
     @Test
@@ -83,7 +83,7 @@ class JwtParserTest {
         String bad = base64Url('{"alg":"none"}') + '.' + base64Url(junkPayload) + '.'
 
         try {
-            Jwts.parser().unsecured().build().parseUnsecuredClaims(bad)
+            Jwt.parser().unsecured().build().parseUnsecuredClaims(bad)
             fail()
         } catch (UnsupportedJwtException expected) {
             String msg = 'Unexpected unsecured content JWT.'
@@ -105,7 +105,7 @@ class JwtParserTest {
         String bad = base64Url(header) + '.' + base64Url(payload) + '.' + base64Url(badSig)
 
         try {
-            Jwts.parser().setSigningKey(randomKey()).build().parse(bad)
+            Jwt.parser().setSigningKey(randomKey()).build().parse(bad)
             fail()
         } catch (SignatureException se) {
             String msg = "Unsupported signature algorithm '$badAlgorithmName': " +
@@ -126,7 +126,7 @@ class JwtParserTest {
         String bad = base64Url(header) + '.' + base64Url(payload) + '.' + base64Url(badSig)
 
         try {
-            Jwts.parser().setSigningKey(randomKey()).build().parse(bad)
+            Jwt.parser().setSigningKey(randomKey()).build().parse(bad)
             fail()
         } catch (SignatureException se) {
             assertEquals se.getMessage(), 'JWT signature does not match locally computed signature. JWT validity cannot be asserted and should not be trusted.'
@@ -146,7 +146,7 @@ class JwtParserTest {
         String bad = base64Url(header) + '.' + base64Url(payload) + '.' + base64Url(badSig)
 
         try {
-            Jwts.parser().unsecured().setSigningKey(randomKey()).build().parse(bad)
+            Jwt.parser().unsecured().setSigningKey(randomKey()).build().parse(bad)
             fail()
         } catch (MalformedJwtException se) {
             assertEquals 'The JWS header references signature algorithm \'none\' yet the compact JWS string contains a signature. This is not permitted per https://tools.ietf.org/html/rfc7518#section-3.6.', se.getMessage()
@@ -164,7 +164,7 @@ class JwtParserTest {
         def payload = '{"subject":"Joe"}'
         String unsecured = base64Url(header) + '.' + base64Url(payload) + '.'
         try {
-            Jwts.parser().build().parse(unsecured)
+            Jwt.parser().build().parse(unsecured)
             fail()
         } catch (UnsupportedJwtException expected) {
             String msg = DefaultJwtParser.UNSECURED_DISABLED_MSG_PREFIX + '{alg=none}'
@@ -184,9 +184,9 @@ class JwtParserTest {
         //noinspection GrDeprecatedAPIUsage
         String compact = Jwts.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, base64Encodedkey).compact()
 
-        assertTrue Jwts.parser().build().isSigned(compact)
+        assertTrue Jwt.parser().build().isSigned(compact)
 
-        def jwt = Jwts.parser().setSigningKey(base64Encodedkey).build().parse(compact)
+        def jwt = Jwt.parser().setSigningKey(base64Encodedkey).build().parse(compact)
 
         assertEquals payload, new String(jwt.payload as byte[], StandardCharsets.UTF_8)
     }
@@ -199,9 +199,9 @@ class JwtParserTest {
 
         String compact = Jwts.builder().setPayload(payload).signWith(key).compact()
 
-        assertTrue Jwts.parser().build().isSigned(compact)
+        assertTrue Jwt.parser().build().isSigned(compact)
 
-        def jwt = Jwts.parser().setSigningKey(key).build().parse(compact)
+        def jwt = Jwt.parser().setSigningKey(key).build().parse(compact)
 
         assertEquals payload, new String(jwt.payload as byte[], StandardCharsets.UTF_8)
     }
@@ -210,16 +210,16 @@ class JwtParserTest {
     void testParseNullPayload() {
         SecretKey key = Keys.secretKeyFor(SignatureAlgorithm.HS256)
         String compact = Jwts.builder().signWith(key).compact()
-        assertTrue Jwts.parser().build().isSigned(compact)
+        assertTrue Jwt.parser().build().isSigned(compact)
 
-        def jwt = Jwts.parser().setSigningKey(key).build().parse(compact)
+        def jwt = Jwt.parser().setSigningKey(key).build().parse(compact)
         assertEquals '', new String(jwt.payload as byte[], StandardCharsets.UTF_8)
     }
 
     @Test
     void testParseNullPayloadWithoutKey() {
         String compact = Jwts.builder().compact()
-        def jwt = Jwts.parser().unsecured().build().parse(compact)
+        def jwt = Jwt.parser().unsecured().build().parse(compact)
         assertEquals 'none', jwt.header.alg
         assertEquals '', new String(jwt.payload as byte[], StandardCharsets.UTF_8)
     }
@@ -236,7 +236,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setSubject('Joe').setExpiration(exp).compact()
 
         try {
-            Jwts.parser().unsecured().setClock(fixedClock).build().parse(compact)
+            Jwt.parser().unsecured().setClock(fixedClock).build().parse(compact)
             fail()
         } catch (ExpiredJwtException e) {
             // https://github.com/jwtk/jjwt/issues/107 (the Z designator at the end of the timestamp):
@@ -257,7 +257,7 @@ class JwtParserTest {
         String compact = Jwts.builder().subject('Joe').notBefore(nbf).compact()
 
         try {
-            Jwts.parser().unsecured().clock(new FixedClock(earlier)).build().parse(compact)
+            Jwt.parser().unsecured().clock(new FixedClock(earlier)).build().parse(compact)
             fail()
         } catch (PrematureJwtException e) {
             def nbf8601 = DateFormats.formatIso8601(nbf, true)
@@ -288,7 +288,7 @@ class JwtParserTest {
         String subject = 'Joe'
         String compact = Jwts.builder().subject(subject).expiration(exp).compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().unsecured().setAllowedClockSkewSeconds(10)
+        Jwt<Header, Claims> jwt = Jwt.parser().unsecured().setAllowedClockSkewSeconds(10)
                 .clock(new FixedClock(later)).build().parse(compact)
 
         assertEquals jwt.getPayload().getSubject(), subject
@@ -306,7 +306,7 @@ class JwtParserTest {
         def skewSeconds = 1
 
         try {
-            Jwts.parser().unsecured().setAllowedClockSkewSeconds(skewSeconds)
+            Jwt.parser().unsecured().setAllowedClockSkewSeconds(skewSeconds)
                     .clock(new FixedClock(later)).build().parse(s)
             fail()
         } catch (ExpiredJwtException e) {
@@ -325,7 +325,7 @@ class JwtParserTest {
         String subject = 'Joe'
         String compact = Jwts.builder().setSubject(subject).setNotBefore(exp).compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().unsecured().setAllowedClockSkewSeconds(10).build().parse(compact)
+        Jwt<Header, Claims> jwt = Jwt.parser().unsecured().setAllowedClockSkewSeconds(10).build().parse(compact)
 
         assertEquals jwt.getPayload().getSubject(), subject
     }
@@ -342,7 +342,7 @@ class JwtParserTest {
         def skewSeconds = 1
 
         try {
-            Jwts.parser().unsecured()
+            Jwt.parser().unsecured()
                     .setAllowedClockSkewSeconds(skewSeconds).clock(new FixedClock(earlier))
                     .build().parse(compact)
             fail()
@@ -366,7 +366,7 @@ class JwtParserTest {
 
         String compact = Jwts.builder().setPayload(payload).compact()
 
-        def jwt = Jwts.parser().unsecured().build().parseUnsecuredContent(compact)
+        def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
 
         assertEquals payload, new String(jwt.payload, StandardCharsets.UTF_8)
     }
@@ -377,7 +377,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setSubject('Joe').compact()
 
         try {
-            Jwts.parser().unsecured().build().parseUnsecuredContent(compact)
+            Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             assertEquals 'Unexpected unsecured Claims JWT.', e.getMessage()
@@ -392,7 +392,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, randomKey()).compact()
 
         try {
-            Jwts.parser().build().parseUnsecuredContent(compact)
+            Jwt.parser().build().parseUnsecuredContent(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             assertEquals 'Cannot verify JWS signature: unable to locate signature verification key for JWS with header: {alg=HS256}', e.getMessage()
@@ -406,7 +406,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setSubject('Joe').signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
-            Jwts.parser().setSigningKey(key).build().parseSignedContent(compact)
+            Jwt.parser().setSigningKey(key).build().parseSignedContent(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             assertEquals 'Unexpected Claims JWS.', e.getMessage()
@@ -424,7 +424,7 @@ class JwtParserTest {
 
         String compact = Jwts.builder().setSubject(subject).compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().unsecured().build().parseUnsecuredClaims(compact)
+        Jwt<Header, Claims> jwt = Jwt.parser().unsecured().build().parseUnsecuredClaims(compact)
 
         assertEquals jwt.getPayload().getSubject(), subject
     }
@@ -437,7 +437,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setPayload(payload).compact()
 
         try {
-            Jwts.parser().unsecured().build().parseUnsecuredClaims(compact)
+            Jwt.parser().unsecured().build().parseUnsecuredClaims(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             assertEquals 'Unexpected unsecured content JWT.', e.getMessage()
@@ -452,7 +452,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, randomKey()).compact()
 
         try {
-            Jwts.parser().build().parseUnsecuredClaims(compact)
+            Jwt.parser().build().parseUnsecuredClaims(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             assertEquals 'Cannot verify JWS signature: unable to locate signature verification key for JWS with header: {alg=HS256}', e.getMessage()
@@ -466,7 +466,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setSubject('Joe').signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
-            Jwts.parser().setSigningKey(key).build().parseUnsecuredClaims(compact)
+            Jwt.parser().setSigningKey(key).build().parseUnsecuredClaims(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             assertEquals 'Unexpected Claims JWS.', e.getMessage()
@@ -486,7 +486,7 @@ class JwtParserTest {
 
         String compact = Jwts.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, key).compact()
 
-        def jwt = Jwts.parser().
+        def jwt = Jwt.parser().
                 setSigningKey(key).
                 build().
                 parseSignedContent(compact)
@@ -504,7 +504,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setPayload(payload).compact()
 
         try {
-            Jwts.parser().unsecured().setSigningKey(key).build().parseSignedContent(compact)
+            Jwt.parser().unsecured().setSigningKey(key).build().parseSignedContent(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             assertEquals 'Unexpected unsecured content JWT.', e.getMessage()
@@ -521,7 +521,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setSubject(subject).compact()
 
         try {
-            Jwts.parser().unsecured().setSigningKey(key).build().parseSignedContent(compact)
+            Jwt.parser().unsecured().setSigningKey(key).build().parseSignedContent(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             assertEquals 'Unexpected unsecured Claims JWT.', e.getMessage()
@@ -538,7 +538,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
-            Jwts.parser().setSigningKey(key).build().parseSignedContent(compact)
+            Jwt.parser().setSigningKey(key).build().parseSignedContent(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             assertEquals 'Unexpected Claims JWS.', e.getMessage()
@@ -558,7 +558,7 @@ class JwtParserTest {
 
         String compact = Jwts.builder().setSubject(sub).signWith(SignatureAlgorithm.HS256, key).compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).build().parseSignedClaims(compact)
+        Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).build().parseSignedClaims(compact)
 
         assertEquals jwt.getPayload().getSubject(), sub
     }
@@ -575,7 +575,7 @@ class JwtParserTest {
         String compact = Jwts.builder().subject(sub).expiration(exp).signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
-            Jwts.parser().setSigningKey(key).clock(new FixedClock(later)).build().parseUnsecuredClaims(compact)
+            Jwt.parser().setSigningKey(key).clock(new FixedClock(later)).build().parseUnsecuredClaims(compact)
             fail()
         } catch (ExpiredJwtException e) {
             def exp8601 = DateFormats.formatIso8601(exp, true)
@@ -600,7 +600,7 @@ class JwtParserTest {
         String compact = Jwts.builder().subject(sub).notBefore(nbf).signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
-            Jwts.parser().setSigningKey(key).clock(new FixedClock(earlier)).build().parseSignedClaims(compact)
+            Jwt.parser().setSigningKey(key).clock(new FixedClock(earlier)).build().parseSignedClaims(compact)
             fail()
         } catch (PrematureJwtException e) {
             def nbf8601 = DateFormats.formatIso8601(nbf, true)
@@ -624,7 +624,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setPayload(payload).compact()
 
         try {
-            Jwts.parser().unsecured().setSigningKey(key).build().parseSignedClaims(compact)
+            Jwt.parser().unsecured().setSigningKey(key).build().parseSignedClaims(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             assertEquals 'Unexpected unsecured content JWT.', e.getMessage()
@@ -641,7 +641,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setSubject(subject).compact()
 
         try {
-            Jwts.parser().unsecured().setSigningKey(key).
+            Jwt.parser().unsecured().setSigningKey(key).
                     build().
                     parseSignedClaims(compact)
             fail()
@@ -660,7 +660,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
-            Jwts.parser().setSigningKey(key).build().parseSignedContent(compact)
+            Jwt.parser().setSigningKey(key).build().parseSignedContent(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             assertEquals 'Unexpected Claims JWS.', e.getMessage()
@@ -687,7 +687,7 @@ class JwtParserTest {
             }
         }
 
-        Jws jws = Jwts.parser().setSigningKeyResolver(signingKeyResolver).build().parseSignedClaims(compact)
+        Jws jws = Jwt.parser().setSigningKeyResolver(signingKeyResolver).build().parseSignedClaims(compact)
 
         assertEquals jws.getPayload().getSubject(), subject
     }
@@ -709,7 +709,7 @@ class JwtParserTest {
         }
 
         try {
-            Jwts.parser().setSigningKeyResolver(signingKeyResolver).build().parseSignedClaims(compact)
+            Jwt.parser().setSigningKeyResolver(signingKeyResolver).build().parseSignedClaims(compact)
             fail()
         } catch (SignatureException se) {
             assertEquals 'JWT signature does not match locally computed signature. JWT validity cannot be asserted and should not be trusted.', se.getMessage()
@@ -726,7 +726,7 @@ class JwtParserTest {
         String compact = Jwts.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
-            Jwts.parser().setSigningKeyResolver(null).build().parseSignedClaims(compact)
+            Jwt.parser().setSigningKeyResolver(null).build().parseSignedClaims(compact)
             fail()
         } catch (IllegalArgumentException iae) {
             assertEquals 'SigningKeyResolver cannot be null.', iae.getMessage()
@@ -745,7 +745,7 @@ class JwtParserTest {
         def signingKeyResolver = new SigningKeyResolverAdapter()
 
         try {
-            Jwts.parser().setSigningKeyResolver(signingKeyResolver).build().parseSignedClaims(compact)
+            Jwt.parser().setSigningKeyResolver(signingKeyResolver).build().parseSignedClaims(compact)
             fail()
         } catch (UnsupportedJwtException ex) {
             assertEquals 'The specified SigningKeyResolver implementation does not support ' +
@@ -773,7 +773,7 @@ class JwtParserTest {
                 claim("long_big", bigLong).
                 compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).build().parseSignedClaims(compact)
+        Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).build().parseSignedClaims(compact)
 
         Claims claims = jwt.getPayload()
 
@@ -804,7 +804,7 @@ class JwtParserTest {
             }
         }
 
-        def jws = Jwts.parser().setSigningKeyResolver(signingKeyResolver).build().parseSignedContent(compact)
+        def jws = Jwt.parser().setSigningKeyResolver(signingKeyResolver).build().parseSignedContent(compact)
 
         assertEquals inputPayload, new String(jws.payload, StandardCharsets.UTF_8)
     }
@@ -826,7 +826,7 @@ class JwtParserTest {
         }
 
         try {
-            Jwts.parser().setSigningKeyResolver(signingKeyResolver).build().parseSignedContent(compact)
+            Jwt.parser().setSigningKeyResolver(signingKeyResolver).build().parseSignedContent(compact)
             fail()
         } catch (SignatureException se) {
             assertEquals 'JWT signature does not match locally computed signature. JWT validity cannot be asserted and should not be trusted.', se.getMessage()
@@ -845,7 +845,7 @@ class JwtParserTest {
         def signingKeyResolver = new SigningKeyResolverAdapter()
 
         try {
-            Jwts.parser().setSigningKeyResolver(signingKeyResolver).build().parseSignedContent(compact)
+            Jwt.parser().setSigningKeyResolver(signingKeyResolver).build().parseSignedContent(compact)
             fail()
         } catch (UnsupportedJwtException ex) {
             assertEquals ex.getMessage(), 'The specified SigningKeyResolver implementation does not support content ' +
@@ -865,7 +865,7 @@ class JwtParserTest {
 
         try {
             // expecting null claim name, but with value
-            Jwts.parser().setSigningKey(key).require(null, expectedClaimValue).build().parseSignedClaims(compact)
+            Jwt.parser().setSigningKey(key).require(null, expectedClaimValue).build().parseSignedClaims(compact)
             fail()
         } catch (IllegalArgumentException e) {
             assertEquals(
@@ -888,7 +888,7 @@ class JwtParserTest {
 
         try {
             // expecting null claim name, but with value
-            Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).
+            Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).
                     require("", expectedClaimValue).
                     build().
                     parseSignedClaims(compact)
@@ -912,7 +912,7 @@ class JwtParserTest {
 
         try {
             // expecting claim name, but with null value
-            Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).
+            Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).
                     require(expectedClaimName, null).
                     build().
                     parseSignedClaims(compact)
@@ -936,7 +936,7 @@ class JwtParserTest {
                 claim(expectedClaimName, expectedClaimValue).
                 compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).
+        Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).
                 require(expectedClaimName, expectedClaimValue).
                 build().
                 parseSignedClaims(compact)
@@ -958,7 +958,7 @@ class JwtParserTest {
                 compact()
 
         try {
-            Jwts.parser().setSigningKey(key).
+            Jwt.parser().setSigningKey(key).
                     require(goodClaimName, goodClaimValue).
                     build().
                     parseSignedClaims(compact)
@@ -983,7 +983,7 @@ class JwtParserTest {
                 compact()
 
         try {
-            Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).
+            Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).
                     require(claimName, claimValue).
                     build().
                     parseSignedClaims(compact)
@@ -1005,7 +1005,7 @@ class JwtParserTest {
                 setIssuedAt(issuedAt).
                 compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).
+        Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).
                 requireIssuedAt(issuedAt).
                 build().
                 parseSignedClaims(compact)
@@ -1024,7 +1024,7 @@ class JwtParserTest {
                 setIssuedAt(badIssuedAt).
                 compact()
 
-        Jwts.parser().setSigningKey(key).
+        Jwt.parser().setSigningKey(key).
                 requireIssuedAt(goodIssuedAt).
                 build().
                 parseSignedClaims(compact)
@@ -1040,7 +1040,7 @@ class JwtParserTest {
                 setSubject("Dummy").
                 compact()
 
-        Jwts.parser().setSigningKey(key).
+        Jwt.parser().setSigningKey(key).
                 requireIssuedAt(issuedAt).
                 build().
                 parseSignedClaims(compact)
@@ -1056,7 +1056,7 @@ class JwtParserTest {
                 setIssuer(issuer).
                 compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).
+        Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).
                 requireIssuer(issuer).
                 build().
                 parseSignedClaims(compact)
@@ -1076,7 +1076,7 @@ class JwtParserTest {
                 compact()
 
         try {
-            Jwts.parser().setSigningKey(key).
+            Jwt.parser().setSigningKey(key).
                     requireIssuer(goodIssuer).
                     build().
                     parseSignedClaims(compact)
@@ -1100,7 +1100,7 @@ class JwtParserTest {
                 compact()
 
         try {
-            Jwts.parser().setSigningKey(key).
+            Jwt.parser().setSigningKey(key).
                     requireIssuer(issuer).
                     build().
                     parseSignedClaims(compact)
@@ -1121,7 +1121,7 @@ class JwtParserTest {
                 setAudience(audience).
                 compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).
+        Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).
                 requireAudience(audience).
                 build().
                 parseSignedClaims(compact)
@@ -1135,7 +1135,7 @@ class JwtParserTest {
         def two = 'two'
         def expected = [one, two]
         String jwt = Jwts.builder().audience().add(one).add(two).and().compact()
-        def aud = Jwts.parser().unsecured().requireAudience(one).requireAudience(two).build()
+        def aud = Jwt.parser().unsecured().requireAudience(one).requireAudience(two).build()
                 .parseUnsecuredClaims(jwt).getPayload().getAudience()
         assertEquals expected.size(), aud.size()
         assertTrue aud.containsAll(expected)
@@ -1147,7 +1147,7 @@ class JwtParserTest {
 
         String jwt = Jwts.builder().audience().add(one).add('two').and().compact() // more audiences than required
 
-        def aud = Jwts.parser().unsecured().requireAudience(one) // require only one
+        def aud = Jwt.parser().unsecured().requireAudience(one) // require only one
                 .build().parseUnsecuredClaims(jwt).getPayload().getAudience()
 
         assertNotNull aud
@@ -1160,7 +1160,7 @@ class JwtParserTest {
         def two = 'two'
         String jwt = Jwts.builder().id('foo').compact()
         try {
-            Jwts.parser().unsecured().requireAudience(one).requireAudience(two).build().parseUnsecuredClaims(jwt)
+            Jwt.parser().unsecured().requireAudience(one).requireAudience(two).build().parseUnsecuredClaims(jwt)
             fail()
         } catch (MissingClaimException expected) {
             String msg = "Missing 'aud' claim. Expected values: [$one, $two]"
@@ -1175,7 +1175,7 @@ class JwtParserTest {
         def expected = [one, two]
         String jwt = Jwts.builder().claim('custom', one).compact()
         try {
-            Jwts.parser().unsecured().require('custom', expected).build().parseUnsecuredClaims(jwt)
+            Jwt.parser().unsecured().require('custom', expected).build().parseUnsecuredClaims(jwt)
         } catch (IncorrectClaimException e) {
             String msg = "Missing expected '$two' value in 'custom' claim [$one]."
             assertEquals msg, e.message
@@ -1194,7 +1194,7 @@ class JwtParserTest {
                 compact()
 
         try {
-            Jwts.parser().setSigningKey(key).
+            Jwt.parser().setSigningKey(key).
                     requireAudience(goodAudience).
                     build().
                     parseSignedClaims(compact)
@@ -1217,7 +1217,7 @@ class JwtParserTest {
                 compact()
 
         try {
-            Jwts.parser().setSigningKey(key).
+            Jwt.parser().setSigningKey(key).
                     requireAudience(audience).
                     build().
                     parseSignedClaims(compact)
@@ -1238,7 +1238,7 @@ class JwtParserTest {
                 setSubject(subject).
                 compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).
+        Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).
                 requireSubject(subject).
                 build().
                 parseSignedClaims(compact)
@@ -1258,7 +1258,7 @@ class JwtParserTest {
                 compact()
 
         try {
-            Jwts.parser().setSigningKey(key).
+            Jwt.parser().setSigningKey(key).
                     requireSubject(goodSubject).
                     build().
                     parseSignedClaims(compact)
@@ -1282,7 +1282,7 @@ class JwtParserTest {
                 compact()
 
         try {
-            Jwts.parser().setSigningKey(key).
+            Jwt.parser().setSigningKey(key).
                     requireSubject(subject).
                     build().
                     parseSignedClaims(compact)
@@ -1303,7 +1303,7 @@ class JwtParserTest {
                 setId(id).
                 compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).
+        Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).
                 requireId(id).
                 build().
                 parseSignedClaims(compact)
@@ -1323,7 +1323,7 @@ class JwtParserTest {
                 compact()
 
         try {
-            Jwts.parser().setSigningKey(key).
+            Jwt.parser().setSigningKey(key).
                     requireId(goodId).
                     build().
                     parseSignedClaims(compact)
@@ -1347,7 +1347,7 @@ class JwtParserTest {
                 compact()
 
         try {
-            Jwts.parser().setSigningKey(key).
+            Jwt.parser().setSigningKey(key).
                     requireId(id).
                     build().
                     parseSignedClaims(compact)
@@ -1369,7 +1369,7 @@ class JwtParserTest {
                 setExpiration(expiration).
                 compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).
+        Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).
                 requireExpiration(expiration).
                 build().
                 parseSignedClaims(compact)
@@ -1388,7 +1388,7 @@ class JwtParserTest {
                 setExpiration(badExpiration).
                 compact()
 
-        Jwts.parser().setSigningKey(key).
+        Jwt.parser().setSigningKey(key).
                 requireExpiration(goodExpiration).
                 build().
                 parseSignedClaims(compact)
@@ -1404,7 +1404,7 @@ class JwtParserTest {
                 setSubject("Dummy").
                 compact()
 
-        Jwts.parser().setSigningKey(key).
+        Jwt.parser().setSigningKey(key).
                 requireExpiration(expiration).
                 build().
                 parseSignedClaims(compact)
@@ -1421,7 +1421,7 @@ class JwtParserTest {
                 setNotBefore(notBefore).
                 compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).
+        Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).
                 requireNotBefore(notBefore).
                 build().
                 parseSignedClaims(compact)
@@ -1440,7 +1440,7 @@ class JwtParserTest {
                 setNotBefore(badNotBefore).
                 compact()
 
-        Jwts.parser().setSigningKey(key).
+        Jwt.parser().setSigningKey(key).
                 requireNotBefore(goodNotBefore).
                 build().
                 parseSignedClaims(compact)
@@ -1456,7 +1456,7 @@ class JwtParserTest {
                 setSubject("Dummy").
                 compact()
 
-        Jwts.parser().setSigningKey(key).
+        Jwt.parser().setSigningKey(key).
                 requireNotBefore(notBefore).
                 build().
                 parseSignedClaims(compact)
@@ -1473,7 +1473,7 @@ class JwtParserTest {
                 claim("aDate", aDate).
                 compact()
 
-        Jwt<Header, Claims> jwt = Jwts.parser().setSigningKey(key).
+        Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).
                 require("aDate", aDate).
                 build().
                 parseSignedClaims(compact)
@@ -1495,7 +1495,7 @@ class JwtParserTest {
                 compact()
 
         try {
-            Jwts.parser().setSigningKey(key).
+            Jwt.parser().setSigningKey(key).
                     require("aDate", goodDate).
                     build().
                     parseSignedClaims(compact)
@@ -1520,7 +1520,7 @@ class JwtParserTest {
                 compact()
 
         try {
-            Jwts.parser().setSigningKey(key).
+            Jwt.parser().setSigningKey(key).
                     require("aDate", goodDate).
                     build().
                     parseSignedClaims(compact)
@@ -1544,7 +1544,7 @@ class JwtParserTest {
                 compact()
 
         try {
-            Jwts.parser().setSigningKey(key).
+            Jwt.parser().setSigningKey(key).
                     require("aDate", aDate).
                     build().
                     parseSignedClaims(compact)
@@ -1563,12 +1563,12 @@ class JwtParserTest {
 
         String compact = Jwts.builder().setSubject('Joe').setExpiration(expiry).compact()
 
-        Jwts.parser().unsecured().setClock(new FixedClock(beforeExpiry)).build().parse(compact)
+        Jwt.parser().unsecured().setClock(new FixedClock(beforeExpiry)).build().parse(compact)
     }
 
     @Test
     void testParseClockManipulationWithNullClock() {
-        JwtParserBuilder parser = Jwts.parser();
+        JwtParserBuilder parser = Jwt.parser();
         try {
             parser.setClock(null)
             fail()
@@ -1590,7 +1590,7 @@ class JwtParserTest {
         String bad = base64Url(header) + '.' + base64Url(payload) + '.' + base64Url(badSig) + '.' + base64Url(bogus)
 
         try {
-            Jwts.parser().setSigningKey(randomKey()).build().parse(bad)
+            Jwt.parser().setSigningKey(randomKey()).build().parse(bad)
             fail()
         } catch (MalformedJwtException se) {
             String expected = JwtTokenizer.DELIM_ERR_MSG_PREFIX + '3'
@@ -1606,7 +1606,7 @@ class JwtParserTest {
         String jwtStr = '.' + base64Url(payload) + '.'
 
         try {
-            Jwts.parser().build().parse(jwtStr)
+            Jwt.parser().build().parse(jwtStr)
             fail()
         } catch (MalformedJwtException e) {
             assertEquals 'Compact JWT strings MUST always have a Base64Url protected header per https://tools.ietf.org/html/rfc7519#section-7.2 (steps 2-4).', e.getMessage()
@@ -1623,7 +1623,7 @@ class JwtParserTest {
         String jwtStr = '.' + base64Url(payload) + '.' + base64Url(sig)
 
         try {
-            Jwts.parser().build().parse(jwtStr)
+            Jwt.parser().build().parse(jwtStr)
             fail()
         } catch (MalformedJwtException se) {
             assertEquals 'Compact JWT strings MUST always have a Base64Url protected header per https://tools.ietf.org/html/rfc7519#section-7.2 (steps 2-4).', se.message
@@ -1642,7 +1642,7 @@ class JwtParserTest {
         String jwtStr = base64Url(header) + '.' + base64Url(payload) + '.' + base64Url(sig)
 
         try {
-            Jwts.parser().unsecured().build().parse(jwtStr)
+            Jwt.parser().unsecured().build().parse(jwtStr)
             fail()
         } catch (MalformedJwtException se) {
             assertEquals 'The JWS header references signature algorithm \'none\' yet the compact JWS string contains a signature. This is not permitted per https://tools.ietf.org/html/rfc7518#section-3.6.', se.message
@@ -1665,7 +1665,7 @@ class JwtParserTest {
                 .compact()
 
         //now build a parser with no decompression algs (which should disable decompression)
-        def parser = Jwts.parser().zip().clear().and().decryptWith(key).build()
+        def parser = Jwt.parser().zip().clear().and().decryptWith(key).build()
 
         //parsing should fail since (de)compression is disabled:
         try {
@@ -1692,7 +1692,7 @@ class JwtParserTest {
                 .compact()
 
         //now build a parser with no signature algs, which should completely disable signature verification
-        def parser = Jwts.parser().sig().clear().and().verifyWith(key).build()
+        def parser = Jwt.parser().sig().clear().and().verifyWith(key).build()
 
         //parsing should fail since signature verification is disabled:
         try {
@@ -1721,7 +1721,7 @@ class JwtParserTest {
                 .compact()
 
         //now build a parser with no encryption algs, which should completely disable decryption
-        def parser = Jwts.parser().enc().clear().and().decryptWith(key).build()
+        def parser = Jwt.parser().enc().clear().and().decryptWith(key).build()
 
         //parsing should fail since decryption is disabled:
         try {
@@ -1748,7 +1748,7 @@ class JwtParserTest {
                 .compact()
 
         //now build a parser with no key management algs, which should completely disable decryption
-        def parser = Jwts.parser().key().clear().and().decryptWith(key).build()
+        def parser = Jwt.parser().key().clear().and().decryptWith(key).build()
 
         //parsing should fail since key management is disabled:
         try {

--- a/impl/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/JwtParserTest.groovy
@@ -182,7 +182,7 @@ class JwtParserTest {
         String payload = 'Hello world!'
 
         //noinspection GrDeprecatedAPIUsage
-        String compact = Jwts.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, base64Encodedkey).compact()
+        String compact = Jwt.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, base64Encodedkey).compact()
 
         assertTrue Jwt.parser().build().isSigned(compact)
 
@@ -197,7 +197,7 @@ class JwtParserTest {
 
         String payload = ''
 
-        String compact = Jwts.builder().setPayload(payload).signWith(key).compact()
+        String compact = Jwt.builder().setPayload(payload).signWith(key).compact()
 
         assertTrue Jwt.parser().build().isSigned(compact)
 
@@ -209,7 +209,7 @@ class JwtParserTest {
     @Test
     void testParseNullPayload() {
         SecretKey key = Keys.secretKeyFor(SignatureAlgorithm.HS256)
-        String compact = Jwts.builder().signWith(key).compact()
+        String compact = Jwt.builder().signWith(key).compact()
         assertTrue Jwt.parser().build().isSigned(compact)
 
         def jwt = Jwt.parser().setSigningKey(key).build().parse(compact)
@@ -218,7 +218,7 @@ class JwtParserTest {
 
     @Test
     void testParseNullPayloadWithoutKey() {
-        String compact = Jwts.builder().compact()
+        String compact = Jwt.builder().compact()
         def jwt = Jwt.parser().unsecured().build().parse(compact)
         assertEquals 'none', jwt.header.alg
         assertEquals '', new String(jwt.payload as byte[], StandardCharsets.UTF_8)
@@ -233,7 +233,7 @@ class JwtParserTest {
 
         Date exp = new Date(testTime - 1000)
 
-        String compact = Jwts.builder().setSubject('Joe').setExpiration(exp).compact()
+        String compact = Jwt.builder().setSubject('Joe').setExpiration(exp).compact()
 
         try {
             Jwt.parser().unsecured().setClock(fixedClock).build().parse(compact)
@@ -254,7 +254,7 @@ class JwtParserTest {
         def nbf = JwtDateConverter.INSTANCE.applyFrom(System.currentTimeMillis() / 1000L)
         def earlier = new Date(nbf.getTime() - differenceMillis)
 
-        String compact = Jwts.builder().subject('Joe').notBefore(nbf).compact()
+        String compact = Jwt.builder().subject('Joe').notBefore(nbf).compact()
 
         try {
             Jwt.parser().unsecured().clock(new FixedClock(earlier)).build().parse(compact)
@@ -283,10 +283,10 @@ class JwtParserTest {
         millis = seconds * 1000L
         def exp = new Date(millis)
         def later = new Date(exp.getTime() + differenceMillis)
-        def s = Jwts.builder().expiration(exp).compact()
+        def s = Jwt.builder().expiration(exp).compact()
 
         String subject = 'Joe'
-        String compact = Jwts.builder().subject(subject).expiration(exp).compact()
+        String compact = Jwt.builder().subject(subject).expiration(exp).compact()
 
         Jwt<Header, Claims> jwt = Jwt.parser().unsecured().setAllowedClockSkewSeconds(10)
                 .clock(new FixedClock(later)).build().parse(compact)
@@ -301,7 +301,7 @@ class JwtParserTest {
         def exp = JwtDateConverter.INSTANCE.applyFrom(System.currentTimeMillis() / 1000L)
         def later = new Date(exp.getTime() + differenceMillis)
 
-        def s = Jwts.builder().expiration(exp).compact()
+        def s = Jwt.builder().expiration(exp).compact()
 
         def skewSeconds = 1
 
@@ -323,7 +323,7 @@ class JwtParserTest {
         Date exp = new Date(System.currentTimeMillis() + 3000)
 
         String subject = 'Joe'
-        String compact = Jwts.builder().setSubject(subject).setNotBefore(exp).compact()
+        String compact = Jwt.builder().setSubject(subject).setNotBefore(exp).compact()
 
         Jwt<Header, Claims> jwt = Jwt.parser().unsecured().setAllowedClockSkewSeconds(10).build().parse(compact)
 
@@ -337,7 +337,7 @@ class JwtParserTest {
         def nbf = JwtDateConverter.INSTANCE.applyFrom(System.currentTimeMillis() / 1000L)
         def earlier = new Date(nbf.getTime() - differenceMillis)
 
-        String compact = Jwts.builder().subject('Joe').notBefore(nbf).compact()
+        String compact = Jwt.builder().subject('Joe').notBefore(nbf).compact()
 
         def skewSeconds = 1
 
@@ -364,7 +364,7 @@ class JwtParserTest {
 
         String payload = 'Hello world!'
 
-        String compact = Jwts.builder().setPayload(payload).compact()
+        String compact = Jwt.builder().setPayload(payload).compact()
 
         def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
 
@@ -374,7 +374,7 @@ class JwtParserTest {
     @Test
     void testParseUnprotectedContentWithClaimsJwt() {
 
-        String compact = Jwts.builder().setSubject('Joe').compact()
+        String compact = Jwt.builder().setSubject('Joe').compact()
 
         try {
             Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
@@ -389,7 +389,7 @@ class JwtParserTest {
 
         String payload = 'Hello world!'
 
-        String compact = Jwts.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, randomKey()).compact()
+        String compact = Jwt.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, randomKey()).compact()
 
         try {
             Jwt.parser().build().parseUnsecuredContent(compact)
@@ -403,7 +403,7 @@ class JwtParserTest {
     void testParseUnsecuredContentWithClaimsJws() {
 
         def key = randomKey()
-        String compact = Jwts.builder().setSubject('Joe').signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().setSubject('Joe').signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
             Jwt.parser().setSigningKey(key).build().parseSignedContent(compact)
@@ -422,7 +422,7 @@ class JwtParserTest {
 
         String subject = 'Joe'
 
-        String compact = Jwts.builder().setSubject(subject).compact()
+        String compact = Jwt.builder().setSubject(subject).compact()
 
         Jwt<Header, Claims> jwt = Jwt.parser().unsecured().build().parseUnsecuredClaims(compact)
 
@@ -434,7 +434,7 @@ class JwtParserTest {
 
         String payload = 'Hello world!'
 
-        String compact = Jwts.builder().setPayload(payload).compact()
+        String compact = Jwt.builder().setPayload(payload).compact()
 
         try {
             Jwt.parser().unsecured().build().parseUnsecuredClaims(compact)
@@ -449,7 +449,7 @@ class JwtParserTest {
 
         String payload = 'Hello world!'
 
-        String compact = Jwts.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, randomKey()).compact()
+        String compact = Jwt.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, randomKey()).compact()
 
         try {
             Jwt.parser().build().parseUnsecuredClaims(compact)
@@ -463,7 +463,7 @@ class JwtParserTest {
     void testParseUnsecuredClaimsWithClaimsJws() {
 
         def key = randomKey()
-        String compact = Jwts.builder().setSubject('Joe').signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().setSubject('Joe').signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
             Jwt.parser().setSigningKey(key).build().parseUnsecuredClaims(compact)
@@ -484,7 +484,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, key).compact()
 
         def jwt = Jwt.parser().
                 setSigningKey(key).
@@ -501,7 +501,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setPayload(payload).compact()
+        String compact = Jwt.builder().setPayload(payload).compact()
 
         try {
             Jwt.parser().unsecured().setSigningKey(key).build().parseSignedContent(compact)
@@ -518,7 +518,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setSubject(subject).compact()
+        String compact = Jwt.builder().setSubject(subject).compact()
 
         try {
             Jwt.parser().unsecured().setSigningKey(key).build().parseSignedContent(compact)
@@ -535,7 +535,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
             Jwt.parser().setSigningKey(key).build().parseSignedContent(compact)
@@ -556,7 +556,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setSubject(sub).signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().setSubject(sub).signWith(SignatureAlgorithm.HS256, key).compact()
 
         Jwt<Header, Claims> jwt = Jwt.parser().setSigningKey(key).build().parseSignedClaims(compact)
 
@@ -572,7 +572,7 @@ class JwtParserTest {
 
         String sub = 'Joe'
         byte[] key = randomKey()
-        String compact = Jwts.builder().subject(sub).expiration(exp).signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().subject(sub).expiration(exp).signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
             Jwt.parser().setSigningKey(key).clock(new FixedClock(later)).build().parseUnsecuredClaims(compact)
@@ -597,7 +597,7 @@ class JwtParserTest {
 
         String sub = 'Joe'
         byte[] key = randomKey()
-        String compact = Jwts.builder().subject(sub).notBefore(nbf).signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().subject(sub).notBefore(nbf).signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
             Jwt.parser().setSigningKey(key).clock(new FixedClock(earlier)).build().parseSignedClaims(compact)
@@ -621,7 +621,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setPayload(payload).compact()
+        String compact = Jwt.builder().setPayload(payload).compact()
 
         try {
             Jwt.parser().unsecured().setSigningKey(key).build().parseSignedClaims(compact)
@@ -638,7 +638,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setSubject(subject).compact()
+        String compact = Jwt.builder().setSubject(subject).compact()
 
         try {
             Jwt.parser().unsecured().setSigningKey(key).
@@ -657,7 +657,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
             Jwt.parser().setSigningKey(key).build().parseSignedContent(compact)
@@ -678,7 +678,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
 
         def signingKeyResolver = new SigningKeyResolverAdapter() {
             @Override
@@ -699,7 +699,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
 
         def signingKeyResolver = new SigningKeyResolverAdapter() {
             @Override
@@ -723,7 +723,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
 
         try {
             Jwt.parser().setSigningKeyResolver(null).build().parseSignedClaims(compact)
@@ -740,7 +740,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().setSubject(subject).signWith(SignatureAlgorithm.HS256, key).compact()
 
         def signingKeyResolver = new SigningKeyResolverAdapter()
 
@@ -765,7 +765,7 @@ class JwtParserTest {
         def smallLong = (long) 42
         def bigLong = ((long) Integer.MAX_VALUE) + 42
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 claim("byte", b).
                 claim("short", s).
                 claim("int", i).
@@ -795,7 +795,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setPayload(inputPayload).signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().setPayload(inputPayload).signWith(SignatureAlgorithm.HS256, key).compact()
 
         def signingKeyResolver = new SigningKeyResolverAdapter() {
             @Override
@@ -816,7 +816,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setPayload(inputPayload).signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().setPayload(inputPayload).signWith(SignatureAlgorithm.HS256, key).compact()
 
         def signingKeyResolver = new SigningKeyResolverAdapter() {
             @Override
@@ -840,7 +840,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, key).compact()
+        String compact = Jwt.builder().setPayload(payload).signWith(SignatureAlgorithm.HS256, key).compact()
 
         def signingKeyResolver = new SigningKeyResolverAdapter()
 
@@ -861,7 +861,7 @@ class JwtParserTest {
         byte[] key = randomKey()
 
         // not setting expected claim name in JWT
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).setIssuer('Dummy').compact()
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).setIssuer('Dummy').compact()
 
         try {
             // expecting null claim name, but with value
@@ -882,7 +882,7 @@ class JwtParserTest {
         byte[] key = randomKey()
 
         // not setting expected claim name in JWT
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setIssuer('Dummy').
                 compact()
 
@@ -908,7 +908,7 @@ class JwtParserTest {
         byte[] key = randomKey()
 
         // not setting expected claim name in JWT
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).setIssuer('Dummy').compact()
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).setIssuer('Dummy').compact()
 
         try {
             // expecting claim name, but with null value
@@ -932,7 +932,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 claim(expectedClaimName, expectedClaimValue).
                 compact()
 
@@ -953,7 +953,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 claim(goodClaimName, badClaimValue).
                 compact()
 
@@ -978,7 +978,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setIssuer('Dummy').
                 compact()
 
@@ -1001,7 +1001,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setIssuedAt(issuedAt).
                 compact()
 
@@ -1020,7 +1020,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setIssuedAt(badIssuedAt).
                 compact()
 
@@ -1036,7 +1036,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setSubject("Dummy").
                 compact()
 
@@ -1052,7 +1052,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setIssuer(issuer).
                 compact()
 
@@ -1071,7 +1071,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setIssuer(badIssuer).
                 compact()
 
@@ -1095,7 +1095,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setId('id').
                 compact()
 
@@ -1117,7 +1117,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setAudience(audience).
                 compact()
 
@@ -1134,7 +1134,7 @@ class JwtParserTest {
         def one = 'one'
         def two = 'two'
         def expected = [one, two]
-        String jwt = Jwts.builder().audience().add(one).add(two).and().compact()
+        String jwt = Jwt.builder().audience().add(one).add(two).and().compact()
         def aud = Jwt.parser().unsecured().requireAudience(one).requireAudience(two).build()
                 .parseUnsecuredClaims(jwt).getPayload().getAudience()
         assertEquals expected.size(), aud.size()
@@ -1145,7 +1145,7 @@ class JwtParserTest {
     void testParseAtLeastOneAudiences() {
         def one = 'one'
 
-        String jwt = Jwts.builder().audience().add(one).add('two').and().compact() // more audiences than required
+        String jwt = Jwt.builder().audience().add(one).add('two').and().compact() // more audiences than required
 
         def aud = Jwt.parser().unsecured().requireAudience(one) // require only one
                 .build().parseUnsecuredClaims(jwt).getPayload().getAudience()
@@ -1158,7 +1158,7 @@ class JwtParserTest {
     void testParseMissingAudiences() {
         def one = 'one'
         def two = 'two'
-        String jwt = Jwts.builder().id('foo').compact()
+        String jwt = Jwt.builder().id('foo').compact()
         try {
             Jwt.parser().unsecured().requireAudience(one).requireAudience(two).build().parseUnsecuredClaims(jwt)
             fail()
@@ -1173,7 +1173,7 @@ class JwtParserTest {
         def one = 'one'
         def two = 'two'
         def expected = [one, two]
-        String jwt = Jwts.builder().claim('custom', one).compact()
+        String jwt = Jwt.builder().claim('custom', one).compact()
         try {
             Jwt.parser().unsecured().require('custom', expected).build().parseUnsecuredClaims(jwt)
         } catch (IncorrectClaimException e) {
@@ -1189,7 +1189,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setAudience(badAudience).
                 compact()
 
@@ -1212,7 +1212,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setId('id').
                 compact()
 
@@ -1234,7 +1234,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setSubject(subject).
                 compact()
 
@@ -1253,7 +1253,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setSubject(badSubject).
                 compact()
 
@@ -1277,7 +1277,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setId('id').
                 compact()
 
@@ -1299,7 +1299,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setId(id).
                 compact()
 
@@ -1318,7 +1318,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setId(badId).
                 compact()
 
@@ -1342,7 +1342,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setIssuer('me').
                 compact()
 
@@ -1365,7 +1365,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setExpiration(expiration).
                 compact()
 
@@ -1384,7 +1384,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setExpiration(badExpiration).
                 compact()
 
@@ -1400,7 +1400,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setSubject("Dummy").
                 compact()
 
@@ -1417,7 +1417,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setNotBefore(notBefore).
                 compact()
 
@@ -1436,7 +1436,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setNotBefore(badNotBefore).
                 compact()
 
@@ -1452,7 +1452,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setSubject("Dummy").
                 compact()
 
@@ -1469,7 +1469,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 claim("aDate", aDate).
                 compact()
 
@@ -1490,7 +1490,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 claim("aDate", badDate).
                 compact()
 
@@ -1515,7 +1515,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 claim("aDate", badDate).
                 compact()
 
@@ -1539,7 +1539,7 @@ class JwtParserTest {
 
         byte[] key = randomKey()
 
-        String compact = Jwts.builder().signWith(SignatureAlgorithm.HS256, key).
+        String compact = Jwt.builder().signWith(SignatureAlgorithm.HS256, key).
                 setSubject("Dummy").
                 compact()
 
@@ -1561,7 +1561,7 @@ class JwtParserTest {
         Date expiry = new Date(then)
         Date beforeExpiry = new Date(then - 1000)
 
-        String compact = Jwts.builder().setSubject('Joe').setExpiration(expiry).compact()
+        String compact = Jwt.builder().setSubject('Joe').setExpiration(expiry).compact()
 
         Jwt.parser().unsecured().setClock(new FixedClock(beforeExpiry)).build().parse(compact)
     }
@@ -1659,7 +1659,7 @@ class JwtParserTest {
 
         // create a compressed JWE first:
         def key = TestKeys.A256GCM
-        def jwe = Jwts.builder().claim("hello", "world")
+        def jwe = Jwt.builder().claim("hello", "world")
                 .compressWith(Jwe.zip.DEF)
                 .encryptWith(key, Jwe.enc.A256GCM)
                 .compact()
@@ -1687,7 +1687,7 @@ class JwtParserTest {
 
         // create a compressed JWE first:
         def key = TestKeys.HS256
-        def jws = Jwts.builder().claim("hello", "world")
+        def jws = Jwt.builder().claim("hello", "world")
                 .signWith(key, Jws.alg.HS256)
                 .compact()
 
@@ -1716,7 +1716,7 @@ class JwtParserTest {
 
         // create a compressed JWE first:
         def key = TestKeys.A256GCM
-        def jwe = Jwts.builder().claim("hello", "world")
+        def jwe = Jwt.builder().claim("hello", "world")
                 .encryptWith(key, Jwe.enc.A256GCM)
                 .compact()
 
@@ -1743,7 +1743,7 @@ class JwtParserTest {
 
         // create a compressed JWE first:
         def key = TestKeys.A256GCM
-        def jwe = Jwts.builder().claim("hello", "world")
+        def jwe = Jwt.builder().claim("hello", "world")
                 .encryptWith(key, Jwe.enc.A256GCM)
                 .compact()
 

--- a/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
@@ -84,6 +84,12 @@ class JwtsTest {
     }
 
     @Test
+    void testBuilder() {
+        assertTrue Jwts.builder() instanceof DefaultJwtBuilder
+        assertTrue Jwt.builder() instanceof DefaultJwtBuilder
+    }
+
+    @Test
     void testHeader() {
         assertTrue Jwt.header() instanceof DefaultJwtHeaderBuilder
         assertTrue Jwts.header() instanceof DefaultJwtsHeaderBuilder
@@ -173,7 +179,7 @@ class JwtsTest {
         // Assert exact output per example at https://www.rfc-editor.org/rfc/rfc7519.html#section-6.1
         String encodedBody = 'eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ'
         String payload = new String(Decoders.BASE64URL.decode(encodedBody), StandardCharsets.UTF_8)
-        String val = Jwts.builder().setPayload(payload).compact()
+        String val = Jwt.builder().setPayload(payload).compact()
         String RFC_VALUE = 'eyJhbGciOiJub25lIn0.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.'
         assertEquals RFC_VALUE, val
     }
@@ -182,7 +188,7 @@ class JwtsTest {
     void testContentWithContentType() {
         String s = 'Hello JJWT'
         String cty = 'text/plain'
-        String compact = Jwts.builder().content(s, cty).compact()
+        String compact = Jwt.builder().content(s, cty).compact()
         def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertEquals cty, jwt.header.getContentType()
         assertEquals s, new String(jwt.payload, StandardCharsets.UTF_8)
@@ -193,7 +199,7 @@ class JwtsTest {
         String s = 'Hello JJWT'
         byte[] content = Strings.utf8(s)
         String cty = 'text/plain'
-        String compact = Jwts.builder().content(content, cty).compact()
+        String compact = Jwt.builder().content(content, cty).compact()
         def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertEquals cty, jwt.header.getContentType()
         assertEquals s, new String(jwt.payload, StandardCharsets.UTF_8)
@@ -204,7 +210,7 @@ class JwtsTest {
         String s = 'Hello JJWT'
         InputStream content = Streams.of(Strings.utf8(s))
         String cty = 'text/plain'
-        String compact = Jwts.builder().content(content, cty).compact()
+        String compact = Jwt.builder().content(content, cty).compact()
         def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertEquals cty, jwt.header.getContentType()
         assertEquals s, new String(jwt.payload, StandardCharsets.UTF_8)
@@ -214,7 +220,7 @@ class JwtsTest {
     void testContentStreamWithoutContentType() {
         String s = 'Hello JJWT'
         InputStream content = Streams.of(Strings.utf8(s))
-        String compact = Jwts.builder().content(content).compact()
+        String compact = Jwt.builder().content(content).compact()
         def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertNull jwt.header.getContentType()
         assertEquals s, new String(jwt.payload, StandardCharsets.UTF_8)
@@ -222,7 +228,7 @@ class JwtsTest {
 
     @Test
     void testContentStreamNull() {
-        String compact = Jwts.builder().content((InputStream) null).compact()
+        String compact = Jwt.builder().content((InputStream) null).compact()
         def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertEquals 'none', jwt.header.getAlgorithm()
         assertTrue Bytes.isEmpty(jwt.getPayload())
@@ -233,7 +239,7 @@ class JwtsTest {
         String s = 'Hello JJWT'
         String subtype = 'foo'
         String cty = "application/$subtype"
-        String compact = Jwts.builder().content(s, cty).compact()
+        String compact = Jwt.builder().content(s, cty).compact()
         def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         // assert raw value is compact form:
         assertEquals subtype, jwt.header.get('cty')
@@ -247,7 +253,7 @@ class JwtsTest {
         String s = 'Hello JJWT'
         String subtype = 'foo'
         String cty = "application/$subtype;part=1/2"
-        String compact = Jwts.builder().content(s, cty).compact()
+        String compact = Jwt.builder().content(s, cty).compact()
         def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertEquals cty, jwt.header.getContentType() // two slashes, can't compact
         assertEquals s, new String(jwt.payload, StandardCharsets.UTF_8)
@@ -258,7 +264,7 @@ class JwtsTest {
 
         def claims = [iss: 'joe', exp: later(), 'https://example.com/is_root': true]
 
-        String jwt = Jwts.builder().claims().add(claims).and().compact()
+        String jwt = Jwt.builder().claims().add(claims).and().compact()
 
         def token = Jwt.parser().unsecured().build().parse(jwt)
 
@@ -351,7 +357,7 @@ class JwtsTest {
     @Test
     void testParseWithMissingRequiredSignature() {
         Key key = Jws.alg.HS256.key().build()
-        String compact = Jwts.builder().setSubject('foo').signWith(key).compact()
+        String compact = Jwt.builder().setSubject('foo').signWith(key).compact()
         int i = compact.lastIndexOf('.')
         String missingSig = compact.substring(0, i + 1)
         try {
@@ -366,7 +372,7 @@ class JwtsTest {
     @Test
     void testWithInvalidCompressionAlgorithm() {
         try {
-            Jwts.builder().header().add('zip', 'CUSTOM').and().id("andId").compact()
+            Jwt.builder().header().add('zip', 'CUSTOM').and().id("andId").compact()
         } catch (CompressionException e) {
             assertEquals "Unsupported compression algorithm 'CUSTOM'", e.getMessage()
         }
@@ -374,11 +380,11 @@ class JwtsTest {
 
     @Test
     void testConvenienceIssuer() {
-        String compact = Jwts.builder().setIssuer("Me").compact()
+        String compact = Jwt.builder().setIssuer("Me").compact()
         Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertEquals 'Me', claims.getIssuer()
 
-        compact = Jwts.builder().setSubject("Joe")
+        compact = Jwt.builder().setSubject("Joe")
                 .setIssuer("Me") //set it
                 .setIssuer(null) //null should remove it
                 .compact()
@@ -389,11 +395,11 @@ class JwtsTest {
 
     @Test
     void testConvenienceSubject() {
-        String compact = Jwts.builder().setSubject("Joe").compact()
+        String compact = Jwt.builder().setSubject("Joe").compact()
         Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertEquals 'Joe', claims.getSubject()
 
-        compact = Jwts.builder().setIssuer("Me")
+        compact = Jwt.builder().setIssuer("Me")
                 .setSubject("Joe") //set it
                 .setSubject(null) //null should remove it
                 .compact()
@@ -404,11 +410,11 @@ class JwtsTest {
 
     @Test
     void testConvenienceAudience() {
-        String compact = Jwts.builder().setAudience("You").compact()
+        String compact = Jwt.builder().setAudience("You").compact()
         Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertEquals 'You', claims.getAudience().iterator().next()
 
-        compact = Jwts.builder().setIssuer("Me")
+        compact = Jwt.builder().setIssuer("Me")
                 .setAudience("You") //set it
                 .setAudience(null) //null should remove it
                 .compact()
@@ -420,12 +426,12 @@ class JwtsTest {
     @Test
     void testConvenienceExpiration() {
         Date then = laterDate(10000)
-        String compact = Jwts.builder().setExpiration(then).compact()
+        String compact = Jwt.builder().setExpiration(then).compact()
         Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         def claimedDate = claims.getExpiration()
         assertEquals then, claimedDate
 
-        compact = Jwts.builder().setIssuer("Me")
+        compact = Jwt.builder().setIssuer("Me")
                 .setExpiration(then) //set it
                 .setExpiration(null) //null should remove it
                 .compact()
@@ -437,12 +443,12 @@ class JwtsTest {
     @Test
     void testConvenienceNotBefore() {
         Date now = now() //jwt exp only supports *seconds* since epoch:
-        String compact = Jwts.builder().setNotBefore(now).compact()
+        String compact = Jwt.builder().setNotBefore(now).compact()
         Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         def claimedDate = claims.getNotBefore()
         assertEquals now, claimedDate
 
-        compact = Jwts.builder().setIssuer("Me")
+        compact = Jwt.builder().setIssuer("Me")
                 .setNotBefore(now) //set it
                 .setNotBefore(null) //null should remove it
                 .compact()
@@ -454,12 +460,12 @@ class JwtsTest {
     @Test
     void testConvenienceIssuedAt() {
         Date now = now() //jwt exp only supports *seconds* since epoch:
-        String compact = Jwts.builder().setIssuedAt(now).compact()
+        String compact = Jwt.builder().setIssuedAt(now).compact()
         Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         def claimedDate = claims.getIssuedAt()
         assertEquals now, claimedDate
 
-        compact = Jwts.builder().setIssuer("Me")
+        compact = Jwt.builder().setIssuer("Me")
                 .setIssuedAt(now) //set it
                 .setIssuedAt(null) //null should remove it
                 .compact()
@@ -471,11 +477,11 @@ class JwtsTest {
     @Test
     void testConvenienceId() {
         String id = UUID.randomUUID().toString()
-        String compact = Jwts.builder().setId(id).compact()
+        String compact = Jwt.builder().setId(id).compact()
         Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertEquals id, claims.getId()
 
-        compact = Jwts.builder().setIssuer("Me")
+        compact = Jwt.builder().setIssuer("Me")
                 .setId(id) //set it
                 .setId(null) //null should remove it
                 .compact()
@@ -492,7 +498,7 @@ class JwtsTest {
 
         String id = UUID.randomUUID().toString()
 
-        String compact = Jwts.builder().id(id).issuer("an issuer").signWith(key, alg)
+        String compact = Jwt.builder().id(id).issuer("an issuer").signWith(key, alg)
                 .claim("state", "hello this is an amazing jwt").compact()
 
         def jws = Jwt.parser().verifyWith(key).build().parseSignedClaims(compact)
@@ -514,7 +520,7 @@ class JwtsTest {
 
         String id = UUID.randomUUID().toString()
 
-        String compact = Jwts.builder().id(id).issuer("an issuer").signWith(key, alg)
+        String compact = Jwt.builder().id(id).issuer("an issuer").signWith(key, alg)
                 .claim("state", "hello this is an amazing jwt").compressWith(Jwe.zip.DEF).compact()
 
         def jws = Jwt.parser().verifyWith(key).build().parseSignedClaims(compact)
@@ -536,7 +542,7 @@ class JwtsTest {
 
         String id = UUID.randomUUID().toString()
 
-        String compact = Jwts.builder().id(id).issuer("an issuer").signWith(key, alg)
+        String compact = Jwt.builder().id(id).issuer("an issuer").signWith(key, alg)
                 .claim("state", "hello this is an amazing jwt").compressWith(Jwe.zip.GZIP).compact()
 
         def jws = Jwt.parser().verifyWith(key).build().parseSignedClaims(compact)
@@ -558,7 +564,7 @@ class JwtsTest {
 
         String id = UUID.randomUUID().toString()
 
-        String compact = Jwts.builder().id(id).issuer("an issuer").signWith(key, alg)
+        String compact = Jwt.builder().id(id).issuer("an issuer").signWith(key, alg)
                 .claim("state", "hello this is an amazing jwt").compressWith(new GzipCompressionAlgorithm() {
             @Override
             String getId() {
@@ -597,7 +603,7 @@ class JwtsTest {
 
         String id = UUID.randomUUID().toString()
 
-        String compact = Jwts.builder().setId(id).setAudience("an audience").signWith(key, alg)
+        String compact = Jwt.builder().setId(id).setAudience("an audience").signWith(key, alg)
                 .claim("state", "hello this is an amazing jwt").compressWith(new GzipCompressionAlgorithm() {
             @Override
             String getId() {
@@ -616,7 +622,7 @@ class JwtsTest {
 
         String payload = "this is my test for a payload"
 
-        String compact = Jwts.builder().setPayload(payload).signWith(key, alg)
+        String compact = Jwt.builder().setPayload(payload).signWith(key, alg)
                 .compressWith(Jwe.zip.DEF).compact()
 
         def jws = Jwt.parser().setSigningKey(key).build().parseSignedContent(compact)
@@ -719,7 +725,7 @@ class JwtsTest {
         def key = alg.key().build()
         def weakKey = Jws.alg.HS256.key().build()
 
-        String jws = Jwts.builder().setSubject("Foo").signWith(key, alg).compact()
+        String jws = Jwt.builder().setSubject("Foo").signWith(key, alg).compact()
 
         Jwt.parser().setSigningKey(weakKey).build().parseSignedClaims(jws)
         fail('parseSignedClaims must fail for weak keys')
@@ -730,7 +736,7 @@ class JwtsTest {
      */
     @Test
     void testBuilderWithEcdsaPublicKey() {
-        def builder = Jwts.builder().setSubject('foo')
+        def builder = Jwt.builder().setSubject('foo')
         def pair = TestKeys.ES256.pair
         try {
             builder.signWith(pair.public, SignatureAlgorithm.ES256) //public keys can't be used to create signatures
@@ -745,7 +751,7 @@ class JwtsTest {
      */
     @Test
     void testBuilderWithMismatchedEllipticCurveKeyAndAlgorithm() {
-        def builder = Jwts.builder().setSubject('foo')
+        def builder = Jwt.builder().setSubject('foo')
         def pair = TestKeys.ES384.pair
         try {
             builder.signWith(pair.private, SignatureAlgorithm.ES256)
@@ -764,7 +770,7 @@ class JwtsTest {
     @Test
     void testParserWithMismatchedEllipticCurveKeyAndAlgorithm() {
         def pair = TestKeys.ES256.pair
-        def jws = Jwts.builder().setSubject('foo').signWith(pair.private).compact()
+        def jws = Jwt.builder().setSubject('foo').signWith(pair.private).compact()
         def parser = Jwt.parser().setSigningKey(TestKeys.ES384.pair.public).build()
         try {
             parser.parseSignedClaims(jws)
@@ -799,7 +805,7 @@ class JwtsTest {
         def alg = Jws.alg.HS256
         SecretKey key = alg.key().build()
 
-        String notSigned = Jwts.builder().setSubject("Foo").compact()
+        String notSigned = Jwt.builder().setSubject("Foo").compact()
 
         try {
             Jwt.parser().unsecured().setSigningKey(key).build().parseSignedClaims(notSigned)
@@ -1069,7 +1075,7 @@ class JwtsTest {
         def id = realAlg.getId() + 'X' // custom id
         def alg = new TestMacAlgorithm(id: id, delegate: realAlg)
 
-        def jws = Jwts.builder().setSubject("joe").signWith(key, alg).compact()
+        def jws = Jwt.builder().setSubject("joe").signWith(key, alg).compact()
 
         assertEquals 'joe', Jwt.parser()
                 .sig().add(alg).and()
@@ -1113,7 +1119,7 @@ class JwtsTest {
             }
         }
 
-        def jwe = Jwts.builder().setSubject("joe").encryptWith(key, encAlg).compact()
+        def jwe = Jwt.builder().setSubject("joe").encryptWith(key, encAlg).compact()
 
         assertEquals 'joe', Jwt.parser()
                 .enc().add(encAlg).and()
@@ -1172,7 +1178,7 @@ class JwtsTest {
     @Test
     void testParseRequiredInt() {
         def key = TestKeys.HS256
-        def jws = Jwts.builder().signWith(key).claim("foo", 42).compact()
+        def jws = Jwt.builder().signWith(key).claim("foo", 42).compact()
         Jwt.parser().setSigningKey(key)
                 .require("foo", 42L) //require a long, but jws contains int, should still work
                 .build().parseSignedClaims(jws)
@@ -1180,7 +1186,7 @@ class JwtsTest {
 
     /**
      * Asserts that if a {@link Claims#builder()} builder is used to set a single string Audience value, and the
-     * resulting constructed {@link Claims} instance is used on a {@link Jwts#builder()}, that the resulting JWT
+     * resulting constructed {@link Claims} instance is used on a {@link io.jsonwebtoken.Jwt#builder()}, that the resulting JWT
      * retains a single-string Audience value (and it is not automatically coerced to a {@code Set<String>}).
      *
      * @since 0.12.4
@@ -1192,7 +1198,7 @@ class JwtsTest {
         def key = TestKeys.HS256
         def aud = 'foo'
         def claims = Claims.builder().audience().single(aud).build()
-        def jws = Jwts.builder().claims(claims).signWith(key).compact()
+        def jws = Jwt.builder().claims(claims).signWith(key).compact()
 
         // we can't use a JwtParser here because that will automatically normalize a single String value as a
         // Set<String> for app developer convenience.  So we assert that the JWT looks as expected by simple
@@ -1217,14 +1223,14 @@ class JwtsTest {
         SecretKey key = alg.key().build()
 
         //this is a 'real', valid JWT:
-        String compact = Jwts.builder().setSubject("Joe").signWith(key, alg).compact()
+        String compact = Jwt.builder().setSubject("Joe").signWith(key, alg).compact()
 
         //Now strip off the signature so we can add it back in later on a forged token:
         int i = compact.lastIndexOf('.')
         String signature = compact.substring(i + 1)
 
         //now let's create a fake header and payload with whatever we want (without signing):
-        String forged = Jwts.builder().setSubject("Not Joe").compact()
+        String forged = Jwt.builder().setSubject("Not Joe").compact()
 
         //assert that our forged header has a 'NONE' algorithm:
         assertEquals 'none', Jwt.parser().unsecured().build().parseUnsecuredClaims(forged).getHeader().get('alg')
@@ -1365,7 +1371,7 @@ class JwtsTest {
                         enc.key().build()
 
                 // encrypt:
-                String jwe = Jwts.builder()
+                String jwe = Jwt.builder()
                         .claim('foo', 'bar')
                         .encryptWith(key, alg, enc)
                         .compact()
@@ -1392,7 +1398,7 @@ class JwtsTest {
                 SecretKey key = enc.key().build()
 
                 // encrypt and compress:
-                String jwe = Jwts.builder()
+                String jwe = Jwt.builder()
                         .claim('foo', 'bar')
                         .compressWith(codec)
                         .encryptWith(key, enc)
@@ -1421,7 +1427,7 @@ class JwtsTest {
                 String payload = 'hello, world!'
 
                 // encrypt and compress:
-                String jwe = Jwts.builder()
+                String jwe = Jwt.builder()
                     .content(payload)
                     .compressWith(zip)
                     .encryptWith(key, enc)
@@ -1451,7 +1457,7 @@ class JwtsTest {
                 Randoms.secureRandom().nextBytes(payload)
 
                 // encrypt and compress:
-                String jwe = Jwts.builder()
+                String jwe = Jwt.builder()
                         .content(payload)
                         .compressWith(zip)
                         .encryptWith(key, enc)
@@ -1483,7 +1489,7 @@ class JwtsTest {
                 ByteArrayInputStream payload = new ByteArrayInputStream(payloadBytes)
 
                 // encrypt and compress:
-                String jwe = Jwts.builder()
+                String jwe = Jwt.builder()
                         .content(payload)
                         .compressWith(zip)
                         .encryptWith(key, enc)
@@ -1513,7 +1519,7 @@ class JwtsTest {
             for (AeadAlgorithm enc : Jwe.enc.registry().values()) {
 
                 // encrypt:
-                String jwe = Jwts.builder()
+                String jwe = Jwt.builder()
                         .claim('foo', 'bar')
                         .encryptWith(key, alg, enc)
                         .compact()
@@ -1534,7 +1540,7 @@ class JwtsTest {
         Password key = Password.of("12345678".toCharArray())
 
         // encrypt:
-        String jwe = Jwts.builder()
+        String jwe = Jwt.builder()
                 .claim('foo', 'bar')
                 .encryptWith(key, Jwe.enc.A256GCM) // should auto choose KeyAlg PBES2_HS512_A256KW
                 .compact()
@@ -1567,7 +1573,7 @@ class JwtsTest {
                 for (AeadAlgorithm enc : Jwe.enc.registry().values()) {
 
                     // encrypt:
-                    String jwe = Jwts.builder()
+                    String jwe = Jwt.builder()
                             .claim('foo', 'bar')
                             .encryptWith(pubKey, alg, enc)
                             .compact()
@@ -1602,7 +1608,7 @@ class JwtsTest {
                 for (AeadAlgorithm enc : Jwe.enc.registry().values()) {
 
                     // encrypt:
-                    String jwe = Jwts.builder()
+                    String jwe = Jwt.builder()
                             .claim('foo', 'bar')
                             .encryptWith(pubKey, alg, enc)
                             .compact()
@@ -1708,7 +1714,7 @@ class JwtsTest {
     }
 
     static String encrypt(PublicKey key, KeyAlgorithm alg, AeadAlgorithm enc) {
-        return Jwts.builder().claim('foo', 'bar').encryptWith(key, alg, enc).compact()
+        return Jwt.builder().claim('foo', 'bar').encryptWith(key, alg, enc).compact()
     }
 
     static Jwe<Claims> decrypt(String jwe, PrivateKey key) {
@@ -1723,7 +1729,7 @@ class JwtsTest {
 
         def claims = new DefaultClaims([iss: 'joe', exp: later(), 'https://example.com/is_root': true])
 
-        String jwt = Jwts.builder().claims().add(claims).and().signWith(privateKey, alg).compact()
+        String jwt = Jwt.builder().claims().add(claims).and().signWith(privateKey, alg).compact()
 
         def token = Jwt.parser().verifyWith(publicKey).build().parse(jwt)
 
@@ -1738,7 +1744,7 @@ class JwtsTest {
 
         def claims = new DefaultClaims([iss: 'joe', exp: later(), 'https://example.com/is_root': true])
 
-        String jwt = Jwts.builder().claims().add(claims).and().signWith(key, alg).compact()
+        String jwt = Jwt.builder().claims().add(claims).and().signWith(key, alg).compact()
 
         def token = Jwt.parser().verifyWith(key).build().parse(jwt)
 
@@ -1757,7 +1763,7 @@ class JwtsTest {
 
         def claims = new DefaultClaims([iss: 'joe', exp: later(), 'https://example.com/is_root': true])
 
-        String jwt = Jwts.builder().claims().add(claims).and().signWith(privateKey, alg).compact()
+        String jwt = Jwt.builder().claims().add(claims).and().signWith(privateKey, alg).compact()
 
         def key = publicKey
         if (verifyWithPrivateKey) {

--- a/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
@@ -84,14 +84,20 @@ class JwtsTest {
     }
 
     @Test
+    void testHeader() {
+        assertTrue Jwt.header() instanceof DefaultJwtHeaderBuilder
+        assertTrue Jwts.header() instanceof DefaultJwtsHeaderBuilder
+    }
+
+    @Test
     void testHeaderWithNoArgs() {
-        def header = Jwts.header().build()
+        def header = Jwt.header().build()
         assertTrue header instanceof DefaultHeader
     }
 
     @Test
     void testHeaderWithMapArg() {
-        def header = Jwts.header().add([alg: "HS256"]).build()
+        def header = Jwt.header().add([alg: "HS256"]).build()
         assertTrue header instanceof DefaultJwsHeader
         assertEquals 'HS256', header.getAlgorithm()
         assertEquals 'HS256', header.alg

--- a/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
@@ -100,7 +100,9 @@ class JwtsTest {
 
     @Test
     void testClaims() {
-        Claims claims = Jwts.claims().build()
+        def builder = Jwts.claims()
+        assertTrue builder instanceof DefaultClaimsBuilder
+        Claims claims = builder.build()
         assertNotNull claims
     }
 
@@ -109,6 +111,12 @@ class JwtsTest {
         Claims claims = Jwts.claims([sub: 'Joe'])
         assertNotNull claims
         assertEquals 'Joe', claims.getSubject()
+    }
+
+    @Test
+    void testParser() {
+        assertTrue Jwts.parser() instanceof DefaultJwtParserBuilder
+        assertTrue Jwt.parser() instanceof DefaultJwtParserBuilder
     }
 
     /**
@@ -122,7 +130,7 @@ class JwtsTest {
         def encodedClaims = base64Url(claimsString)
         def compact = encodedHeader + '.' + encodedClaims + '.AAD='
         try {
-            Jwts.parser().build().parseSignedClaims(compact)
+            Jwt.parser().build().parseSignedClaims(compact)
             fail()
         } catch (MalformedJwtException e) {
             String expected = 'Invalid protected header: Invalid JWS header \'jku\' (JWK Set URL) value: 42. ' +
@@ -145,7 +153,7 @@ class JwtsTest {
         def sig = Encoders.BASE64URL.encode(result)
         def compact = "$h.$c.$sig" as String
         try {
-            Jwts.parser().setSigningKey(key).build().parseSignedClaims(compact)
+            Jwt.parser().setSigningKey(key).build().parseSignedClaims(compact)
             fail()
         } catch (MalformedJwtException e) {
             String expected = 'Invalid claims: Invalid JWT Claims \'exp\' (Expiration Time) value: -42-. ' +
@@ -170,7 +178,7 @@ class JwtsTest {
         String s = 'Hello JJWT'
         String cty = 'text/plain'
         String compact = Jwts.builder().content(s, cty).compact()
-        def jwt = Jwts.parser().unsecured().build().parseUnsecuredContent(compact)
+        def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertEquals cty, jwt.header.getContentType()
         assertEquals s, new String(jwt.payload, StandardCharsets.UTF_8)
     }
@@ -181,7 +189,7 @@ class JwtsTest {
         byte[] content = Strings.utf8(s)
         String cty = 'text/plain'
         String compact = Jwts.builder().content(content, cty).compact()
-        def jwt = Jwts.parser().unsecured().build().parseUnsecuredContent(compact)
+        def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertEquals cty, jwt.header.getContentType()
         assertEquals s, new String(jwt.payload, StandardCharsets.UTF_8)
     }
@@ -192,7 +200,7 @@ class JwtsTest {
         InputStream content = Streams.of(Strings.utf8(s))
         String cty = 'text/plain'
         String compact = Jwts.builder().content(content, cty).compact()
-        def jwt = Jwts.parser().unsecured().build().parseUnsecuredContent(compact)
+        def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertEquals cty, jwt.header.getContentType()
         assertEquals s, new String(jwt.payload, StandardCharsets.UTF_8)
     }
@@ -202,7 +210,7 @@ class JwtsTest {
         String s = 'Hello JJWT'
         InputStream content = Streams.of(Strings.utf8(s))
         String compact = Jwts.builder().content(content).compact()
-        def jwt = Jwts.parser().unsecured().build().parseUnsecuredContent(compact)
+        def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertNull jwt.header.getContentType()
         assertEquals s, new String(jwt.payload, StandardCharsets.UTF_8)
     }
@@ -210,7 +218,7 @@ class JwtsTest {
     @Test
     void testContentStreamNull() {
         String compact = Jwts.builder().content((InputStream) null).compact()
-        def jwt = Jwts.parser().unsecured().build().parseUnsecuredContent(compact)
+        def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertEquals 'none', jwt.header.getAlgorithm()
         assertTrue Bytes.isEmpty(jwt.getPayload())
     }
@@ -221,7 +229,7 @@ class JwtsTest {
         String subtype = 'foo'
         String cty = "application/$subtype"
         String compact = Jwts.builder().content(s, cty).compact()
-        def jwt = Jwts.parser().unsecured().build().parseUnsecuredContent(compact)
+        def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         // assert raw value is compact form:
         assertEquals subtype, jwt.header.get('cty')
         // assert getter reflects normalized form per https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.10:
@@ -235,7 +243,7 @@ class JwtsTest {
         String subtype = 'foo'
         String cty = "application/$subtype;part=1/2"
         String compact = Jwts.builder().content(s, cty).compact()
-        def jwt = Jwts.parser().unsecured().build().parseUnsecuredContent(compact)
+        def jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertEquals cty, jwt.header.getContentType() // two slashes, can't compact
         assertEquals s, new String(jwt.payload, StandardCharsets.UTF_8)
     }
@@ -247,7 +255,7 @@ class JwtsTest {
 
         String jwt = Jwts.builder().claims().add(claims).and().compact()
 
-        def token = Jwts.parser().unsecured().build().parse(jwt)
+        def token = Jwt.parser().unsecured().build().parse(jwt)
 
         //noinspection GrEqualsBetweenInconvertibleTypes
         assert token.payload == claims
@@ -255,17 +263,17 @@ class JwtsTest {
 
     @Test(expected = IllegalArgumentException)
     void testParseNull() {
-        Jwts.parser().build().parse(null)
+        Jwt.parser().build().parse(null)
     }
 
     @Test(expected = IllegalArgumentException)
     void testParseEmptyString() {
-        Jwts.parser().build().parse('')
+        Jwt.parser().build().parse('')
     }
 
     @Test(expected = IllegalArgumentException)
     void testParseWhitespaceString() {
-        Jwts.parser().build().parse('   ')
+        Jwt.parser().build().parse('   ')
     }
 
     @Test
@@ -277,7 +285,7 @@ class JwtsTest {
         String claims = Encoders.BASE64URL.encode(claimsJson.getBytes(StandardCharsets.UTF_8))
 
         String compact = header + '.' + claims + '.'
-        def jwt = Jwts.parser().unsecured().build().parseUnsecuredClaims(compact)
+        def jwt = Jwt.parser().unsecured().build().parseUnsecuredClaims(compact)
         assertEquals 'none', jwt.header.getAlgorithm()
         assertEquals 'joe', jwt.payload.getSubject()
     }
@@ -285,7 +293,7 @@ class JwtsTest {
     @Test
     void testParseWithNoPeriods() {
         try {
-            Jwts.parser().build().parse('foo')
+            Jwt.parser().build().parse('foo')
             fail()
         } catch (MalformedJwtException e) {
             //noinspection GroovyAccessibility
@@ -297,7 +305,7 @@ class JwtsTest {
     @Test
     void testParseWithOnePeriodOnly() {
         try {
-            Jwts.parser().build().parse('.')
+            Jwt.parser().build().parse('.')
             fail()
         } catch (MalformedJwtException e) {
             //noinspection GroovyAccessibility
@@ -309,7 +317,7 @@ class JwtsTest {
     @Test
     void testParseWithTwoPeriodsOnly() {
         try {
-            Jwts.parser().build().parse('..')
+            Jwt.parser().build().parse('..')
             fail()
         } catch (MalformedJwtException e) {
             String msg = 'Compact JWT strings MUST always have a Base64Url protected header per ' +
@@ -321,14 +329,14 @@ class JwtsTest {
     @Test
     void testParseWithHeaderOnly() {
         String unsecuredJwt = base64Url("{\"alg\":\"none\"}") + ".."
-        Jwt jwt = Jwts.parser().unsecured().build().parse(unsecuredJwt)
+        Jwt jwt = Jwt.parser().unsecured().build().parse(unsecuredJwt)
         assertEquals "none", jwt.getHeader().get("alg")
     }
 
     @Test
     void testParseWithSignatureOnly() {
         try {
-            Jwts.parser().build().parse('..bar')
+            Jwt.parser().build().parse('..bar')
             fail()
         } catch (MalformedJwtException e) {
             assertEquals 'Compact JWT strings MUST always have a Base64Url protected header per https://tools.ietf.org/html/rfc7519#section-7.2 (steps 2-4).', e.message
@@ -342,7 +350,7 @@ class JwtsTest {
         int i = compact.lastIndexOf('.')
         String missingSig = compact.substring(0, i + 1)
         try {
-            Jwts.parser().unsecured().setSigningKey(key).build().parseSignedClaims(missingSig)
+            Jwt.parser().unsecured().setSigningKey(key).build().parseSignedClaims(missingSig)
             fail()
         } catch (MalformedJwtException expected) {
             String s = String.format(DefaultJwtParser.MISSING_JWS_DIGEST_MSG_FMT, 'HS256')
@@ -362,7 +370,7 @@ class JwtsTest {
     @Test
     void testConvenienceIssuer() {
         String compact = Jwts.builder().setIssuer("Me").compact()
-        Claims claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertEquals 'Me', claims.getIssuer()
 
         compact = Jwts.builder().setSubject("Joe")
@@ -370,14 +378,14 @@ class JwtsTest {
                 .setIssuer(null) //null should remove it
                 .compact()
 
-        claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertNull claims.getIssuer()
     }
 
     @Test
     void testConvenienceSubject() {
         String compact = Jwts.builder().setSubject("Joe").compact()
-        Claims claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertEquals 'Joe', claims.getSubject()
 
         compact = Jwts.builder().setIssuer("Me")
@@ -385,14 +393,14 @@ class JwtsTest {
                 .setSubject(null) //null should remove it
                 .compact()
 
-        claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertNull claims.getSubject()
     }
 
     @Test
     void testConvenienceAudience() {
         String compact = Jwts.builder().setAudience("You").compact()
-        Claims claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertEquals 'You', claims.getAudience().iterator().next()
 
         compact = Jwts.builder().setIssuer("Me")
@@ -400,7 +408,7 @@ class JwtsTest {
                 .setAudience(null) //null should remove it
                 .compact()
 
-        claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertNull claims.getAudience()
     }
 
@@ -408,7 +416,7 @@ class JwtsTest {
     void testConvenienceExpiration() {
         Date then = laterDate(10000)
         String compact = Jwts.builder().setExpiration(then).compact()
-        Claims claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         def claimedDate = claims.getExpiration()
         assertEquals then, claimedDate
 
@@ -417,7 +425,7 @@ class JwtsTest {
                 .setExpiration(null) //null should remove it
                 .compact()
 
-        claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertNull claims.getExpiration()
     }
 
@@ -425,7 +433,7 @@ class JwtsTest {
     void testConvenienceNotBefore() {
         Date now = now() //jwt exp only supports *seconds* since epoch:
         String compact = Jwts.builder().setNotBefore(now).compact()
-        Claims claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         def claimedDate = claims.getNotBefore()
         assertEquals now, claimedDate
 
@@ -434,7 +442,7 @@ class JwtsTest {
                 .setNotBefore(null) //null should remove it
                 .compact()
 
-        claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertNull claims.getNotBefore()
     }
 
@@ -442,7 +450,7 @@ class JwtsTest {
     void testConvenienceIssuedAt() {
         Date now = now() //jwt exp only supports *seconds* since epoch:
         String compact = Jwts.builder().setIssuedAt(now).compact()
-        Claims claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         def claimedDate = claims.getIssuedAt()
         assertEquals now, claimedDate
 
@@ -451,7 +459,7 @@ class JwtsTest {
                 .setIssuedAt(null) //null should remove it
                 .compact()
 
-        claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertNull claims.getIssuedAt()
     }
 
@@ -459,7 +467,7 @@ class JwtsTest {
     void testConvenienceId() {
         String id = UUID.randomUUID().toString()
         String compact = Jwts.builder().setId(id).compact()
-        Claims claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        Claims claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertEquals id, claims.getId()
 
         compact = Jwts.builder().setIssuer("Me")
@@ -467,7 +475,7 @@ class JwtsTest {
                 .setId(null) //null should remove it
                 .compact()
 
-        claims = Jwts.parser().unsecured().build().parse(compact).payload as Claims
+        claims = Jwt.parser().unsecured().build().parse(compact).payload as Claims
         assertNull claims.getId()
     }
 
@@ -482,7 +490,7 @@ class JwtsTest {
         String compact = Jwts.builder().id(id).issuer("an issuer").signWith(key, alg)
                 .claim("state", "hello this is an amazing jwt").compact()
 
-        def jws = Jwts.parser().verifyWith(key).build().parseSignedClaims(compact)
+        def jws = Jwt.parser().verifyWith(key).build().parseSignedClaims(compact)
 
         Claims claims = jws.payload
 
@@ -504,7 +512,7 @@ class JwtsTest {
         String compact = Jwts.builder().id(id).issuer("an issuer").signWith(key, alg)
                 .claim("state", "hello this is an amazing jwt").compressWith(Jwe.zip.DEF).compact()
 
-        def jws = Jwts.parser().verifyWith(key).build().parseSignedClaims(compact)
+        def jws = Jwt.parser().verifyWith(key).build().parseSignedClaims(compact)
 
         Claims claims = jws.payload
 
@@ -526,7 +534,7 @@ class JwtsTest {
         String compact = Jwts.builder().id(id).issuer("an issuer").signWith(key, alg)
                 .claim("state", "hello this is an amazing jwt").compressWith(Jwe.zip.GZIP).compact()
 
-        def jws = Jwts.parser().verifyWith(key).build().parseSignedClaims(compact)
+        def jws = Jwt.parser().verifyWith(key).build().parseSignedClaims(compact)
 
         Claims claims = jws.payload
 
@@ -553,7 +561,7 @@ class JwtsTest {
             }
         }).compact()
 
-        def jws = Jwts.parser().verifyWith(key).setCompressionCodecResolver(new CompressionCodecResolver() {
+        def jws = Jwt.parser().verifyWith(key).setCompressionCodecResolver(new CompressionCodecResolver() {
             @Override
             CompressionCodec resolveCompressionCodec(Header header) throws CompressionException {
                 String algorithm = header.getCompressionAlgorithm()
@@ -592,7 +600,7 @@ class JwtsTest {
             }
         }).compact()
 
-        Jwts.parser().setSigningKey(key).build().parseSignedClaims(compact)
+        Jwt.parser().setSigningKey(key).build().parseSignedClaims(compact)
     }
 
     @Test
@@ -606,7 +614,7 @@ class JwtsTest {
         String compact = Jwts.builder().setPayload(payload).signWith(key, alg)
                 .compressWith(Jwe.zip.DEF).compact()
 
-        def jws = Jwts.parser().setSigningKey(key).build().parseSignedContent(compact)
+        def jws = Jwt.parser().setSigningKey(key).build().parseSignedContent(compact)
 
         assertEquals "DEF", jws.header.getCompressionAlgorithm()
 
@@ -708,7 +716,7 @@ class JwtsTest {
 
         String jws = Jwts.builder().setSubject("Foo").signWith(key, alg).compact()
 
-        Jwts.parser().setSigningKey(weakKey).build().parseSignedClaims(jws)
+        Jwt.parser().setSigningKey(weakKey).build().parseSignedClaims(jws)
         fail('parseSignedClaims must fail for weak keys')
     }
 
@@ -752,7 +760,7 @@ class JwtsTest {
     void testParserWithMismatchedEllipticCurveKeyAndAlgorithm() {
         def pair = TestKeys.ES256.pair
         def jws = Jwts.builder().setSubject('foo').signWith(pair.private).compact()
-        def parser = Jwts.parser().setSigningKey(TestKeys.ES384.pair.public).build()
+        def parser = Jwt.parser().setSigningKey(TestKeys.ES384.pair.public).build()
         try {
             parser.parseSignedClaims(jws)
         } catch (UnsupportedJwtException expected) {
@@ -775,7 +783,7 @@ class JwtsTest {
         def invalidEncodedSignature = "_____wAAAAD__________7zm-q2nF56E87nKwvxjJVH_____AAAAAP__________vOb6racXnoTzucrC_GMlUQ"
         String jws = withoutSignature + '.' + invalidEncodedSignature
         def keypair = Jws.alg.ES256.keyPair().build()
-        Jwts.parser().setSigningKey(keypair.public).build().parseSignedClaims(jws)
+        Jwt.parser().setSigningKey(keypair.public).build().parseSignedClaims(jws)
     }
 
     //Asserts correct/expected behavior discussed in https://github.com/jwtk/jjwt/issues/20
@@ -789,7 +797,7 @@ class JwtsTest {
         String notSigned = Jwts.builder().setSubject("Foo").compact()
 
         try {
-            Jwts.parser().unsecured().setSigningKey(key).build().parseSignedClaims(notSigned)
+            Jwt.parser().unsecured().setSigningKey(key).build().parseSignedClaims(notSigned)
             fail('parseSignedClaims must fail for unsigned JWTs')
         } catch (UnsupportedJwtException expected) {
             assertEquals 'Unexpected unsecured Claims JWT.', expected.message
@@ -805,7 +813,7 @@ class JwtsTest {
         def c = base64Url('{"sub":"joe"}')
         def compact = h + '.ecek.iv.' + c + '.tag'
         try {
-            Jwts.parser().build().parseEncryptedClaims(compact)
+            Jwt.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (MalformedJwtException e) {
             assertEquals DefaultJwtParser.MISSING_JWE_ALG_MSG, e.getMessage()
@@ -821,7 +829,7 @@ class JwtsTest {
         def c = base64Url('{"sub":"joe"}')
         def compact = h + '.ecek.iv.' + c + '.tag'
         try {
-            Jwts.parser().build().parseEncryptedClaims(compact)
+            Jwt.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (MalformedJwtException e) {
             assertEquals DefaultJwtParser.MISSING_JWE_ALG_MSG, e.getMessage()
@@ -837,7 +845,7 @@ class JwtsTest {
         def c = base64Url('{"sub":"joe"}')
         def compact = h + '.ecek.iv.' + c + '.tag'
         try {
-            Jwts.parser().build().parseEncryptedClaims(compact)
+            Jwt.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (MalformedJwtException e) {
             assertEquals DefaultJwtParser.MISSING_JWE_ALG_MSG, e.getMessage()
@@ -853,7 +861,7 @@ class JwtsTest {
         def c = base64Url('{"sub":"joe"}')
         def compact = h + '.ecek.iv.' + c + '.tag'
         try {
-            Jwts.parser().build().parseEncryptedClaims(compact)
+            Jwt.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (MalformedJwtException e) {
             assertEquals DefaultJwtParser.JWE_NONE_MSG, e.getMessage()
@@ -869,7 +877,7 @@ class JwtsTest {
         def c = base64Url('{"sub":"joe"}')
         def compact = h + '.ecek.iv.' + c + '.'
         try {
-            Jwts.parser().build().parseEncryptedClaims(compact)
+            Jwt.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (MalformedJwtException e) {
             String expected = String.format(DefaultJwtParser.MISSING_JWE_DIGEST_MSG_FMT, 'dir')
@@ -888,7 +896,7 @@ class JwtsTest {
         def tag = '&'
         def compact = h + '.IA==.IA==.' + c + '.' + tag
         try {
-            Jwts.parser().build().parseEncryptedClaims(compact)
+            Jwt.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (MalformedJwtException e) {
             String expected = 'Compact JWE strings must always contain an AAD Authentication Tag.'
@@ -904,7 +912,7 @@ class JwtsTest {
         def h = base64Url('{"alg":"dir","enc":"A128GCM"}')
         def compact = h + '.ecek.iv..tag'
         try {
-            Jwts.parser().build().parseEncryptedClaims(compact)
+            Jwt.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (MalformedJwtException e) {
             String expected = 'Compact JWE strings MUST always contain a payload (ciphertext).'
@@ -923,7 +931,7 @@ class JwtsTest {
         def encodedKey = '&'
         def compact = h + '.' + encodedKey + '.iv.' + c + '.tag'
         try {
-            Jwts.parser().build().parseEncryptedClaims(compact)
+            Jwt.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (MalformedJwtException e) {
             String expected = 'Compact JWE string represents an encrypted key, but the key is empty.'
@@ -940,7 +948,7 @@ class JwtsTest {
         def c = base64Url('{"sub":"joe"}')
         def compact = h + '.IA==..' + c + '.tag'
         try {
-            Jwts.parser().build().parseEncryptedClaims(compact)
+            Jwt.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (MalformedJwtException e) {
             String expected = 'Compact JWE strings must always contain an Initialization Vector.'
@@ -960,7 +968,7 @@ class JwtsTest {
         def tag = 'IA=='
         def compact = "$h.$ekey.$iv.$c.$tag" as String
         try {
-            Jwts.parser().build().parseEncryptedClaims(compact)
+            Jwt.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (MalformedJwtException e) {
             assertEquals DefaultJwtParser.MISSING_ENC_MSG, e.getMessage()
@@ -979,7 +987,7 @@ class JwtsTest {
         def tag = 'IA=='
         def compact = "$h.$ekey.$iv.$c.$tag" as String
         try {
-            Jwts.parser().build().parseEncryptedClaims(compact)
+            Jwt.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             String expected = "Unsupported JWE header 'enc' (Encryption Algorithm) value 'foo'."
@@ -999,7 +1007,7 @@ class JwtsTest {
         def tag = 'IA=='
         def compact = "$h.$ekey.$iv.$c.$tag" as String
         try {
-            Jwts.parser().build().parseEncryptedClaims(compact)
+            Jwt.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             String expected = "Unsupported JWE header 'alg' (Algorithm) value 'bar'."
@@ -1017,7 +1025,7 @@ class JwtsTest {
         def sig = 'IA=='
         def compact = "$h.$c.$sig" as String
         try {
-            Jwts.parser().build().parseSignedClaims(compact)
+            Jwt.parser().build().parseSignedClaims(compact)
             fail()
         } catch (io.jsonwebtoken.security.SignatureException e) {
             String expected = "Unsupported signature algorithm 'bar': " +
@@ -1038,7 +1046,7 @@ class JwtsTest {
         def tag = 'IA=='
         def compact = "$h.$ekey.$iv.$c.$tag" as String
         try {
-            Jwts.parser().build().parseEncryptedClaims(compact)
+            Jwt.parser().build().parseEncryptedClaims(compact)
             fail()
         } catch (UnsupportedJwtException e) {
             String expected = "Cannot decrypt JWE payload: unable to locate key for JWE with header: {alg=dir, enc=A128GCM}"
@@ -1058,7 +1066,7 @@ class JwtsTest {
 
         def jws = Jwts.builder().setSubject("joe").signWith(key, alg).compact()
 
-        assertEquals 'joe', Jwts.parser()
+        assertEquals 'joe', Jwt.parser()
                 .sig().add(alg).and()
                 .setSigningKey(key)
                 .build()
@@ -1102,7 +1110,7 @@ class JwtsTest {
 
         def jwe = Jwts.builder().setSubject("joe").encryptWith(key, encAlg).compact()
 
-        assertEquals 'joe', Jwts.parser()
+        assertEquals 'joe', Jwt.parser()
                 .enc().add(encAlg).and()
                 .decryptWith(key)
                 .build()
@@ -1140,7 +1148,7 @@ class JwtsTest {
         }
 
         try {
-            Jwts.parser()
+            Jwt.parser()
                     .keyLocator(new ConstantKeyLocator(TestKeys.HS256, TestKeys.A128GCM))
                     .key().add(badKeyAlg).and() // <-- add bad alg here
                     .build()
@@ -1160,13 +1168,13 @@ class JwtsTest {
     void testParseRequiredInt() {
         def key = TestKeys.HS256
         def jws = Jwts.builder().signWith(key).claim("foo", 42).compact()
-        Jwts.parser().setSigningKey(key)
+        Jwt.parser().setSigningKey(key)
                 .require("foo", 42L) //require a long, but jws contains int, should still work
                 .build().parseSignedClaims(jws)
     }
 
     /**
-     * Asserts that if a {@link Jwts#claims()} builder is used to set a single string Audience value, and the
+     * Asserts that if a {@link Claims#builder()} builder is used to set a single string Audience value, and the
      * resulting constructed {@link Claims} instance is used on a {@link Jwts#builder()}, that the resulting JWT
      * retains a single-string Audience value (and it is not automatically coerced to a {@code Set<String>}).
      *
@@ -1178,7 +1186,7 @@ class JwtsTest {
 
         def key = TestKeys.HS256
         def aud = 'foo'
-        def claims = Jwts.claims().audience().single(aud).build()
+        def claims = Claims.builder().audience().single(aud).build()
         def jws = Jwts.builder().claims(claims).signWith(key).compact()
 
         // we can't use a JwtParser here because that will automatically normalize a single String value as a
@@ -1214,14 +1222,14 @@ class JwtsTest {
         String forged = Jwts.builder().setSubject("Not Joe").compact()
 
         //assert that our forged header has a 'NONE' algorithm:
-        assertEquals 'none', Jwts.parser().unsecured().build().parseUnsecuredClaims(forged).getHeader().get('alg')
+        assertEquals 'none', Jwt.parser().unsecured().build().parseUnsecuredClaims(forged).getHeader().get('alg')
 
         //now let's forge it by appending the signature the server expects:
         forged += signature
 
         //now assert that, when the server tries to parse the forged token, parsing fails:
         try {
-            Jwts.parser().unsecured().setSigningKey(key).build().parse(forged)
+            Jwt.parser().unsecured().setSigningKey(key).build().parse(forged)
             fail("Parsing must fail for a forged token.")
         } catch (MalformedJwtException expected) {
             assertEquals 'The JWS header references signature algorithm \'none\' yet the compact JWS string contains a signature. This is not permitted per https://tools.ietf.org/html/rfc7518#section-3.6.', expected.message
@@ -1257,7 +1265,7 @@ class JwtsTest {
 
         // Assert that the server does not recognized the forged token:
         try {
-            Jwts.parser().verifyWith(publicKey).build().parse(forged)
+            Jwt.parser().verifyWith(publicKey).build().parse(forged)
             fail("Forged token must not be successfully parsed.")
         } catch (UnsupportedJwtException expected) {
             assertTrue expected.getMessage().startsWith('The parsed JWT indicates it was signed with the')
@@ -1293,7 +1301,7 @@ class JwtsTest {
 
         // Assert that the parser does not recognized the forged token:
         try {
-            Jwts.parser().setSigningKey(publicKey).build().parse(forged)
+            Jwt.parser().setSigningKey(publicKey).build().parse(forged)
             fail("Forged token must not be successfully parsed.")
         } catch (UnsupportedJwtException expected) {
             assertTrue expected.getMessage().startsWith('The parsed JWT indicates it was signed with the')
@@ -1329,7 +1337,7 @@ class JwtsTest {
 
         // Assert that the parser does not recognized the forged token:
         try {
-            Jwts.parser().setSigningKey(publicKey).build().parse(forged)
+            Jwt.parser().setSigningKey(publicKey).build().parse(forged)
             fail("Forged token must not be successfully parsed.")
         } catch (UnsupportedJwtException expected) {
             assertTrue expected.getMessage().startsWith('The parsed JWT indicates it was signed with the')
@@ -1358,7 +1366,7 @@ class JwtsTest {
                         .compact()
 
                 //decrypt:
-                def jwt = Jwts.parser()
+                def jwt = Jwt.parser()
                         .decryptWith(key)
                         .build()
                         .parseEncryptedClaims(jwe)
@@ -1386,7 +1394,7 @@ class JwtsTest {
                         .compact()
 
                 //decompress and decrypt:
-                def jwt = Jwts.parser()
+                def jwt = Jwt.parser()
                         .decryptWith(key)
                         .build()
                         .parseEncryptedClaims(jwe)
@@ -1415,7 +1423,7 @@ class JwtsTest {
                     .compact()
 
                 //decompress and decrypt:
-                def jwt = Jwts.parser()
+                def jwt = Jwt.parser()
                     .decryptWith(key)
                     .build()
                     .parseEncryptedContent(jwe)
@@ -1445,7 +1453,7 @@ class JwtsTest {
                         .compact()
 
                 //decompress and decrypt:
-                def jwt = Jwts.parser()
+                def jwt = Jwt.parser()
                         .decryptWith(key)
                         .build()
                         .parseEncryptedContent(jwe)
@@ -1477,7 +1485,7 @@ class JwtsTest {
                         .compact()
 
                 //decompress and decrypt:
-                def jwt = Jwts.parser()
+                def jwt = Jwt.parser()
                         .decryptWith(key)
                         .build()
                         .parseEncryptedContent(jwe)
@@ -1506,7 +1514,7 @@ class JwtsTest {
                         .compact()
 
                 //decrypt:
-                def jwt = Jwts.parser()
+                def jwt = Jwt.parser()
                         .decryptWith(key)
                         .build()
                         .parseEncryptedClaims(jwe)
@@ -1527,7 +1535,7 @@ class JwtsTest {
                 .compact()
 
         //decrypt:
-        def jwt = Jwts.parser()
+        def jwt = Jwt.parser()
                 .decryptWith(key)
                 .build()
                 .parseEncryptedClaims(jwe)
@@ -1560,7 +1568,7 @@ class JwtsTest {
                             .compact()
 
                     //decrypt:
-                    def jwt = Jwts.parser()
+                    def jwt = Jwt.parser()
                             .decryptWith(privKey)
                             .build()
                             .parseEncryptedClaims(jwe)
@@ -1595,7 +1603,7 @@ class JwtsTest {
                             .compact()
 
                     //decrypt:
-                    def jwt = Jwts.parser()
+                    def jwt = Jwt.parser()
                             .decryptWith(privKey)
                             .build()
                             .parseEncryptedClaims(jwe)
@@ -1699,7 +1707,7 @@ class JwtsTest {
     }
 
     static Jwe<Claims> decrypt(String jwe, PrivateKey key) {
-        return Jwts.parser().decryptWith(key).build().parseEncryptedClaims(jwe)
+        return Jwt.parser().decryptWith(key).build().parseEncryptedClaims(jwe)
     }
 
     static void testRsa(io.jsonwebtoken.security.SignatureAlgorithm alg) {
@@ -1712,7 +1720,7 @@ class JwtsTest {
 
         String jwt = Jwts.builder().claims().add(claims).and().signWith(privateKey, alg).compact()
 
-        def token = Jwts.parser().verifyWith(publicKey).build().parse(jwt)
+        def token = Jwt.parser().verifyWith(publicKey).build().parse(jwt)
 
         assertEquals([alg: alg.getId()], token.header)
         assertEquals(claims, token.payload)
@@ -1727,7 +1735,7 @@ class JwtsTest {
 
         String jwt = Jwts.builder().claims().add(claims).and().signWith(key, alg).compact()
 
-        def token = Jwts.parser().verifyWith(key).build().parse(jwt)
+        def token = Jwt.parser().verifyWith(key).build().parse(jwt)
 
         assertEquals([alg: alg.getId()], token.header)
         assertEquals(claims, token.payload)
@@ -1751,7 +1759,7 @@ class JwtsTest {
             key = privateKey
         }
 
-        def token = Jwts.parser().verifyWith(key).build().parse(jwt)
+        def token = Jwt.parser().verifyWith(key).build().parse(jwt)
 
         assertEquals([alg: alg.getId()], token.header)
         assertEquals(claims, token.payload)

--- a/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/JwtsTest.groovy
@@ -15,7 +15,6 @@
  */
 package io.jsonwebtoken
 
-import io.jsonwebtoken.SignatureAlgorithm
 import io.jsonwebtoken.impl.*
 import io.jsonwebtoken.impl.compression.GzipCompressionAlgorithm
 import io.jsonwebtoken.impl.io.Streams

--- a/impl/src/test/groovy/io/jsonwebtoken/LocatorAdapterTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/LocatorAdapterTest.groovy
@@ -27,7 +27,7 @@ class LocatorAdapterTest {
 
     @Test
     void testJwtHeader() {
-        Header input = Jwts.header().build()
+        Header input = Jwt.header().build()
         def locator = new LocatorAdapter() {
             @Override
             protected Object doLocate(Header header) {
@@ -39,7 +39,7 @@ class LocatorAdapterTest {
 
     @Test
     void testJwtHeaderWithoutOverride() {
-        Header input = Jwts.header().build()
+        Header input = Jwt.header().build()
         Locator locator = new LocatorAdapter() {}
         assertNull locator.locate(input as Header /* force Groovy to avoid signature erasure */)
     }

--- a/impl/src/test/groovy/io/jsonwebtoken/RFC7515AppendixETest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/RFC7515AppendixETest.groovy
@@ -57,7 +57,7 @@ class RFC7515AppendixETest {
         String jws = b64url + '.RkFJTA.'
 
         try {
-            Jwts.parser().unsecured().build().parse(jws)
+            Jwt.parser().unsecured().build().parse(jws)
             fail()
         } catch (MalformedJwtException expected) {
             String msg = String.format(DefaultJwtParser.CRIT_UNSECURED_MSG, header)
@@ -88,7 +88,7 @@ class RFC7515AppendixETest {
         String jws = b64url + '.RkFJTA.fakesignature' // needed to parse a JWS properly
 
         try {
-            Jwts.parser().unsecured().build().parse(jws)
+            Jwt.parser().unsecured().build().parse(jws)
             fail()
         } catch (UnsupportedJwtException expected) {
             String msg = String.format(DefaultJwtParser.CRIT_UNSUPPORTED_MSG, critVal, critVal, header)

--- a/impl/src/test/groovy/io/jsonwebtoken/RFC7797Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/RFC7797Test.groovy
@@ -74,7 +74,7 @@ class RFC7797Test {
         InputStream asBufferedInputStream = new BufferedInputStream(Streams.of(content))
 
         for (def payload : [content, asByteInputStream, asBufferedInputStream]) {
-            def parser = Jwts.parser().verifyWith(key).build()
+            def parser = Jwt.parser().verifyWith(key).build()
             def jws
             if (payload instanceof byte[]) {
                 jws = parser.parseSignedContent(s, (byte[]) payload)
@@ -97,7 +97,7 @@ class RFC7797Test {
 
         def key = TestKeys.HS256
 
-        def claims = Jwts.claims().subject('me').build()
+        def claims = Claims.builder().subject('me').build()
 
         ByteArrayOutputStream out = new ByteArrayOutputStream()
         Services.get(Serializer).serialize(claims, out)
@@ -110,7 +110,7 @@ class RFC7797Test {
         InputStream asBufferedInputStream = new BufferedInputStream(Streams.of(content))
 
         for (def payload : [content, asByteInputStream, asBufferedInputStream]) {
-            def parser = Jwts.parser().verifyWith(key).build()
+            def parser = Jwt.parser().verifyWith(key).build()
             def jws
             if (payload instanceof byte[]) {
                 jws = parser.parseSignedClaims(s, (byte[]) payload)
@@ -136,7 +136,7 @@ class RFC7797Test {
         InputStream asBufferedInputStream = new BufferedInputStream(Streams.of(content))
 
         for (def payload : [content, asByteInputStream, asBufferedInputStream]) {
-            def parser = Jwts.parser().verifyWith(key).build()
+            def parser = Jwt.parser().verifyWith(key).build()
             def jws
             if (payload instanceof byte[]) {
                 jws = parser.parseSignedContent(s, (byte[]) payload)
@@ -175,7 +175,7 @@ class RFC7797Test {
         String compact = Jwts.builder().content(stream).signWith(key).encodePayload(false).compact()
 
         // signature still verified:
-        def jwt = Jwts.parser().verifyWith(key).build().parseSignedContent(compact, data)
+        def jwt = Jwt.parser().verifyWith(key).build().parseSignedContent(compact, data)
         assertEquals 'HS256', jwt.header.getAlgorithm()
         assertEquals s, Strings.utf8(jwt.getPayload())
     }
@@ -189,7 +189,7 @@ class RFC7797Test {
 
         String s = Jwts.builder().signWith(key).content(payload).encodePayload(false).compact()
 
-        def jws = Jwts.parser().verifyWith(key).build().parseSignedClaims(s, payload)
+        def jws = Jwt.parser().verifyWith(key).build().parseSignedClaims(s, payload)
 
         assertEquals 'me', jws.getPayload().getSubject()
     }
@@ -209,7 +209,7 @@ class RFC7797Test {
 
         String s = Jwts.builder().signWith(key).content(payload).encodePayload(false).compact()
 
-        def jws = Jwts.parser().verifyWith(key) // .critical("b64") is not called, should still work:
+        def jws = Jwt.parser().verifyWith(key) // .critical("b64") is not called, should still work:
                 .build().parseSignedClaims(s, payload)
 
         assertEquals 'me', jws.getPayload().getSubject()
@@ -229,7 +229,7 @@ class RFC7797Test {
     @Test
     void testParseContentWithEmptyBytesPayload() {
         try {
-            Jwts.parser().verifyWith(TestKeys.HS256).build().parseSignedContent('whatever', Bytes.EMPTY) // <-- empty
+            Jwt.parser().verifyWith(TestKeys.HS256).build().parseSignedContent('whatever', Bytes.EMPTY) // <-- empty
             fail()
         } catch (IllegalArgumentException expected) {
             String msg = 'unencodedPayload argument cannot be null or empty.'
@@ -240,7 +240,7 @@ class RFC7797Test {
     @Test
     void testParseClaimsWithEmptyBytesPayload() {
         try {
-            Jwts.parser().verifyWith(TestKeys.HS256).build().parseSignedClaims('whatever', Bytes.EMPTY) // <-- empty
+            Jwt.parser().verifyWith(TestKeys.HS256).build().parseSignedClaims('whatever', Bytes.EMPTY) // <-- empty
             fail()
         } catch (IllegalArgumentException expected) {
             String msg = 'unencodedPayload argument cannot be null or empty.'
@@ -261,7 +261,7 @@ class RFC7797Test {
 
         // try to parse it as a 'normal' JWS (without supplying the payload):
         try {
-            Jwts.parser().verifyWith(key).critical().add(DefaultJwsHeader.B64.id).and().build()
+            Jwt.parser().verifyWith(key).critical().add(DefaultJwsHeader.B64.id).and().build()
                     .parseSignedContent(s) // <-- no payload supplied
             fail()
         } catch (io.jsonwebtoken.security.SignatureException expected) {
@@ -284,7 +284,7 @@ class RFC7797Test {
 
         // try to parse it as a 'normal' JWS (without supplying the payload):
         try {
-            Jwts.parser().verifyWith(key).critical().add(DefaultJwsHeader.B64.id).and().build()
+            Jwt.parser().verifyWith(key).critical().add(DefaultJwsHeader.B64.id).and().build()
                     .parseSignedClaims(s) // <-- no payload supplied
             fail()
         } catch (io.jsonwebtoken.security.SignatureException expected) {
@@ -308,7 +308,7 @@ class RFC7797Test {
         // create a non-detached unencoded JWS:
         String s = Jwts.builder().signWith(key).content(payload).encodePayload(false).compact()
 
-        def jws = Jwts.parser().verifyWith(key).critical().add(DefaultJwsHeader.B64.id).and().build()
+        def jws = Jwt.parser().verifyWith(key).critical().add(DefaultJwsHeader.B64.id).and().build()
                 .parseSignedContent(s) // <--- parse normally, without calling parseSignedContent(s, unencodedPayload)
 
         assertArrayEquals Strings.utf8(payload), jws.getPayload()
@@ -322,7 +322,7 @@ class RFC7797Test {
         // create a non-detached unencoded JWS:
         String s = Jwts.builder().signWith(key).subject('me').encodePayload(false).compact()
 
-        def jws = Jwts.parser().verifyWith(key).critical().add(DefaultJwsHeader.B64.id).and().build()
+        def jws = Jwt.parser().verifyWith(key).critical().add(DefaultJwsHeader.B64.id).and().build()
                 .parseSignedClaims(s) // <--- parse normally, without calling parseSignedClaims(s, unencodedPayload)
 
         assertEquals 'me', jws.getPayload().getSubject()
@@ -351,7 +351,7 @@ class RFC7797Test {
             InputStream asBufferedInputStream = new BufferedInputStream(Streams.of(compressed))
 
             for (def payload : [compressed, asByteInputStream, asBufferedInputStream]) {
-                def parser = Jwts.parser().verifyWith(key).build()
+                def parser = Jwt.parser().verifyWith(key).build()
                 def jws
                 if (payload instanceof byte[]) {
                     jws = parser.parseSignedContent(s, (byte[]) payload)
@@ -391,7 +391,7 @@ class RFC7797Test {
 
         // now try to parse a compressed unencoded using a signing key resolver:
         try {
-            Jwts.parser()
+            Jwt.parser()
                     .setSigningKeyResolver(new SigningKeyResolverAdapter() {
                         @Override
                         Key resolveSigningKey(JwsHeader header, byte[] content) {

--- a/impl/src/test/groovy/io/jsonwebtoken/RFC7797Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/RFC7797Test.groovy
@@ -37,7 +37,7 @@ class RFC7797Test {
     @Test
     void testJwe() {
         try {
-            Jwts.builder().content('hello').encryptWith(TestKeys.A128GCM, Jwe.enc.A128GCM)
+            Jwt.builder().content('hello').encryptWith(TestKeys.A128GCM, Jwe.enc.A128GCM)
                     .encodePayload(false) // not allowed with JWE
                     .compact()
             fail()
@@ -50,7 +50,7 @@ class RFC7797Test {
     @Test
     void testUnprotectedJwt() {
         try {
-            Jwts.builder().content('hello')
+            Jwt.builder().content('hello')
                     .encodePayload(false) // not allowed with JWT
                     .compact()
             fail()
@@ -67,7 +67,7 @@ class RFC7797Test {
 
         byte[] content = Strings.utf8('$.02') // https://datatracker.ietf.org/doc/html/rfc7797#section-4.2
 
-        String s = Jwts.builder().signWith(key).content(content).encodePayload(false).compact()
+        String s = Jwt.builder().signWith(key).content(content).encodePayload(false).compact()
 
         // But verify with 3 types of sources: string, byte array, and two different kinds of InputStreams:
         InputStream asByteInputStream = Streams.of(content)
@@ -103,7 +103,7 @@ class RFC7797Test {
         Services.get(Serializer).serialize(claims, out)
         byte[] content = out.toByteArray()
 
-        String s = Jwts.builder().signWith(key).content(content).encodePayload(false).compact()
+        String s = Jwt.builder().signWith(key).content(content).encodePayload(false).compact()
 
         // But verify with 3 types of sources: string, byte array, and two different kinds of InputStreams:
         InputStream asByteInputStream = Streams.of(content)
@@ -129,7 +129,7 @@ class RFC7797Test {
         byte[] content = Strings.utf8('$.02') // https://datatracker.ietf.org/doc/html/rfc7797#section-4.2
         InputStream contentStream = Streams.of(content)
 
-        String s = Jwts.builder().signWith(key).content(contentStream).encodePayload(false).compact()
+        String s = Jwt.builder().signWith(key).content(contentStream).encodePayload(false).compact()
 
         // But verify with 3 types of sources: byte array, and two different kinds of InputStreams:
         InputStream asByteInputStream = Streams.of(content)
@@ -172,7 +172,7 @@ class RFC7797Test {
         }
 
         // compact/sign shouldn't fail, should still compute signature:
-        String compact = Jwts.builder().content(stream).signWith(key).encodePayload(false).compact()
+        String compact = Jwt.builder().content(stream).signWith(key).encodePayload(false).compact()
 
         // signature still verified:
         def jwt = Jwt.parser().verifyWith(key).build().parseSignedContent(compact, data)
@@ -187,7 +187,7 @@ class RFC7797Test {
 
         byte[] payload = Strings.utf8('{"sub":"me"}')
 
-        String s = Jwts.builder().signWith(key).content(payload).encodePayload(false).compact()
+        String s = Jwt.builder().signWith(key).content(payload).encodePayload(false).compact()
 
         def jws = Jwt.parser().verifyWith(key).build().parseSignedClaims(s, payload)
 
@@ -207,7 +207,7 @@ class RFC7797Test {
 
         byte[] payload = Strings.utf8('{"sub":"me"}')
 
-        String s = Jwts.builder().signWith(key).content(payload).encodePayload(false).compact()
+        String s = Jwt.builder().signWith(key).content(payload).encodePayload(false).compact()
 
         def jws = Jwt.parser().verifyWith(key) // .critical("b64") is not called, should still work:
                 .build().parseSignedClaims(s, payload)
@@ -218,7 +218,7 @@ class RFC7797Test {
     @Test
     void testEmptyBytesPayload() {
         try {
-            Jwts.builder().content(Bytes.EMPTY).encodePayload(false).signWith(TestKeys.HS256).compact()
+            Jwt.builder().content(Bytes.EMPTY).encodePayload(false).signWith(TestKeys.HS256).compact()
             fail()
         } catch (IllegalStateException expected) {
             String msg = "'b64' Unencoded payload option has been specified, but payload is empty."
@@ -256,7 +256,7 @@ class RFC7797Test {
         byte[] payload = Strings.utf8('$.02') // https://datatracker.ietf.org/doc/html/rfc7797#section-4.2
 
         // s is an unencoded-payload JWS
-        String s = Jwts.builder().signWith(key).content(payload).encodePayload(false).compact()
+        String s = Jwt.builder().signWith(key).content(payload).encodePayload(false).compact()
         def expectedHeader = [alg: 'HS256', b64: false, crit: ['b64']]
 
         // try to parse it as a 'normal' JWS (without supplying the payload):
@@ -278,7 +278,7 @@ class RFC7797Test {
         byte[] payload = Strings.utf8('$.02') // https://datatracker.ietf.org/doc/html/rfc7797#section-4.2
 
         // s is an unencoded-payload JWS
-        String s = Jwts.builder().signWith(key).content(payload).encodePayload(false).compact()
+        String s = Jwt.builder().signWith(key).content(payload).encodePayload(false).compact()
 
         def expectedHeader = [alg: 'HS256', b64: false, crit: ['b64']]
 
@@ -306,7 +306,7 @@ class RFC7797Test {
         String payload = 'foo'
 
         // create a non-detached unencoded JWS:
-        String s = Jwts.builder().signWith(key).content(payload).encodePayload(false).compact()
+        String s = Jwt.builder().signWith(key).content(payload).encodePayload(false).compact()
 
         def jws = Jwt.parser().verifyWith(key).critical().add(DefaultJwsHeader.B64.id).and().build()
                 .parseSignedContent(s) // <--- parse normally, without calling parseSignedContent(s, unencodedPayload)
@@ -320,7 +320,7 @@ class RFC7797Test {
         def key = TestKeys.HS256
 
         // create a non-detached unencoded JWS:
-        String s = Jwts.builder().signWith(key).subject('me').encodePayload(false).compact()
+        String s = Jwt.builder().signWith(key).subject('me').encodePayload(false).compact()
 
         def jws = Jwt.parser().verifyWith(key).critical().add(DefaultJwsHeader.B64.id).and().build()
                 .parseSignedClaims(s) // <--- parse normally, without calling parseSignedClaims(s, unencodedPayload)
@@ -342,7 +342,7 @@ class RFC7797Test {
             def compressed = out.toByteArray()
 
             // create a detached unencoded JWS that is compressed:
-            String s = Jwts.builder().signWith(key).content(content).encodePayload(false)
+            String s = Jwt.builder().signWith(key).content(content).encodePayload(false)
                     .compressWith(zip)
                     .compact()
 
@@ -386,7 +386,7 @@ class RFC7797Test {
         def zip = Jwe.zip.DEF
 
         // create a detached unencoded JWS that is compressed:
-        String s = Jwts.builder().content(payload).encodePayload(false)
+        String s = Jwt.builder().content(payload).encodePayload(false)
                 .compressWith(zip).signWith(key).compact()
 
         // now try to parse a compressed unencoded using a signing key resolver:

--- a/impl/src/test/groovy/io/jsonwebtoken/RsaSigningKeyResolverAdapterTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/RsaSigningKeyResolverAdapterTest.groovy
@@ -32,7 +32,7 @@ class RsaSigningKeyResolverAdapterTest {
 
         def compact = Jwts.builder().claim('foo', 'bar').signWith(pair.private, alg).compact()
 
-        Jws<Claims> jws = Jwts.parser().setSigningKey(pair.public).build().parseSignedClaims(compact)
+        Jws<Claims> jws = Jwt.parser().setSigningKey(pair.public).build().parseSignedClaims(compact)
 
         try {
             new SigningKeyResolverAdapter().resolveSigningKey(jws.header, jws.payload)

--- a/impl/src/test/groovy/io/jsonwebtoken/RsaSigningKeyResolverAdapterTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/RsaSigningKeyResolverAdapterTest.groovy
@@ -30,7 +30,7 @@ class RsaSigningKeyResolverAdapterTest {
 
         def pair = Keys.keyPairFor(alg)
 
-        def compact = Jwts.builder().claim('foo', 'bar').signWith(pair.private, alg).compact()
+        def compact = Jwt.builder().claim('foo', 'bar').signWith(pair.private, alg).compact()
 
         Jws<Claims> jws = Jwt.parser().setSigningKey(pair.public).build().parseSignedClaims(compact)
 

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/AbstractProtectedHeaderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/AbstractProtectedHeaderTest.groovy
@@ -15,7 +15,7 @@
  */
 package io.jsonwebtoken.impl
 
-import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.impl.security.Randoms
 import io.jsonwebtoken.impl.security.TestKeys
 import io.jsonwebtoken.io.Encoders
@@ -57,7 +57,7 @@ class AbstractProtectedHeaderTest {
     @Test
     void testJku() {
         URI uri = URI.create('https://github.com')
-        def header = Jwts.header().add('alg', 'foo').jwkSetUrl(uri).build() as DefaultProtectedHeader
+        def header = Jwt.header().add('alg', 'foo').jwkSetUrl(uri).build() as DefaultProtectedHeader
         assertEquals uri.toString(), header.get('jku')
         assertEquals uri, header.getJwkSetUrl()
     }
@@ -213,7 +213,7 @@ class AbstractProtectedHeaderTest {
     @Test
     void testCritical() {
         Set<String> crits = Collections.setOf('foo', 'bar')
-        def header = Jwts.header().add('alg', 'HS256').add('foo', 'value1').add('bar', 'value2')
+        def header = Jwt.header().add('alg', 'HS256').add('foo', 'value1').add('bar', 'value2')
                 .critical().add(crits).and().build() as DefaultProtectedHeader
         assertEquals crits, header.getCritical()
     }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJweTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJweTest.groovy
@@ -16,6 +16,7 @@
 package io.jsonwebtoken.impl
 
 import io.jsonwebtoken.Jwe
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Encoders
 import io.jsonwebtoken.security.AeadAlgorithm
@@ -31,7 +32,7 @@ class DefaultJweTest {
         def alg = Jwe.enc.A128CBC_HS256 as AeadAlgorithm
         def key = alg.key().build()
         String compact = Jwts.builder().claim('foo', 'bar').encryptWith(key, alg).compact()
-        def jwe = Jwts.parser().decryptWith(key).build().parseEncryptedClaims(compact)
+        def jwe = Jwt.parser().decryptWith(key).build().parseEncryptedClaims(compact)
         String encodedIv = Encoders.BASE64URL.encode(jwe.initializationVector)
         String encodedTag = Encoders.BASE64URL.encode(jwe.digest)
         String expected = "header={alg=dir, enc=A128CBC-HS256},payload={foo=bar},tag=$encodedTag,iv=$encodedIv"
@@ -43,7 +44,7 @@ class DefaultJweTest {
         def alg = Jwe.enc.A128CBC_HS256 as AeadAlgorithm
         def key = alg.key().build()
         String compact = Jwts.builder().claim('foo', 'bar').encryptWith(key, alg).compact()
-        def parser = Jwts.parser().decryptWith(key).build()
+        def parser = Jwt.parser().decryptWith(key).build()
         def jwe1 = parser.parseEncryptedClaims(compact)
         def jwe2 = parser.parseEncryptedClaims(compact)
         assertNotEquals jwe1, 'hello' as String

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJweTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJweTest.groovy
@@ -17,7 +17,6 @@ package io.jsonwebtoken.impl
 
 import io.jsonwebtoken.Jwe
 import io.jsonwebtoken.Jwt
-import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Encoders
 import io.jsonwebtoken.security.AeadAlgorithm
 import org.junit.Test
@@ -31,7 +30,7 @@ class DefaultJweTest {
     void testToString() {
         def alg = Jwe.enc.A128CBC_HS256 as AeadAlgorithm
         def key = alg.key().build()
-        String compact = Jwts.builder().claim('foo', 'bar').encryptWith(key, alg).compact()
+        String compact = Jwt.builder().claim('foo', 'bar').encryptWith(key, alg).compact()
         def jwe = Jwt.parser().decryptWith(key).build().parseEncryptedClaims(compact)
         String encodedIv = Encoders.BASE64URL.encode(jwe.initializationVector)
         String encodedTag = Encoders.BASE64URL.encode(jwe.digest)
@@ -43,7 +42,7 @@ class DefaultJweTest {
     void testEqualsAndHashCode() {
         def alg = Jwe.enc.A128CBC_HS256 as AeadAlgorithm
         def key = alg.key().build()
-        String compact = Jwts.builder().claim('foo', 'bar').encryptWith(key, alg).compact()
+        String compact = Jwt.builder().claim('foo', 'bar').encryptWith(key, alg).compact()
         def parser = Jwt.parser().decryptWith(key).build()
         def jwe1 = parser.parseEncryptedClaims(compact)
         def jwe2 = parser.parseEncryptedClaims(compact)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwsTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwsTest.groovy
@@ -18,7 +18,6 @@ package io.jsonwebtoken.impl
 import io.jsonwebtoken.Jws
 import io.jsonwebtoken.JwsHeader
 import io.jsonwebtoken.Jwt
-import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.impl.lang.Bytes
 import io.jsonwebtoken.io.Encoders
 import org.junit.Test
@@ -46,7 +45,7 @@ class DefaultJwsTest {
         //create random signing key for testing:
         def alg = Jws.alg.HS256
         def key = alg.key().build()
-        String compact = Jwts.builder().claim('foo', 'bar').signWith(key, alg).compact()
+        String compact = Jwt.builder().claim('foo', 'bar').signWith(key, alg).compact()
         int i = compact.lastIndexOf('.')
         String signature = compact.substring(i + 1)
         def jws = Jwt.parser().verifyWith(key).build().parseSignedClaims(compact)
@@ -57,7 +56,7 @@ class DefaultJwsTest {
     void testEqualsAndHashCode() {
         def alg = Jws.alg.HS256
         def key = alg.key().build()
-        String compact = Jwts.builder().claim('foo', 'bar').signWith(key, alg).compact()
+        String compact = Jwt.builder().claim('foo', 'bar').signWith(key, alg).compact()
         def parser = Jwt.parser().verifyWith(key).build()
         def jws1 = parser.parseSignedClaims(compact)
         def jws2 = parser.parseSignedClaims(compact)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwsTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwsTest.groovy
@@ -17,6 +17,7 @@ package io.jsonwebtoken.impl
 
 import io.jsonwebtoken.Jws
 import io.jsonwebtoken.JwsHeader
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.impl.lang.Bytes
 import io.jsonwebtoken.io.Encoders
@@ -48,7 +49,7 @@ class DefaultJwsTest {
         String compact = Jwts.builder().claim('foo', 'bar').signWith(key, alg).compact()
         int i = compact.lastIndexOf('.')
         String signature = compact.substring(i + 1)
-        def jws = Jwts.parser().verifyWith(key).build().parseSignedClaims(compact)
+        def jws = Jwt.parser().verifyWith(key).build().parseSignedClaims(compact)
         assertEquals 'header={alg=HS256},payload={foo=bar},signature=' + signature, jws.toString()
     }
 
@@ -57,7 +58,7 @@ class DefaultJwsTest {
         def alg = Jws.alg.HS256
         def key = alg.key().build()
         String compact = Jwts.builder().claim('foo', 'bar').signWith(key, alg).compact()
-        def parser = Jwts.parser().verifyWith(key).build()
+        def parser = Jwt.parser().verifyWith(key).build()
         def jws1 = parser.parseSignedClaims(compact)
         def jws2 = parser.parseSignedClaims(compact)
         assertNotEquals jws1, 'hello' as String

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtBuilderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtBuilderTest.groovy
@@ -686,19 +686,19 @@ class DefaultJwtBuilderTest {
     @Test
     void testAudience() {
         def aud = 'fubar'
-        def jwt = Jwts.builder().audience().add(aud).and().compact()
+        def jwt = Jwt.builder().audience().add(aud).and().compact()
         assertEquals aud, Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience().iterator().next()
     }
 
     @Test
     void testAudienceNullString() {
-        def jwt = Jwts.builder().subject('me').audience().add(null).and().compact()
+        def jwt = Jwt.builder().subject('me').audience().add(null).and().compact()
         assertNull Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
     }
 
     @Test
     void testAudienceEmptyString() {
-        def jwt = Jwts.builder().subject('me').audience().add('  ').and().compact()
+        def jwt = Jwt.builder().subject('me').audience().add('  ').and().compact()
         assertNull Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
     }
 
@@ -706,7 +706,7 @@ class DefaultJwtBuilderTest {
     void testAudienceMultipleTimes() {
         def one = 'one'
         def two = 'two'
-        def jwt = Jwts.builder().audience().add(one).add(two).and().compact()
+        def jwt = Jwt.builder().audience().add(one).add(two).and().compact()
         def aud = Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
         assertTrue aud.contains(one)
         assertTrue aud.contains(two)
@@ -715,14 +715,14 @@ class DefaultJwtBuilderTest {
     @Test
     void testAudienceNullCollection() {
         Collection c = null
-        def jwt = Jwts.builder().subject('me').audience().add(c).and().compact()
+        def jwt = Jwt.builder().subject('me').audience().add(c).and().compact()
         assertNull Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
     }
 
     @Test
     void testAudienceEmptyCollection() {
         Collection c = new ArrayList()
-        def jwt = Jwts.builder().subject('me').audience().add(c).and().compact()
+        def jwt = Jwt.builder().subject('me').audience().add(c).and().compact()
         assertNull Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
     }
 
@@ -730,7 +730,7 @@ class DefaultJwtBuilderTest {
     void testAudienceCollectionWithNullElement() {
         Collection c = new ArrayList()
         c.add(null)
-        def jwt = Jwts.builder().subject('me').audience().add(c).and().compact()
+        def jwt = Jwt.builder().subject('me').audience().add(c).and().compact()
         assertNull Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
     }
 
@@ -743,7 +743,7 @@ class DefaultJwtBuilderTest {
         def one = 'one'
         def two = 'two'
         //noinspection GrDeprecatedAPIUsage
-        def jwt = Jwts.builder().audience().single(one).audience().add(two).and().compact()
+        def jwt = Jwt.builder().audience().single(one).audience().add(two).and().compact()
         def aud = Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
         assertTrue aud.contains(one)
         assertTrue aud.contains(two)
@@ -759,7 +759,7 @@ class DefaultJwtBuilderTest {
         def one = 'one'
         def two = 'two'
         //noinspection GrDeprecatedAPIUsage
-        def jwt = Jwts.builder().audience().add(one).and().audience().single(two).compact()
+        def jwt = Jwt.builder().audience().add(one).and().audience().single(two).compact()
 
         // can't use the parser here to validate because it coerces the string value into an array automatically,
         // so we need to check the raw payload:
@@ -780,7 +780,7 @@ class DefaultJwtBuilderTest {
         def collection = ['two', 'three'] as Set<String>
         def expected = ['one', 'two', 'three'] as Set<String>
         //noinspection GrDeprecatedAPIUsage
-        def jwt = Jwts.builder().audience().single(single).audience().add(collection).and().compact()
+        def jwt = Jwt.builder().audience().single(single).audience().add(collection).and().compact()
         def aud = Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
         assertEquals expected.size(), aud.size()
         assertTrue aud.contains(single) && aud.containsAll(collection)
@@ -796,7 +796,7 @@ class DefaultJwtBuilderTest {
         def one = 'one'
         def two = 'two'
         def three = 'three'
-        def jwt = Jwts.builder().audience().add([one, two]).and().audience().single(three).compact()
+        def jwt = Jwt.builder().audience().add([one, two]).and().audience().single(three).compact()
 
         // can't use the parser here to validate because it coerces the string value into an array automatically,
         // so we need to check the raw payload:
@@ -816,7 +816,7 @@ class DefaultJwtBuilderTest {
     @Test
     void testAudienceWithoutConjunction() {
         def aud = 'my-web'
-        def builder = Jwts.builder()
+        def builder = Jwt.builder()
         builder.audience().add(aud) // no .and() call
         def jwt = builder.compact()
 
@@ -834,7 +834,7 @@ class DefaultJwtBuilderTest {
     @Test
     void testCritWithoutConjunction() {
         def crit = 'test'
-        def builder = Jwts.builder().issuer('me')
+        def builder = Jwt.builder().issuer('me')
         def headerBuilder = builder.header()
         headerBuilder.critical().add(crit) // no .and() method
         headerBuilder.add(crit, 'foo') // no .and() method

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtBuilderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtBuilderTest.groovy
@@ -181,7 +181,7 @@ class DefaultJwtBuilderTest {
 
     @Test
     void testSetClaims() {
-        Claims c = Jwts.claims().add('foo', 'bar').build()
+        Claims c = Claims.builder().add('foo', 'bar').build()
         builder.setClaims(c)
         assertEquals c, builder.claimsBuilder
     }
@@ -237,7 +237,7 @@ class DefaultJwtBuilderTest {
 
     @Test
     void testExistingClaimsAndSetClaim() {
-        Claims c = Jwts.claims().add('foo', 'bar').build()
+        Claims c = Claims.builder().add('foo', 'bar').build()
         builder.claims().add(c)
         assertEquals c, builder.claimsBuilder
         assertEquals builder.claimsBuilder.size(), 1
@@ -345,7 +345,7 @@ class DefaultJwtBuilderTest {
                 vkey = key
             }
 
-            def parser = Jwts.parser().verifyWith(vkey).build()
+            def parser = Jwt.parser().verifyWith(vkey).build()
 
             String s1 = builder.signWith(key).compact()
             def jws = parser.parseSignedClaims(s1)
@@ -531,7 +531,7 @@ class DefaultJwtBuilderTest {
                 .compact()
 
         assertTrue invoked // ensure we call our custom one
-        assertEquals 'bar', Jwts.parser().setSigningKey(key).build().parseSignedClaims(jws).getPayload().get('foo')
+        assertEquals 'bar', Jwt.parser().setSigningKey(key).build().parseSignedClaims(jws).getPayload().get('foo')
     }
 
     @Test
@@ -563,7 +563,7 @@ class DefaultJwtBuilderTest {
         def enc = Jwe.enc.A128GCM
         def key = enc.key().build()
         def jwe = builder.setPayload("me").encryptWith(key, enc).compact()
-        def jwt = Jwts.parser().decryptWith(key).build().parseEncryptedContent(jwe)
+        def jwt = Jwt.parser().decryptWith(key).build().parseEncryptedContent(jwe)
         assertEquals 'me', new String(jwt.getPayload(), StandardCharsets.UTF_8)
     }
 
@@ -572,7 +572,7 @@ class DefaultJwtBuilderTest {
         def enc = Jwe.enc.A128GCM
         def key = enc.key().build()
         def jwe = builder.setSubject('joe').encryptWith(key, enc).compact()
-        def jwt = Jwts.parser().decryptWith(key).build().parseEncryptedClaims(jwe)
+        def jwt = Jwt.parser().decryptWith(key).build().parseEncryptedClaims(jwe)
         assertEquals 'joe', jwt.getPayload().getSubject()
     }
 
@@ -646,7 +646,7 @@ class DefaultJwtBuilderTest {
                 .compact()
 
         // shouldn't be an audience at all:
-        assertNull Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
+        assertNull Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
     }
 
     /**
@@ -664,7 +664,7 @@ class DefaultJwtBuilderTest {
                 .audience().add([first, second]).and() // sets collection
                 .compact()
 
-        def aud = Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
+        def aud = Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
         assertEquals expected, aud
     }
 
@@ -679,7 +679,7 @@ class DefaultJwtBuilderTest {
         String audienceSingleString = 'test'
         def jwt = builder.audience().single(audienceSingleString).compact()
 
-        assertEquals audienceSingleString, Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt).payload
+        assertEquals audienceSingleString, Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload
                 .getAudience().iterator().next() // a collection, not a single string
     }
 
@@ -687,19 +687,19 @@ class DefaultJwtBuilderTest {
     void testAudience() {
         def aud = 'fubar'
         def jwt = Jwts.builder().audience().add(aud).and().compact()
-        assertEquals aud, Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience().iterator().next()
+        assertEquals aud, Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience().iterator().next()
     }
 
     @Test
     void testAudienceNullString() {
         def jwt = Jwts.builder().subject('me').audience().add(null).and().compact()
-        assertNull Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
+        assertNull Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
     }
 
     @Test
     void testAudienceEmptyString() {
         def jwt = Jwts.builder().subject('me').audience().add('  ').and().compact()
-        assertNull Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
+        assertNull Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
     }
 
     @Test
@@ -707,7 +707,7 @@ class DefaultJwtBuilderTest {
         def one = 'one'
         def two = 'two'
         def jwt = Jwts.builder().audience().add(one).add(two).and().compact()
-        def aud = Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
+        def aud = Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
         assertTrue aud.contains(one)
         assertTrue aud.contains(two)
     }
@@ -716,14 +716,14 @@ class DefaultJwtBuilderTest {
     void testAudienceNullCollection() {
         Collection c = null
         def jwt = Jwts.builder().subject('me').audience().add(c).and().compact()
-        assertNull Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
+        assertNull Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
     }
 
     @Test
     void testAudienceEmptyCollection() {
         Collection c = new ArrayList()
         def jwt = Jwts.builder().subject('me').audience().add(c).and().compact()
-        assertNull Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
+        assertNull Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
     }
 
     @Test
@@ -731,7 +731,7 @@ class DefaultJwtBuilderTest {
         Collection c = new ArrayList()
         c.add(null)
         def jwt = Jwts.builder().subject('me').audience().add(c).and().compact()
-        assertNull Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
+        assertNull Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
     }
 
     /**
@@ -744,7 +744,7 @@ class DefaultJwtBuilderTest {
         def two = 'two'
         //noinspection GrDeprecatedAPIUsage
         def jwt = Jwts.builder().audience().single(one).audience().add(two).and().compact()
-        def aud = Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
+        def aud = Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
         assertTrue aud.contains(one)
         assertTrue aud.contains(two)
     }
@@ -781,7 +781,7 @@ class DefaultJwtBuilderTest {
         def expected = ['one', 'two', 'three'] as Set<String>
         //noinspection GrDeprecatedAPIUsage
         def jwt = Jwts.builder().audience().single(single).audience().add(collection).and().compact()
-        def aud = Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
+        def aud = Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).payload.getAudience()
         assertEquals expected.size(), aud.size()
         assertTrue aud.contains(single) && aud.containsAll(collection)
     }
@@ -821,7 +821,7 @@ class DefaultJwtBuilderTest {
         def jwt = builder.compact()
 
         // assert that the resulting claims has the audience array set as expected:
-        def parsed = Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt)
+        def parsed = Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt)
         assertEquals aud, parsed.payload.getAudience()[0]
     }
 

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtBuilderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtBuilderTest.groovy
@@ -146,14 +146,14 @@ class DefaultJwtBuilderTest {
 
     @Test
     void testSetHeader() {
-        def h = Jwts.header().add('foo', 'bar').build()
+        def h = Jwt.header().add('foo', 'bar').build()
         builder.setHeader(h)
         assertEquals h, builder.headerBuilder.build()
     }
 
     @Test
     void testHeaderConsumer() {
-        def h = Jwts.header().add('foo', 'bar').build()
+        def h = Jwt.header().add('foo', 'bar').build()
         builder.header(header -> header.add('foo', 'bar'))
         assertEquals h, builder.headerBuilder.build()
     }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtHeaderBuilderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtHeaderBuilderTest.groovy
@@ -74,7 +74,7 @@ class DefaultJwtHeaderBuilderTest {
 
     @Test
     void testStaticFactoryMethod() {
-        assertTrue Jwts.header() instanceof DefaultJwtHeaderBuilder
+        assertTrue Jwt.header() instanceof DefaultJwtHeaderBuilder
     }
 
     @Test

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserBuilderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserBuilderTest.groovy
@@ -185,7 +185,7 @@ class DefaultJwtParserBuilderTest {
     void testAddCompressionAlgorithms() {
         def codec = new TestCompressionCodec(id: 'test')
         def parser = builder.zip().add(codec).and().build()
-        def header = Jwts.header().add('zip', codec.getId()).build()
+        def header = Jwt.header().add('zip', codec.getId()).build()
         assertSame codec, parser.zipAlgs.locate(header)
     }
 
@@ -200,13 +200,13 @@ class DefaultJwtParserBuilderTest {
         def codec = new TestCompressionCodec(id: 'test')
         builder.zip().add(codec) // no .and() call
         def parser = builder.build()
-        def header = Jwts.header().add('zip', codec.getId()).build()
+        def header = Jwt.header().add('zip', codec.getId()).build()
         assertSame codec, parser.zipAlgs.locate(header)
     }
 
     @Test
     void testAddCompressionAlgorithmsOverrideDefaults() {
-        def header = Jwts.header().add('zip', 'DEF').build()
+        def header = Jwt.header().add('zip', 'DEF').build()
         def parser = builder.build()
         assertSame Jwe.zip.DEF, parser.zipAlgs.apply(header) // standard implementation default
 
@@ -217,8 +217,8 @@ class DefaultJwtParserBuilderTest {
 
     @Test
     void testCaseSensitiveCompressionAlgorithm() {
-        def standard = Jwts.header().add('zip', 'DEF').build()
-        def nonStandard = Jwts.header().add('zip', 'def').build()
+        def standard = Jwt.header().add('zip', 'DEF').build()
+        def nonStandard = Jwt.header().add('zip', 'def').build()
         def parser = builder.build()
         assertSame Jwe.zip.DEF, parser.zipAlgs.apply(standard) // standard implementation default
         try {
@@ -233,7 +233,7 @@ class DefaultJwtParserBuilderTest {
     @Test
     void testAddEncryptionAlgorithmsOverrideDefaults() {
         final String standardId = Jwe.enc.A256GCM.getId()
-        def header = Jwts.header().add('enc', standardId).build()
+        def header = Jwt.header().add('enc', standardId).build()
         def parser = builder.build()
         assertSame Jwe.enc.A256GCM, parser.encAlgs.apply(header) // standard implementation default
 
@@ -253,15 +253,15 @@ class DefaultJwtParserBuilderTest {
         def alg = new TestAeadAlgorithm(id: 'test')
         builder.enc().add(alg) // no .and() call
         def parser = builder.build() as DefaultJwtParser
-        def header = Jwts.header().add('alg', 'foo').add('enc', alg.getId()).build() as JweHeader
+        def header = Jwt.header().add('alg', 'foo').add('enc', alg.getId()).build() as JweHeader
         assertSame alg, parser.encAlgs.apply(header)
     }
 
     @Test
     void testCaseSensitiveEncryptionAlgorithm() {
         def alg = Jwe.enc.A256GCM
-        def standard = Jwts.header().add('alg', 'foo').add('enc', alg.id).build()
-        def nonStandard = Jwts.header().add('alg', 'foo').add('enc', alg.id.toLowerCase()).build()
+        def standard = Jwt.header().add('alg', 'foo').add('enc', alg.id).build()
+        def nonStandard = Jwt.header().add('alg', 'foo').add('enc', alg.id.toLowerCase()).build()
         def parser = builder.build()
         assertSame alg, parser.encAlgs.apply(standard) // standard id
         try {
@@ -276,7 +276,7 @@ class DefaultJwtParserBuilderTest {
     @Test
     void testAddKeyAlgorithmsOverrideDefaults() {
         final String standardId = Jwe.alg.A256GCMKW.id
-        def header = Jwts.header().add('enc', Jwe.enc.A256GCM.id).add('alg', standardId).build()
+        def header = Jwt.header().add('enc', Jwe.enc.A256GCM.id).add('alg', standardId).build()
         def parser = builder.build()
         assertSame Jwe.alg.A256GCMKW, parser.keyAlgs.apply(header) // standard implementation default
 
@@ -296,7 +296,7 @@ class DefaultJwtParserBuilderTest {
         def alg = new TestKeyAlgorithm(id: 'test')
         builder.key().add(alg) // no .and() call
         def parser = builder.build() as DefaultJwtParser
-        def header = Jwts.header()
+        def header = Jwt.header()
                 .add('enc', 'foo')
                 .add('alg', alg.getId()).build() as JweHeader
         assertSame alg, parser.keyAlgs.apply(header)
@@ -305,7 +305,7 @@ class DefaultJwtParserBuilderTest {
     @Test
     void testCaseSensitiveKeyAlgorithm() {
         def alg = Jwe.alg.A256GCMKW
-        def hb = Jwts.header().add('enc', Jwe.enc.A256GCM.id)
+        def hb = Jwt.header().add('enc', Jwe.enc.A256GCM.id)
         def standard = hb.add('alg', alg.id).build()
         def nonStandard = hb.add('alg', alg.id.toLowerCase()).build()
         def parser = builder.build()
@@ -322,7 +322,7 @@ class DefaultJwtParserBuilderTest {
     @Test
     void testAddSignatureAlgorithmsOverrideDefaults() {
         final String standardId = Jws.alg.HS256.id
-        def header = Jwts.header().add('alg', standardId).build()
+        def header = Jwt.header().add('alg', standardId).build()
         def parser = builder.build()
         assertSame Jws.alg.HS256, parser.sigAlgs.apply(header) // standard implementation default
 
@@ -342,14 +342,14 @@ class DefaultJwtParserBuilderTest {
         def alg = new TestMacAlgorithm(id: 'test')
         builder.sig().add(alg) // no .and() call
         def parser = builder.build() as DefaultJwtParser
-        def header = Jwts.header().add('alg', alg.getId()).build() as JwsHeader
+        def header = Jwt.header().add('alg', alg.getId()).build() as JwsHeader
         assertSame alg, parser.sigAlgs.apply(header)
     }
 
     @Test
     void testCaseSensitiveSignatureAlgorithm() {
         def alg = Jws.alg.HS256
-        def hb = Jwts.header().add('alg', alg.id)
+        def hb = Jwt.header().add('alg', alg.id)
         def standard = hb.build()
         def nonStandard = hb.add('alg', alg.id.toLowerCase()).build()
         def parser = builder.build()

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserBuilderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserBuilderTest.groovy
@@ -111,7 +111,7 @@ class DefaultJwtParserBuilderTest {
     @Test
     void testBase64UrlEncodeWithCustomDecoder() {
 
-        String jwt = Jwts.builder().claim('foo', 'bar').compact()
+        String jwt = Jwt.builder().claim('foo', 'bar').compact()
 
         boolean invoked = false
         Decoder<String, byte[]> decoder = new Decoder<String, byte[]>() {
@@ -147,7 +147,7 @@ class DefaultJwtParserBuilderTest {
         def alg = Jws.alg.HS256
         def key = alg.key().build()
 
-        String jws = Jwts.builder().claim('foo', 'bar').signWith(key, alg).compact()
+        String jws = Jwt.builder().claim('foo', 'bar').signWith(key, alg).compact()
 
         assertEquals 'bar', p.verifyWith(key).build().parseSignedClaims(jws).getPayload().get('foo')
     }
@@ -395,7 +395,7 @@ class DefaultJwtParserBuilderTest {
     @Test
     void testDecompressUnprotectedJwtDefault() {
         def codec = Jwe.zip.GZIP
-        String jwt = Jwts.builder().compressWith(codec).setSubject('joe').compact()
+        String jwt = Jwt.builder().compressWith(codec).setSubject('joe').compact()
         try {
             builder.unsecured().build().parse(jwt)
             fail()
@@ -408,7 +408,7 @@ class DefaultJwtParserBuilderTest {
     @Test
     void testDecompressUnprotectedJwtEnabled() {
         def codec = Jwe.zip.GZIP
-        String jws = Jwts.builder().compressWith(codec).setSubject('joe').compact()
+        String jws = Jwt.builder().compressWith(codec).setSubject('joe').compact()
         def jwt = builder.unsecured().unsecuredDecompression().build().parse(jws)
         assertEquals 'joe', ((Claims) jwt.getPayload()).getSubject()
     }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserTest.groovy
@@ -62,7 +62,7 @@ class DefaultJwtParserTest {
 
     @Before
     void setUp() {
-        parser = Jwts.parser().build() as DefaultJwtParser
+        parser = Jwt.parser().build() as DefaultJwtParser
     }
 
     @Test(expected = MalformedJwtException)
@@ -80,7 +80,7 @@ class DefaultJwtParserTest {
                 return OBJECT_MAPPER.readValue(reader, Map.class)
             }
         }
-        def pb = Jwts.parser().deserializeJsonWith(deserializer)
+        def pb = Jwt.parser().deserializeJsonWith(deserializer)
         assertFalse invoked
 
         def key = Jws.alg.HS256.key().build()
@@ -106,7 +106,7 @@ class DefaultJwtParserTest {
 
         String invalidJws = compact + encodedSignature
 
-        Jwts.parser().verifyWith(key).build().parseSignedClaims(invalidJws)
+        Jwt.parser().verifyWith(key).build().parseSignedClaims(invalidJws)
     }
 
     @Test(expected = MalformedJwtException)
@@ -124,7 +124,7 @@ class DefaultJwtParserTest {
 
         String invalidJws = compact + encodedSignature
 
-        Jwts.parser().verifyWith(key).build().parseEncryptedClaims(invalidJws)
+        Jwt.parser().verifyWith(key).build().parseEncryptedClaims(invalidJws)
     }
 
     @Test(expected = MalformedJwtException)
@@ -142,7 +142,7 @@ class DefaultJwtParserTest {
 
         String invalidJws = compact + encodedSignature
 
-        Jwts.parser().verifyWith(key).build().parseSignedClaims(invalidJws)
+        Jwt.parser().verifyWith(key).build().parseSignedClaims(invalidJws)
     }
 
     /*
@@ -204,7 +204,7 @@ class DefaultJwtParserTest {
         def header = b64Url(serialize(map))
         String compact = header + '.doesntMatter.'
         try {
-            Jwts.parser().unsecured().build().parse(compact)
+            Jwt.parser().unsecured().build().parse(compact)
             fail()
         } catch (MalformedJwtException expected) {
             String msg = String.format(DefaultJwtParser.CRIT_UNSECURED_MSG, map)
@@ -218,7 +218,7 @@ class DefaultJwtParserTest {
         def header = b64Url(serialize(map))
         String compact = header + '.a.b'
         try {
-            Jwts.parser().unsecured().build().parse(compact)
+            Jwt.parser().unsecured().build().parse(compact)
             fail()
         } catch (MalformedJwtException expected) {
             String msg = String.format(DefaultJwtParser.CRIT_MISSING_MSG, 'whatever', 'whatever', map)
@@ -232,7 +232,7 @@ class DefaultJwtParserTest {
         def header = b64Url(serialize(map))
         String compact = header + '.a.b'
         try {
-            Jwts.parser().unsecured().build().parse(compact)
+            Jwt.parser().unsecured().build().parse(compact)
             fail()
         } catch (UnsupportedJwtException expected) {
             String msg = String.format(DefaultJwtParser.CRIT_UNSUPPORTED_MSG, 'whatever', 'whatever', map)
@@ -249,7 +249,7 @@ class DefaultJwtParserTest {
                 .subject('me')
                 .signWith(key).compact()
 
-        def jwt = Jwts.parser().critical().add(crit).and().verifyWith(key).build().parseSignedClaims(jws)
+        def jwt = Jwt.parser().critical().add(crit).and().verifyWith(key).build().parseSignedClaims(jws)
 
         // no exception thrown, as expected, check the header values:
         def parsedCrit = jwt.getHeader().getCritical()
@@ -267,7 +267,7 @@ class DefaultJwtParserTest {
         def s = Jwts.builder().expiration(exp).compact()
 
         try {
-            Jwts.parser().unsecured().clock(new FixedClock(later)).build().parse(s)
+            Jwt.parser().unsecured().clock(new FixedClock(later)).build().parse(s)
         } catch (ExpiredJwtException expected) {
             def exp8601 = DateFormats.formatIso8601(exp, true)
             def later8601 = DateFormats.formatIso8601(later, true)
@@ -286,7 +286,7 @@ class DefaultJwtParserTest {
         def s = Jwts.builder().notBefore(nbf).compact()
 
         try {
-            Jwts.parser().unsecured().clock(new FixedClock(earlier)).build().parseUnsecuredClaims(s)
+            Jwt.parser().unsecured().clock(new FixedClock(earlier)).build().parseUnsecuredClaims(s)
         } catch (PrematureJwtException expected) {
             def nbf8601 = DateFormats.formatIso8601(nbf, true)
             def earlier8601 = DateFormats.formatIso8601(earlier, true)
@@ -301,7 +301,7 @@ class DefaultJwtParserTest {
         def jwt = Encoders.BASE64URL.encode(Strings.utf8('{"alg":"none"}'))
         jwt += ".F!3!#." // <-- invalid Base64URL payload
         try {
-            Jwts.parser().unsecured().build().parse(jwt)
+            Jwt.parser().unsecured().build().parse(jwt)
             fail()
         } catch (MalformedJwtException expected) {
             String msg = 'Invalid Base64Url payload: <redacted>'
@@ -316,20 +316,20 @@ class DefaultJwtParserTest {
         // parseContentJwt
         byte[] data = Strings.utf8('hello')
         def jwt = Jwts.builder().content(data).compact()
-        assertArrayEquals data, Jwts.parser().unsecured().build().parseContentJwt(jwt).getPayload()
+        assertArrayEquals data, Jwt.parser().unsecured().build().parseContentJwt(jwt).getPayload()
 
         // parseClaimsJwt
         jwt = Jwts.builder().subject('me').compact()
-        assertEquals 'me', Jwts.parser().unsecured().build().parseClaimsJwt(jwt).getPayload().getSubject()
+        assertEquals 'me', Jwt.parser().unsecured().build().parseClaimsJwt(jwt).getPayload().getSubject()
 
         // parseContentJws
         def key = TestKeys.HS256
         jwt = Jwts.builder().content(data).signWith(key).compact()
-        assertArrayEquals data, Jwts.parser().verifyWith(key).build().parseContentJws(jwt).getPayload()
+        assertArrayEquals data, Jwt.parser().verifyWith(key).build().parseContentJws(jwt).getPayload()
 
         // parseClaimsJws
         jwt = Jwts.builder().subject('me').signWith(key).compact()
-        assertEquals 'me', Jwts.parser().verifyWith(key).build().parseClaimsJws(jwt).getPayload().getSubject()
+        assertEquals 'me', Jwt.parser().verifyWith(key).build().parseClaimsJws(jwt).getPayload().getSubject()
 
         //parse(jwt, handler)
         def value = 'foo'
@@ -339,6 +339,6 @@ class DefaultJwtParserTest {
                 return value
             }
         }
-        assertEquals value, Jwts.parser().verifyWith(key).build().parse(jwt, handler)
+        assertEquals value, Jwt.parser().verifyWith(key).build().parse(jwt, handler)
     }
 }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtParserTest.groovy
@@ -84,7 +84,7 @@ class DefaultJwtParserTest {
         assertFalse invoked
 
         def key = Jws.alg.HS256.key().build()
-        String jws = Jwts.builder().claim('foo', 'bar').signWith(key, Jws.alg.HS256).compact()
+        String jws = Jwt.builder().claim('foo', 'bar').signWith(key, Jws.alg.HS256).compact()
         assertFalse invoked
 
         assertEquals 'bar', pb.verifyWith(key).build().parseSignedClaims(jws).getPayload().get('foo')
@@ -244,7 +244,7 @@ class DefaultJwtParserTest {
     void testProtectedCritWithSupportedHeader() {
         def key = TestKeys.HS256
         def crit = Collections.setOf('whatever')
-        String jws = Jwts.builder()
+        String jws = Jwt.builder()
                 .header().critical().add(crit).and().add('whatever', 42).and()
                 .subject('me')
                 .signWith(key).compact()
@@ -264,7 +264,7 @@ class DefaultJwtParserTest {
         long differenceMillis = 843 // arbitrary, anything > 0 is fine
         def exp = JwtDateConverter.INSTANCE.applyFrom(System.currentTimeMillis() / 1000L)
         def later = new Date(exp.getTime() + differenceMillis)
-        def s = Jwts.builder().expiration(exp).compact()
+        def s = Jwt.builder().expiration(exp).compact()
 
         try {
             Jwt.parser().unsecured().clock(new FixedClock(later)).build().parse(s)
@@ -283,7 +283,7 @@ class DefaultJwtParserTest {
         long differenceMillis = 3842 // arbitrary, anything > 0 is fine
         def nbf = JwtDateConverter.INSTANCE.applyFrom(System.currentTimeMillis() / 1000L)
         def earlier = new Date(nbf.getTime() - differenceMillis)
-        def s = Jwts.builder().notBefore(nbf).compact()
+        def s = Jwt.builder().notBefore(nbf).compact()
 
         try {
             Jwt.parser().unsecured().clock(new FixedClock(earlier)).build().parseUnsecuredClaims(s)
@@ -315,20 +315,20 @@ class DefaultJwtParserTest {
 
         // parseContentJwt
         byte[] data = Strings.utf8('hello')
-        def jwt = Jwts.builder().content(data).compact()
+        def jwt = Jwt.builder().content(data).compact()
         assertArrayEquals data, Jwt.parser().unsecured().build().parseContentJwt(jwt).getPayload()
 
         // parseClaimsJwt
-        jwt = Jwts.builder().subject('me').compact()
+        jwt = Jwt.builder().subject('me').compact()
         assertEquals 'me', Jwt.parser().unsecured().build().parseClaimsJwt(jwt).getPayload().getSubject()
 
         // parseContentJws
         def key = TestKeys.HS256
-        jwt = Jwts.builder().content(data).signWith(key).compact()
+        jwt = Jwt.builder().content(data).signWith(key).compact()
         assertArrayEquals data, Jwt.parser().verifyWith(key).build().parseContentJws(jwt).getPayload()
 
         // parseClaimsJws
-        jwt = Jwts.builder().subject('me').signWith(key).compact()
+        jwt = Jwt.builder().subject('me').signWith(key).compact()
         assertEquals 'me', Jwt.parser().verifyWith(key).build().parseClaimsJws(jwt).getPayload().getSubject()
 
         //parse(jwt, handler)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtTest.groovy
@@ -30,7 +30,7 @@ class DefaultJwtTest {
     @Test
     void testToString() {
         String compact = Jwts.builder().header().add('foo', 'bar').and().audience().add('jsmith').and().compact()
-        Jwt jwt = Jwts.parser().unsecured().build().parseUnsecuredClaims(compact)
+        Jwt jwt = Jwt.parser().unsecured().build().parseUnsecuredClaims(compact)
         assertEquals 'header={foo=bar, alg=none},payload={aud=[jsmith]}', jwt.toString()
     }
 
@@ -39,14 +39,14 @@ class DefaultJwtTest {
         byte[] bytes = 'hello JJWT'.getBytes(StandardCharsets.UTF_8)
         String encoded = Encoders.BASE64URL.encode(bytes)
         String compact = Jwts.builder().header().add('foo', 'bar').and().content(bytes).compact()
-        Jwt jwt = Jwts.parser().unsecured().build().parseUnsecuredContent(compact)
+        Jwt jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertEquals "header={foo=bar, alg=none},payload=$encoded" as String, jwt.toString()
     }
 
     @Test
     void testEqualsAndHashCode() {
         String compact = Jwts.builder().claim('foo', 'bar').compact()
-        def parser = Jwts.parser().unsecured().build()
+        def parser = Jwt.parser().unsecured().build()
         def jwt1 = parser.parseUnsecuredClaims(compact)
         def jwt2 = parser.parseUnsecuredClaims(compact)
         assertNotEquals jwt1, 'hello' as String
@@ -60,7 +60,7 @@ class DefaultJwtTest {
     @Test
     void testBodyAndPayloadSame() {
         String compact = Jwts.builder().claim('foo', 'bar').compact()
-        def parser = Jwts.parser().unsecured().build()
+        def parser = Jwt.parser().unsecured().build()
         def jwt1 = parser.parseUnsecuredClaims(compact)
         def jwt2 = parser.parseUnsecuredClaims(compact)
         assertEquals jwt1.getBody(), jwt1.getPayload()

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultJwtTest.groovy
@@ -16,7 +16,6 @@
 package io.jsonwebtoken.impl
 
 import io.jsonwebtoken.Jwt
-import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Encoders
 import org.junit.Test
 
@@ -29,7 +28,7 @@ class DefaultJwtTest {
 
     @Test
     void testToString() {
-        String compact = Jwts.builder().header().add('foo', 'bar').and().audience().add('jsmith').and().compact()
+        String compact = Jwt.builder().header().add('foo', 'bar').and().audience().add('jsmith').and().compact()
         Jwt jwt = Jwt.parser().unsecured().build().parseUnsecuredClaims(compact)
         assertEquals 'header={foo=bar, alg=none},payload={aud=[jsmith]}', jwt.toString()
     }
@@ -38,14 +37,14 @@ class DefaultJwtTest {
     void testByteArrayPayloadToString() {
         byte[] bytes = 'hello JJWT'.getBytes(StandardCharsets.UTF_8)
         String encoded = Encoders.BASE64URL.encode(bytes)
-        String compact = Jwts.builder().header().add('foo', 'bar').and().content(bytes).compact()
+        String compact = Jwt.builder().header().add('foo', 'bar').and().content(bytes).compact()
         Jwt jwt = Jwt.parser().unsecured().build().parseUnsecuredContent(compact)
         assertEquals "header={foo=bar, alg=none},payload=$encoded" as String, jwt.toString()
     }
 
     @Test
     void testEqualsAndHashCode() {
-        String compact = Jwts.builder().claim('foo', 'bar').compact()
+        String compact = Jwt.builder().claim('foo', 'bar').compact()
         def parser = Jwt.parser().unsecured().build()
         def jwt1 = parser.parseUnsecuredClaims(compact)
         def jwt2 = parser.parseUnsecuredClaims(compact)
@@ -59,7 +58,7 @@ class DefaultJwtTest {
     @SuppressWarnings('GrDeprecatedAPIUsage')
     @Test
     void testBodyAndPayloadSame() {
-        String compact = Jwts.builder().claim('foo', 'bar').compact()
+        String compact = Jwt.builder().claim('foo', 'bar').compact()
         def parser = Jwt.parser().unsecured().build()
         def jwt1 = parser.parseUnsecuredClaims(compact)
         def jwt2 = parser.parseUnsecuredClaims(compact)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultMutableJweHeaderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/DefaultMutableJweHeaderTest.groovy
@@ -16,7 +16,7 @@
 package io.jsonwebtoken.impl
 
 import io.jsonwebtoken.Jwe
-import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.impl.io.Streams
 import io.jsonwebtoken.impl.lang.Bytes
 import io.jsonwebtoken.impl.security.DefaultHashAlgorithm
@@ -38,7 +38,7 @@ class DefaultMutableJweHeaderTest {
 
     @Before
     void setUp() {
-        header = new DefaultMutableJweHeader(Jwts.header() as DefaultJweHeaderMutator)
+        header = new DefaultMutableJweHeader(Jwt.header() as DefaultJweHeaderMutator)
     }
 
     @SuppressWarnings('GroovyAssignabilityCheck')

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/IdLocatorTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/IdLocatorTest.groovy
@@ -16,7 +16,7 @@
 package io.jsonwebtoken.impl
 
 import io.jsonwebtoken.Identifiable
-import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.MalformedJwtException
 import io.jsonwebtoken.UnsupportedJwtException
 import io.jsonwebtoken.impl.lang.IdRegistry
@@ -46,13 +46,13 @@ class IdLocatorTest {
     @Test
     void unrequiredHeaderValueTest() {
         locator = new IdLocator(TEST_PARAM, registry, 'foo', 'bar', null)
-        def header = Jwts.header().add('a', 'b').build()
+        def header = Jwt.header().add('a', 'b').build()
         assertNull locator.apply(header)
     }
 
     @Test
     void missingRequiredHeaderValueTest() {
-        def header = Jwts.header().build()
+        def header = Jwt.header().build()
         try {
             locator.apply(header)
             fail()
@@ -63,7 +63,7 @@ class IdLocatorTest {
 
     @Test
     void unlocatableJwtHeaderInstanceTest() {
-        def header = Jwts.header().add('foo', 'foo').build()
+        def header = Jwt.header().add('foo', 'foo').build()
         try {
             locator.apply(header)
         } catch (UnsupportedJwtException expected) {
@@ -74,7 +74,7 @@ class IdLocatorTest {
 
     @Test
     void unlocatableJwsHeaderInstanceTest() {
-        def header = Jwts.header().add('alg', 'HS256').add('foo', 'foo').build()
+        def header = Jwt.header().add('alg', 'HS256').add('foo', 'foo').build()
         try {
             locator.apply(header)
         } catch (UnsupportedJwtException expected) {
@@ -85,7 +85,7 @@ class IdLocatorTest {
 
     @Test
     void unlocatableJweHeaderInstanceTest() {
-        def header = Jwts.header().add('alg', 'foo').add('enc', 'A256GCM').add('foo', 'foo').build()
+        def header = Jwt.header().add('alg', 'foo').add('enc', 'A256GCM').add('foo', 'foo').build()
         try {
             locator.apply(header)
         } catch (UnsupportedJwtException expected) {

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/compression/DeflateCompressionCodecTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/compression/DeflateCompressionCodecTest.groovy
@@ -16,7 +16,7 @@
 package io.jsonwebtoken.impl.compression
 
 import io.jsonwebtoken.CompressionException
-import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.io.Decoders
 import org.junit.Test
 
@@ -33,7 +33,7 @@ class DeflateCompressionCodecTest {
     @Test
     void testBackwardsCompatibility_0_10_6() {
         final String jwtFrom0106 = 'eyJhbGciOiJub25lIiwiemlwIjoiREVGIn0.eNqqVsosLlayUspNVdJRKi5NAjJLi1OLgJzMxBIlK0sTMzMLEwsDAx2l1IoCJSsTQwMjExOQQC0AAAD__w.'
-        Jwts.parser().unsecured().unsecuredDecompression().build().parseUnsecuredClaims(jwtFrom0106) // no exception should be thrown
+        Jwt.parser().unsecured().unsecuredDecompression().build().parseUnsecuredClaims(jwtFrom0106) // no exception should be thrown
     }
 
     /**

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/lang/LocatorFunctionTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/lang/LocatorFunctionTest.groovy
@@ -16,7 +16,7 @@
 package io.jsonwebtoken.impl.lang
 
 import io.jsonwebtoken.Header
-import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Locator
 import org.junit.Test
 
@@ -29,7 +29,7 @@ class LocatorFunctionTest {
         final int value = 42
         def locator = new StaticLocator(value)
         def fn = new LocatorFunction(locator)
-        assertEquals value, fn.apply(Jwts.header().build())
+        assertEquals value, fn.apply(Jwt.header().build())
     }
 
     static class StaticLocator<T> implements Locator<T> {

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/AesGcmKeyAlgorithmTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/AesGcmKeyAlgorithmTest.groovy
@@ -17,7 +17,7 @@ package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jwe
 import io.jsonwebtoken.JweHeader
-import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.MalformedJwtException
 import io.jsonwebtoken.impl.DefaultMutableJweHeader
 import io.jsonwebtoken.impl.io.Streams
@@ -89,7 +89,7 @@ class AesGcmKeyAlgorithmTest {
 
         def template = new JcaTemplate('AES')
 
-        def header = Jwts.header().add('alg', alg.id).add('enc', 'foo')
+        def header = Jwt.header().add('alg', alg.id).add('enc', 'foo')
         SecretKey kek = template.generateSecretKey(keyLength)
         def cek = template.generateSecretKey(keyLength)
         def enc = new GcmAesAeadAlgorithm(keyLength) {
@@ -126,7 +126,7 @@ class AesGcmKeyAlgorithmTest {
         int keyLength = 128
         def alg = new AesGcmKeyAlgorithm(keyLength)
         def template = new JcaTemplate('AES')
-        def headerBuilder = Jwts.header().add('alg', alg.id).add('enc', 'foo')
+        def headerBuilder = Jwt.header().add('alg', alg.id).add('enc', 'foo')
         def kek = template.generateSecretKey(keyLength)
         def cek = template.generateSecretKey(keyLength)
         def enc = new GcmAesAeadAlgorithm(keyLength) {

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/AesGcmKeyAlgorithmTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/AesGcmKeyAlgorithmTest.groovy
@@ -95,7 +95,7 @@ class AesGcmKeyAlgorithmTest {
         def enc = new GcmAesAeadAlgorithm(keyLength) {
             @Override
             SecretKeyBuilder key() {
-                return Keys.builder(cek)
+                return SecretKeyBuilder.with(cek)
             }
         }
 
@@ -132,7 +132,7 @@ class AesGcmKeyAlgorithmTest {
         def enc = new GcmAesAeadAlgorithm(keyLength) {
             @Override
             SecretKeyBuilder key() {
-                return Keys.builder(cek)
+                return SecretKeyBuilder.with(cek)
             }
         }
         def delegate = new DefaultMutableJweHeader(headerBuilder)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/DefaultSecretKeyBuilderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/DefaultSecretKeyBuilderTest.groovy
@@ -15,6 +15,7 @@
  */
 package io.jsonwebtoken.impl.security
 
+
 import org.junit.Test
 
 import static org.junit.Assert.assertEquals

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/EcdhKeyAlgorithmTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/EcdhKeyAlgorithmTest.groovy
@@ -17,7 +17,7 @@ package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jwe
 import io.jsonwebtoken.JweHeader
-import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.MalformedJwtException
 import io.jsonwebtoken.impl.DefaultJweHeader
 import io.jsonwebtoken.impl.DefaultMutableJweHeader
@@ -41,15 +41,15 @@ import static org.junit.Assert.*
  */
 class EcdhKeyAlgorithmTest {
 
-    private static Jwts.HeaderBuilder jwe() {
-        return Jwts.header().add('alg', 'foo').add('enc', 'bar')
+    private static Jwt.HeaderBuilder jwe() {
+        return Jwt.header().add('alg', 'foo').add('enc', 'bar')
     }
 
     @Test
     void testEdwardsEncryptionWithRequestProvider() {
         def alg = new EcdhKeyAlgorithm()
         PublicKey encKey = TestKeys.X25519.pair.public as PublicKey
-        def header = new DefaultMutableJweHeader(Jwts.header())
+        def header = new DefaultMutableJweHeader(Jwt.header())
         def provider = TestKeys.BC
         def req = KeyRequest.builder().payload(encKey).provider(provider).header(header)
                 .encryptionAlgorithm(Jwe.enc.A128GCM).build()
@@ -126,7 +126,7 @@ class EcdhKeyAlgorithmTest {
     void testEncryptionWithInvalidPublicKey() {
         def alg = new EcdhKeyAlgorithm()
         PublicKey encKey = TestKeys.RS256.pair.public as PublicKey // not an elliptic curve key, must fail
-        def header = new DefaultMutableJweHeader(Jwts.header())
+        def header = new DefaultMutableJweHeader(Jwt.header())
         try {
             alg.getEncryptionKey(encKey, header, Jwe.enc.A128GCM)
             fail()

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/EdSignatureAlgorithmTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/EdSignatureAlgorithmTest.groovy
@@ -17,7 +17,6 @@ package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jws
 import io.jsonwebtoken.Jwt
-import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.UnsupportedJwtException
 import io.jsonwebtoken.security.SecureDigestRequest
 import io.jsonwebtoken.security.SignatureException
@@ -127,7 +126,7 @@ class EdSignatureAlgorithmTest {
     }
 
     static void testSig(PrivateKey signing, PublicKey verification) {
-        String jwt = Jwts.builder().issuer('me').audience().add('you').and().signWith(signing, alg).compact()
+        String jwt = Jwt.builder().issuer('me').audience().add('you').and().signWith(signing, alg).compact()
         def token = Jwt.parser().verifyWith(verification).build().parseSignedClaims(jwt)
         assertEquals([alg: alg.getId()], token.header)
         assertEquals 'me', token.getPayload().getIssuer()

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/EdSignatureAlgorithmTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/EdSignatureAlgorithmTest.groovy
@@ -16,6 +16,7 @@
 package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jws
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.UnsupportedJwtException
 import io.jsonwebtoken.security.SecureDigestRequest
@@ -127,7 +128,7 @@ class EdSignatureAlgorithmTest {
 
     static void testSig(PrivateKey signing, PublicKey verification) {
         String jwt = Jwts.builder().issuer('me').audience().add('you').and().signWith(signing, alg).compact()
-        def token = Jwts.parser().verifyWith(verification).build().parseSignedClaims(jwt)
+        def token = Jwt.parser().verifyWith(verification).build().parseSignedClaims(jwt)
         assertEquals([alg: alg.getId()], token.header)
         assertEquals 'me', token.getPayload().getIssuer()
         assertEquals 'you', token.getPayload().getAudience().iterator().next()

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pbes2HsAkwAlgorithmTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pbes2HsAkwAlgorithmTest.groovy
@@ -59,7 +59,7 @@ class Pbes2HsAkwAlgorithmTest {
         for (Pbes2HsAkwAlgorithm alg : ALGS) {
             def password = Password.of('correct horse battery staple'.toCharArray())
             def iterations = alg.MAX_ITERATIONS + 1
-            // we make the JWE string directly from JSON here (instead of using Jwts.builder()) to avoid
+            // we make the JWE string directly from JSON here (instead of using Jwt.builder()) to avoid
             // the computational time it would take to create such JWEs with excessive iterations as well as
             // avoid the builder throwing any exceptions (and this is what a potential attacker would do anyway):
             def headerJson = """

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pbes2HsAkwAlgorithmTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pbes2HsAkwAlgorithmTest.groovy
@@ -16,6 +16,7 @@
 package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jwe
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.UnsupportedJwtException
 import io.jsonwebtoken.impl.DefaultJweHeaderMutator
@@ -73,7 +74,7 @@ class Pbes2HsAkwAlgorithmTest {
                     '.OSAhMk3FtaCeZ5v1c8bWBgssEVqx2mCPUEnJUsg4hwIQyrUP-LCYkg.' +
                     'K4R_-zb4qaZ3R0W8.sGS4mcT_xBhZC1d7G-g.kWqd_4sEsaKrWE_hMZ5HmQ'
             try {
-                Jwts.parser().decryptWith(password).build().parse(jwe)
+                Jwt.parser().decryptWith(password).build().parse(jwe)
             } catch (UnsupportedJwtException expected) {
                 String msg = "JWE Header 'p2c' (PBES2 Count) value ${iterations} exceeds ${alg.id} maximum allowed " +
                         "value ${alg.MAX_ITERATIONS}. The larger value is rejected to help mitigate potential " +

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pbes2HsAkwAlgorithmTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pbes2HsAkwAlgorithmTest.groovy
@@ -17,7 +17,6 @@ package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jwe
 import io.jsonwebtoken.Jwt
-import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.UnsupportedJwtException
 import io.jsonwebtoken.impl.DefaultJweHeaderMutator
 import io.jsonwebtoken.impl.DefaultMutableJweHeader
@@ -41,7 +40,7 @@ class Pbes2HsAkwAlgorithmTest {
     void testInsufficientIterations() {
         for (Pbes2HsAkwAlgorithm alg : ALGS) {
             int iterations = 50 // must be 1000 or more
-            def header = Jwts.header().pbes2Count(iterations) as DefaultJweHeaderMutator
+            def header = Jwt.header().pbes2Count(iterations) as DefaultJweHeaderMutator
             def mutable = new DefaultMutableJweHeader(header)
             try {
                 alg.getEncryptionKey(KEY, mutable, Jwe.enc.A256GCM)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pkcs11Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pkcs11Test.groovy
@@ -237,7 +237,7 @@ class Pkcs11Test {
             alg = alg instanceof Curve ? Jws.alg.EdDSA : alg as SecureDigestAlgorithm
 
             // We might need to specify the PKCS11 provider since we can't access the private key material:
-            def jws = Jwts.builder().provider(keyProvider).issuer('me').signWith(signKey, alg).compact()
+            def jws = Jwt.builder().provider(keyProvider).issuer('me').signWith(signKey, alg).compact()
 
             def builder = Jwt.parser()
             if (verifyKey instanceof SecretKey) {
@@ -279,7 +279,7 @@ class Pkcs11Test {
         }
 
         // Encryption uses the public key, and that key material is available, so no need for the PKCS11 provider:
-        String jwe = Jwts.builder().issuer('me').encryptWith(pub, keyalg, Jwe.enc.A256GCM).compact()
+        String jwe = Jwt.builder().issuer('me').encryptWith(pub, keyalg, Jwe.enc.A256GCM).compact()
 
         // The private key can be null if SunPKCS11 doesn't support the key algorithm directly.  In this case
         // encryption only worked because generic X.509 decoding (from the key certificate in the keystore) produced the

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pkcs11Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pkcs11Test.groovy
@@ -15,7 +15,11 @@
  */
 package io.jsonwebtoken.impl.security
 
-import io.jsonwebtoken.*
+
+import io.jsonwebtoken.Identifiable
+import io.jsonwebtoken.Jwe
+import io.jsonwebtoken.Jws
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.impl.lang.Bytes
 import io.jsonwebtoken.lang.Assert
 import io.jsonwebtoken.lang.Classes
@@ -243,7 +247,7 @@ class Pkcs11Test {
             if (verifyKey instanceof SecretKey) {
                 // We only need to specify a provider during parsing for MAC HSM keys: SignatureAlgorithm verification
                 // only needs the PublicKey, and a recipient doesn't need/won't have an HSM for public material anyway.
-                verifyKey = Keys.builder(verifyKey).provider(keyProvider).build()
+                verifyKey = SecretKeyBuilder.with(verifyKey).provider(keyProvider).build()
                 builder.verifyWith(verifyKey as SecretKey)
             } else {
                 builder.verifyWith(verifyKey as PublicKey)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pkcs11Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/Pkcs11Test.groovy
@@ -15,10 +15,7 @@
  */
 package io.jsonwebtoken.impl.security
 
-import io.jsonwebtoken.Identifiable
-import io.jsonwebtoken.Jwe
-import io.jsonwebtoken.Jws
-import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.*
 import io.jsonwebtoken.impl.lang.Bytes
 import io.jsonwebtoken.lang.Assert
 import io.jsonwebtoken.lang.Classes
@@ -242,7 +239,7 @@ class Pkcs11Test {
             // We might need to specify the PKCS11 provider since we can't access the private key material:
             def jws = Jwts.builder().provider(keyProvider).issuer('me').signWith(signKey, alg).compact()
 
-            def builder = Jwts.parser()
+            def builder = Jwt.parser()
             if (verifyKey instanceof SecretKey) {
                 // We only need to specify a provider during parsing for MAC HSM keys: SignatureAlgorithm verification
                 // only needs the PublicKey, and a recipient doesn't need/won't have an HSM for public material anyway.
@@ -291,7 +288,7 @@ class Pkcs11Test {
             // Decryption may need private material inside the HSM:
             priv = Keys.builder(pair.private).publicKey(pub).provider(provider).build()
 
-            String iss = Jwts.parser().decryptWith(priv).build().parseEncryptedClaims(jwe).getPayload().getIssuer()
+            String iss = Jwt.parser().decryptWith(priv).build().parseEncryptedClaims(jwe).getPayload().getIssuer()
             assertEquals 'me', iss
         }
     }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/PrivateConstructorsTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/PrivateConstructorsTest.groovy
@@ -18,16 +18,20 @@ package io.jsonwebtoken.impl.security
 import io.jsonwebtoken.Jwe
 import io.jsonwebtoken.Jws
 import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.Suppliers
 import io.jsonwebtoken.impl.lang.Functions
 import io.jsonwebtoken.lang.Classes
-import io.jsonwebtoken.security.*
+import io.jsonwebtoken.security.Jwk
+import io.jsonwebtoken.security.JwkThumbprint
+import io.jsonwebtoken.security.Jwks
+import io.jsonwebtoken.security.Keys
 import org.junit.Test
 
 import static org.junit.Assert.assertSame
 
 class PrivateConstructorsTest {
 
-    @SuppressWarnings(['GrDeprecatedAPIUsage', 'GroovyResultOfObjectAllocationIgnored'])
+    @SuppressWarnings(['GrDeprecatedAPIUsage', 'GroovyResultOfObjectAllocationIgnored', 'UnnecessaryQualifiedReference'])
     @Test
     void testPrivateCtors() { // for code coverage only
         new Classes()
@@ -35,6 +39,7 @@ class PrivateConstructorsTest {
         new KeysBridge()
         new Functions()
         new Suppliers()
+        new io.jsonwebtoken.security.Suppliers()
         new Jws.alg()
         new Jwe.enc()
         new Jwe.alg()

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/ProvidedKeyBuilderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/ProvidedKeyBuilderTest.groovy
@@ -17,6 +17,7 @@ package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.impl.lang.Bytes
 import io.jsonwebtoken.security.Keys
+import io.jsonwebtoken.security.SecretKeyBuilder
 import org.junit.Test
 
 import javax.crypto.SecretKey
@@ -44,13 +45,13 @@ class ProvidedKeyBuilderTest {
     void testBuildWithSpecifiedProviderKey() {
         Provider provider = new TestProvider()
         SecretKey key = new SecretKeySpec(Bytes.random(256), 'AES')
-        def providerKey = Keys.builder(key).provider(provider).build() as ProviderSecretKey
+        def providerKey = SecretKeyBuilder.with(key).provider(provider).build() as ProviderSecretKey
 
         assertSame provider, providerKey.getProvider()
         assertSame key, providerKey.getKey()
 
         // now for the test: ensure that our provider key isn't wrapped again
-        SecretKey returned = Keys.builder(providerKey).provider(new TestProvider('different')).build()
+        SecretKey returned = SecretKeyBuilder.with(providerKey).provider(new TestProvider('different')).build()
 
         assertSame providerKey, returned // not wrapped again
     }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/ProvidedSecretKeyBuilderTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/ProvidedSecretKeyBuilderTest.groovy
@@ -17,21 +17,31 @@ package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.security.Keys
 import io.jsonwebtoken.security.Password
+import io.jsonwebtoken.security.SecretKeyBuilder
 import org.junit.Test
 
 import static org.junit.Assert.assertSame
 
 class ProvidedSecretKeyBuilderTest {
 
+    @SuppressWarnings('GrDeprecatedAPIUsage')
+    @Test
+    void testBuildSecretKeyWithoutProvider() {
+        // does not wrap in ProviderKey:
+        assertSame TestKeys.HS256, SecretKeyBuilder.with(TestKeys.HS256).build()
+        assertSame TestKeys.HS256, Keys.builder(TestKeys.HS256).build() // for coverage, will be removed before 1.0
+    }
+
     @Test
     void testBuildPasswordWithoutProvider() {
         def password = Password.of('foo'.toCharArray())
-        assertSame password, Keys.builder(password).build() // does not wrap in ProviderKey
+        assertSame password, SecretKeyBuilder.with(password).build() // does not wrap in ProviderKey
     }
 
     @Test
     void testBuildPasswordWithProvider() {
         def password = Password.of('foo'.toCharArray())
-        assertSame password, Keys.builder(password).provider(new TestProvider()).build() // does not wrap in ProviderKey
+        // does not wrap in ProviderKey:
+        assertSame password, SecretKeyBuilder.with(password).provider(new TestProvider()).build()
     }
 }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7516AppendixA1Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7516AppendixA1Test.groovy
@@ -16,7 +16,7 @@
 package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jwe
-import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.io.Encoders
 import io.jsonwebtoken.security.Jwk
@@ -174,7 +174,7 @@ class RFC7516AppendixA1Test {
         RsaPrivateJwk jwk = Jwk.builder().add(KEK_VALUES).build() as RsaPrivateJwk
         RSAPrivateKey privKey = jwk.toKey()
 
-        Jwe<byte[]> jwe = Jwts.parser().decryptWith(privKey).build().parseEncryptedContent(COMPLETE_JWE)
+        Jwe<byte[]> jwe = Jwt.parser().decryptWith(privKey).build().parseEncryptedContent(COMPLETE_JWE)
         assertEquals PLAINTEXT, new String(jwe.getPayload(), StandardCharsets.UTF_8)
     }
 }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7516AppendixA2Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7516AppendixA2Test.groovy
@@ -16,7 +16,7 @@
 package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jwe
-import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.io.Encoders
 import io.jsonwebtoken.security.Jwk
@@ -168,7 +168,7 @@ class RFC7516AppendixA2Test {
         RsaPrivateJwk jwk = Jwk.builder().add(KEK_VALUES).build() as RsaPrivateJwk
         RSAPrivateKey privKey = jwk.toKey()
 
-        Jwe<byte[]> jwe = Jwts.parser().decryptWith(privKey).build().parseEncryptedContent(COMPLETE_JWE)
+        Jwe<byte[]> jwe = Jwt.parser().decryptWith(privKey).build().parseEncryptedContent(COMPLETE_JWE)
         assertEquals PLAINTEXT, new String(jwe.getPayload(), StandardCharsets.UTF_8)
     }
 }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7516AppendixA3Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7516AppendixA3Test.groovy
@@ -16,6 +16,7 @@
 package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jwe
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.io.Encoders
@@ -106,7 +107,7 @@ class RFC7516AppendixA3Test {
         SecretKey kek = jwk.toKey()
 
         // test decryption per the RFC
-        Jwe<byte[]> jwe = Jwts.parser().decryptWith(kek).build().parseEncryptedContent(COMPLETE_JWE)
+        Jwe<byte[]> jwe = Jwt.parser().decryptWith(kek).build().parseEncryptedContent(COMPLETE_JWE)
         assertEquals PLAINTEXT, new String(jwe.getPayload(), StandardCharsets.UTF_8)
 
         // now ensure that when JJWT does the encryption (i.e. a compact value is produced from JJWT, not from the RFC text),

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7516AppendixA3Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7516AppendixA3Test.groovy
@@ -17,7 +17,6 @@ package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jwe
 import io.jsonwebtoken.Jwt
-import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.io.Encoders
 import io.jsonwebtoken.security.*
@@ -127,7 +126,7 @@ class RFC7516AppendixA3Test {
             }
         }
 
-        String compact = Jwts.builder()
+        String compact = Jwt.builder()
                 .setPayload(PLAINTEXT)
                 .encryptWith(kek, Jwe.alg.A128KW, enc)
                 .compact()

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7516AppendixA3Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7516AppendixA3Test.groovy
@@ -122,7 +122,7 @@ class RFC7516AppendixA3Test {
 
             @Override
             SecretKeyBuilder key() {
-                return Keys.builder(CEK)
+                return SecretKeyBuilder.with(CEK)
             }
         }
 

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7517AppendixCTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7517AppendixCTest.groovy
@@ -17,6 +17,7 @@ package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jwe
 import io.jsonwebtoken.JweHeader
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.impl.io.TestSerializer
 import io.jsonwebtoken.io.Encoders
@@ -330,7 +331,7 @@ class RFC7517AppendixCTest {
         assertEquals RFC_COMPACT_JWE, compact
 
         //ensure we can decrypt now:
-        Jwe<byte[]> jwe = Jwts.parser().decryptWith(key).build().parseEncryptedContent(compact)
+        Jwe<byte[]> jwe = Jwt.parser().decryptWith(key).build().parseEncryptedContent(compact)
 
         assertEquals RFC_JWK_JSON, new String(jwe.getPayload(), StandardCharsets.UTF_8)
     }

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7517AppendixCTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7517AppendixCTest.groovy
@@ -18,7 +18,6 @@ package io.jsonwebtoken.impl.security
 import io.jsonwebtoken.Jwe
 import io.jsonwebtoken.JweHeader
 import io.jsonwebtoken.Jwt
-import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.impl.io.TestSerializer
 import io.jsonwebtoken.io.Encoders
 import io.jsonwebtoken.security.*
@@ -321,7 +320,7 @@ class RFC7517AppendixCTest {
 
         Password key = Password.of(RFC_SHARED_PASSPHRASE.toCharArray())
 
-        String compact = Jwts.builder()
+        String compact = Jwt.builder()
                 .setPayload(RFC_JWK_JSON)
                 .header().contentType('jwk+json').pbes2Count(RFC_P2C).and()
                 .encryptWith(key, alg, enc)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7517AppendixCTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7517AppendixCTest.groovy
@@ -20,7 +20,10 @@ import io.jsonwebtoken.JweHeader
 import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.impl.io.TestSerializer
 import io.jsonwebtoken.io.Encoders
-import io.jsonwebtoken.security.*
+import io.jsonwebtoken.security.KeyRequest
+import io.jsonwebtoken.security.Password
+import io.jsonwebtoken.security.Request
+import io.jsonwebtoken.security.SecretKeyBuilder
 import org.junit.Test
 
 import javax.crypto.SecretKey
@@ -284,7 +287,7 @@ class RFC7517AppendixCTest {
         def enc = new HmacAesAeadAlgorithm(128) {
             @Override
             SecretKeyBuilder key() {
-                return Keys.builder(RFC_CEK)
+                return SecretKeyBuilder.with(RFC_CEK)
             }
 
             @Override

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7518AppendixCTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7518AppendixCTest.groovy
@@ -18,7 +18,6 @@ package io.jsonwebtoken.impl.security
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwe
 import io.jsonwebtoken.Jwt
-import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.impl.lang.Services
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.io.Deserializer
@@ -112,7 +111,7 @@ class RFC7518AppendixCTest {
             }
         }
 
-        String jwe = Jwts.builder()
+        String jwe = Jwt.builder()
                 .header().agreementPartyUInfo("Alice").agreementPartyVInfo("Bob").and()
                 .claim("Hello", "World")
                 .encryptWith(bobJwk.toPublicJwk().toKey(), alg, Jwe.enc.A128GCM)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7518AppendixCTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7518AppendixCTest.groovy
@@ -17,6 +17,7 @@ package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwe
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.impl.lang.Services
 import io.jsonwebtoken.io.Decoders
@@ -126,7 +127,7 @@ class RFC7518AppendixCTest {
         assertArrayEquals RFC_DERIVED_KEY, derivedKey
 
         // now reverse the process and ensure it all works:
-        Jwe<Claims> claimsJwe = Jwts.parser()
+        Jwe<Claims> claimsJwe = Jwt.parser()
                 .decryptWith(bobJwk.toKey())
                 .build().parseEncryptedClaims(jwe)
 

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7520Section4Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7520Section4Test.groovy
@@ -17,7 +17,6 @@ package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jws
 import io.jsonwebtoken.Jwt
-import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.impl.io.TestSerializer
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.io.Encoders
@@ -217,7 +216,7 @@ class RFC7520Section4Test {
                 return FIGURE_9
             }
         }
-        String result = Jwts.builder()
+        String result = Jwt.builder()
                 .json(writer) // assert input, return RFC ordered string
                 .header().keyId(jwk.getId()).and()
                 .setPayload(FIGURE_7)
@@ -256,7 +255,7 @@ class RFC7520Section4Test {
             }
         }
 
-        String result = Jwts.builder()
+        String result = Jwt.builder()
                 .json(ser) // assert input, return RFC ordered string
                 .header().keyId(kid).and()
                 .setPayload(FIGURE_7)
@@ -302,7 +301,7 @@ class RFC7520Section4Test {
             }
         }
 
-        String result = Jwts.builder()
+        String result = Jwt.builder()
                 .json(ser) // assert input, return RFC ordered string
                 .header().keyId(jwk.getId()).and()
                 .setPayload(FIGURE_7)
@@ -347,7 +346,7 @@ class RFC7520Section4Test {
             }
         }
 
-        String result = Jwts.builder()
+        String result = Jwt.builder()
                 .json(writer) // assert input, return RFC ordered string
                 .header().keyId(jwk.getId()).and()
                 .setPayload(FIGURE_7)
@@ -385,7 +384,7 @@ class RFC7520Section4Test {
             }
         }
 
-        String result = Jwts.builder()
+        String result = Jwt.builder()
                 .json(writer) // assert input, return RFC ordered string
                 .header().keyId(jwk.getId()).and()
                 .setPayload(FIGURE_7)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7520Section4Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7520Section4Test.groovy
@@ -16,6 +16,7 @@
 package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jws
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.impl.io.TestSerializer
 import io.jsonwebtoken.io.Decoders
@@ -226,7 +227,7 @@ class RFC7520Section4Test {
         assertEquals FIGURE_13, result
 
         // Assert round trip works as expected:
-        def parsed = Jwts.parser().verifyWith(jwk.toPublicJwk().toKey()).build().parseSignedContent(result)
+        def parsed = Jwt.parser().verifyWith(jwk.toPublicJwk().toKey()).build().parseSignedContent(result)
         assertEquals alg.getId(), parsed.header.getAlgorithm()
         assertEquals jwk.getId(), parsed.header.getKeyId()
         assertEquals FIGURE_7, utf8(parsed.payload)
@@ -270,7 +271,7 @@ class RFC7520Section4Test {
 
         // even though we can't know what the signature output is ahead of time due to random data, we can assert
         // the signature to guarantee a round trip works as expected:
-        def parsed = Jwts.parser()
+        def parsed = Jwt.parser()
                 .verifyWith(jwk.toPublicJwk().toKey())
                 .build().parseSignedContent(result)
 
@@ -315,7 +316,7 @@ class RFC7520Section4Test {
 
         // even though we can't know what the signature output is ahead of time due to random data, we can assert
         // the signature to guarantee a round trip works as expected:
-        def parsed = Jwts.parser()
+        def parsed = Jwt.parser()
                 .verifyWith(jwk.toPublicJwk().toKey())
                 .build().parseSignedContent(result)
 
@@ -356,7 +357,7 @@ class RFC7520Section4Test {
         assertEquals FIGURE_34, result
 
         // Assert round trip works as expected:
-        def parsed = Jwts.parser().verifyWith(key).build().parseSignedContent(result)
+        def parsed = Jwt.parser().verifyWith(key).build().parseSignedContent(result)
         assertEquals alg.getId(), parsed.header.getAlgorithm()
         assertEquals jwk.getId(), parsed.header.getKeyId()
         assertEquals FIGURE_7, utf8(parsed.payload)
@@ -397,7 +398,7 @@ class RFC7520Section4Test {
         assertEquals FIGURE_41, detached
 
         // Assert round trip works as expected:
-        def parsed = Jwts.parser().verifyWith(key).build().parseSignedContent(result)
+        def parsed = Jwt.parser().verifyWith(key).build().parseSignedContent(result)
         assertEquals alg.getId(), parsed.header.getAlgorithm()
         assertEquals jwk.getId(), parsed.header.getKeyId()
         assertEquals FIGURE_7, utf8(parsed.payload)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7520Section5Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7520Section5Test.groovy
@@ -16,7 +16,6 @@
 package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jwt
-import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.impl.io.TestSerializer
 import io.jsonwebtoken.impl.lang.CheckedFunction
 import io.jsonwebtoken.io.Decoders
@@ -470,7 +469,7 @@ class RFC7520Section5Test {
                 return FIGURE_77
             }
         }
-        String result = Jwts.builder()
+        String result = Jwt.builder()
                 .json(ser) // assert input, return RFC ordered string
                 .header().keyId(jwk.getId()).and()
                 .setPayload(FIGURE_72)
@@ -533,7 +532,7 @@ class RFC7520Section5Test {
             }
         }
 
-        String result = Jwts.builder()
+        String result = Jwt.builder()
                 .json(ser) // assert input, return RFC ordered string
                 .header().keyId(jwk.getId()).and()
                 .setPayload(FIGURE_72)
@@ -593,7 +592,7 @@ class RFC7520Section5Test {
             }
         }
 
-        String result = Jwts.builder()
+        String result = Jwt.builder()
                 .json(ser) // assert input, return RFC ordered string
                 .header().contentType(cty).pbes2Count(p2c).and()
                 .setPayload(FIGURE_95)
@@ -657,7 +656,7 @@ class RFC7520Section5Test {
             }
         }
 
-        String result = Jwts.builder()
+        String result = Jwt.builder()
                 .json(ser) // assert input, return RFC ordered string
                 .header().keyId(jwk.getId()).and()
                 .setPayload(FIGURE_72)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7520Section5Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC7520Section5Test.groovy
@@ -15,6 +15,7 @@
  */
 package io.jsonwebtoken.impl.security
 
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.impl.io.TestSerializer
 import io.jsonwebtoken.impl.lang.CheckedFunction
@@ -479,7 +480,7 @@ class RFC7520Section5Test {
         assertEquals FIGURE_81, result
 
         // Assert round trip works as expected:
-        def parsed = Jwts.parser().decryptWith(jwk.toKey()).build().parseEncryptedContent(result)
+        def parsed = Jwt.parser().decryptWith(jwk.toKey()).build().parseEncryptedContent(result)
         assertEquals alg.getId(), parsed.header.getAlgorithm()
         assertEquals jwk.getId(), parsed.header.getKeyId()
         assertEquals enc.getId(), parsed.header.getEncryptionAlgorithm()
@@ -542,7 +543,7 @@ class RFC7520Section5Test {
         assertEquals FIGURE_92, result
 
         // Assert round trip works as expected:
-        def parsed = Jwts.parser().decryptWith(jwk.toKey()).build().parseEncryptedContent(result)
+        def parsed = Jwt.parser().decryptWith(jwk.toKey()).build().parseEncryptedContent(result)
         assertEquals alg.getId(), parsed.header.getAlgorithm()
         assertEquals jwk.getId(), parsed.header.getKeyId()
         assertEquals enc.getId(), parsed.header.getEncryptionAlgorithm()
@@ -602,7 +603,7 @@ class RFC7520Section5Test {
         assertEquals FIGURE_105, result
 
         // Assert round trip works as expected:
-        def parsed = Jwts.parser().decryptWith(key).build().parseEncryptedContent(result)
+        def parsed = Jwt.parser().decryptWith(key).build().parseEncryptedContent(result)
         assertEquals alg.getId(), parsed.header.getAlgorithm()
         assertEquals FIGURE_99, b64Url(parsed.header.getPbes2Salt())
         assertEquals p2c, parsed.header.getPbes2Count()
@@ -666,7 +667,7 @@ class RFC7520Section5Test {
         assertEquals FIGURE_117, result
 
         // Assert round trip works as expected:
-        def parsed = Jwts.parser().decryptWith(jwk.toKey()).build().parseEncryptedContent(result)
+        def parsed = Jwt.parser().decryptWith(jwk.toKey()).build().parseEncryptedContent(result)
         assertEquals alg.getId(), parsed.header.getAlgorithm()
         assertEquals enc.getId(), parsed.header.getEncryptionAlgorithm()
         assertEquals jwk.getId(), parsed.header.getKeyId()

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC8037AppendixATest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC8037AppendixATest.groovy
@@ -18,7 +18,6 @@ package io.jsonwebtoken.impl.security
 import io.jsonwebtoken.Jwe
 import io.jsonwebtoken.Jws
 import io.jsonwebtoken.Jwt
-import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.impl.RfcTests
 import io.jsonwebtoken.security.Curve
 import io.jsonwebtoken.security.Jwk
@@ -105,7 +104,7 @@ class RFC8037AppendixATest {
     @Test
     void test_Sections_A4_and_A5() {
         def privJwk = a1Jwk()
-        String compact = Jwts.builder()
+        String compact = Jwt.builder()
                 .content(A4_JWS_PAYLOAD.getBytes(StandardCharsets.UTF_8))
                 .signWith(privJwk.toKey() as PrivateKey, Jws.alg.EdDSA)
                 .compact()
@@ -168,7 +167,7 @@ class RFC8037AppendixATest {
         final String issuer = RfcTests.srandom()
 
         // Create the test case JWE with the 'kid' header to ensure the output matches the RFC expected value:
-        String jwe = Jwts.builder()
+        String jwe = Jwt.builder()
                 .header().keyId(bobPrivJwk.getId()).and()
                 .setIssuer(issuer)
                 .encryptWith(bobPrivJwk.toPublicJwk().toKey() as PublicKey, alg, Jwe.enc.A128GCM)
@@ -259,7 +258,7 @@ class RFC8037AppendixATest {
         final String issuer = RfcTests.srandom()
 
         // Create the test case JWE with the 'kid' header to ensure the output matches the RFC expected value:
-        String jwe = Jwts.builder()
+        String jwe = Jwt.builder()
                 .header().keyId(bobPrivJwk.getId()).and() //value will be "Dave" as noted above
                 .issuer(issuer)
                 .encryptWith(bobPrivJwk.toPublicJwk().toKey() as PublicKey, alg, Jwe.enc.A256GCM)

--- a/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC8037AppendixATest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/impl/security/RFC8037AppendixATest.groovy
@@ -17,6 +17,7 @@ package io.jsonwebtoken.impl.security
 
 import io.jsonwebtoken.Jwe
 import io.jsonwebtoken.Jws
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.impl.RfcTests
 import io.jsonwebtoken.security.Curve
@@ -111,7 +112,7 @@ class RFC8037AppendixATest {
         assertEquals A4_JWS_COMPACT, compact
 
         def pubJwk = a2Jwk()
-        def payloadBytes = Jwts.parser().verifyWith(pubJwk.toKey()).build().parse(compact).getPayload() as byte[]
+        def payloadBytes = Jwt.parser().verifyWith(pubJwk.toKey()).build().parse(compact).getPayload() as byte[]
         def payload = new String(payloadBytes, StandardCharsets.UTF_8)
         assertEquals A4_JWS_PAYLOAD, payload
     }
@@ -196,7 +197,7 @@ class RFC8037AppendixATest {
         assertEquals(rfcExpectedHeaderMap.get('epk'), jweHeaderMap.get('epk'))
 
         //ensure that bob can decrypt:
-        def jwt = Jwts.parser().decryptWith(bobPrivJwk.toKey() as PrivateKey).build().parseEncryptedClaims(jwe)
+        def jwt = Jwt.parser().decryptWith(bobPrivJwk.toKey() as PrivateKey).build().parseEncryptedClaims(jwe)
 
         assertEquals(issuer, jwt.getPayload().getIssuer())
     }
@@ -287,7 +288,7 @@ class RFC8037AppendixATest {
         assertEquals(rfcExpectedHeaderMap.get('epk'), jweHeaderMap.get('epk'))
 
         //ensure that Bob ("Dave") can decrypt:
-        def jwt = Jwts.parser().decryptWith(bobPrivJwk.toKey() as PrivateKey).build().parseEncryptedClaims(jwe)
+        def jwt = Jwt.parser().decryptWith(bobPrivJwk.toKey() as PrivateKey).build().parseEncryptedClaims(jwe)
 
         //assert that we've decrypted and the value in the body/content is as expected:
         assertEquals(issuer, jwt.getPayload().getIssuer())

--- a/impl/src/test/groovy/io/jsonwebtoken/issues/Issue365Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/issues/Issue365Test.groovy
@@ -59,7 +59,7 @@ class Issue365Test {
         for (def alg : sigalgs) {
             def pair = TestKeys.forAlgorithm(alg).pair
             try {
-                Jwts.builder().issuer('me').signWith(pair.public, alg).compact()
+                Jwt.builder().issuer('me').signWith(pair.public, alg).compact()
                 fail()
             } catch (IllegalArgumentException expected) {
                 assertEquals DefaultJwtBuilder.PUB_KEY_SIGN_MSG, expected.getMessage()
@@ -71,7 +71,7 @@ class Issue365Test {
     void testVerifyWithPrivateKey() {
         for (def alg : sigalgs) {
             def pair = TestKeys.forAlgorithm(alg).pair
-            String jws = Jwts.builder().issuer('me').signWith(pair.private).compact()
+            String jws = Jwt.builder().issuer('me').signWith(pair.private).compact()
             try {
                 Jwt.parser().verifyWith(pair.private).build().parseSignedClaims(jws)
                 fail()
@@ -85,7 +85,7 @@ class Issue365Test {
     void testVerifyWithKeyLocatorPrivateKey() {
         for (def alg : sigalgs) {
             def pair = TestKeys.forAlgorithm(alg).pair
-            String jws = Jwts.builder().issuer('me').signWith(pair.private).compact()
+            String jws = Jwt.builder().issuer('me').signWith(pair.private).compact()
             try {
                 Jwt.parser().keyLocator(new Locator<Key>() {
                     @Override
@@ -105,7 +105,7 @@ class Issue365Test {
     void testEncryptWithPrivateKey() {
         for (def alg : asymKeyAlgs) {
             try {
-                Jwts.builder().issuer('me').encryptWith(new TestPrivateKey(), alg, Jwe.enc.A256GCM).compact()
+                Jwt.builder().issuer('me').encryptWith(new TestPrivateKey(), alg, Jwe.enc.A256GCM).compact()
                 fail()
             } catch (IllegalArgumentException expected) {
                 assertEquals DefaultJwtBuilder.PRIV_KEY_ENC_MSG, expected.getMessage()
@@ -116,7 +116,7 @@ class Issue365Test {
     @Test
     void testDecryptWithPublicKey() {
         def pub = TestKeys.RS256.pair.public
-        String jwe = Jwts.builder().issuer('me').encryptWith(pub, Jwe.alg.RSA1_5, Jwe.enc.A256GCM).compact()
+        String jwe = Jwt.builder().issuer('me').encryptWith(pub, Jwe.alg.RSA1_5, Jwe.enc.A256GCM).compact()
         try {
             Jwt.parser().decryptWith(new TestPublicKey()).build().parseEncryptedClaims(jwe)
             fail()
@@ -128,7 +128,7 @@ class Issue365Test {
     @Test
     void testDecryptWithKeyLocatorPublicKey() {
         def pub = TestKeys.RS256.pair.public
-        String jwe = Jwts.builder().issuer('me').encryptWith(pub, Jwe.alg.RSA1_5, Jwe.enc.A256GCM).compact()
+        String jwe = Jwt.builder().issuer('me').encryptWith(pub, Jwe.alg.RSA1_5, Jwe.enc.A256GCM).compact()
         try {
             Jwt.parser().keyLocator(new Locator<Key>() {
                 @Override

--- a/impl/src/test/groovy/io/jsonwebtoken/issues/Issue365Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/issues/Issue365Test.groovy
@@ -73,7 +73,7 @@ class Issue365Test {
             def pair = TestKeys.forAlgorithm(alg).pair
             String jws = Jwts.builder().issuer('me').signWith(pair.private).compact()
             try {
-                Jwts.parser().verifyWith(pair.private).build().parseSignedClaims(jws)
+                Jwt.parser().verifyWith(pair.private).build().parseSignedClaims(jws)
                 fail()
             } catch (IllegalArgumentException expected) {
                 assertEquals DefaultJwtParser.PRIV_KEY_VERIFY_MSG, expected.getMessage()
@@ -87,7 +87,7 @@ class Issue365Test {
             def pair = TestKeys.forAlgorithm(alg).pair
             String jws = Jwts.builder().issuer('me').signWith(pair.private).compact()
             try {
-                Jwts.parser().keyLocator(new Locator<Key>() {
+                Jwt.parser().keyLocator(new Locator<Key>() {
                     @Override
                     Key locate(Header header) {
                         return pair.private
@@ -118,7 +118,7 @@ class Issue365Test {
         def pub = TestKeys.RS256.pair.public
         String jwe = Jwts.builder().issuer('me').encryptWith(pub, Jwe.alg.RSA1_5, Jwe.enc.A256GCM).compact()
         try {
-            Jwts.parser().decryptWith(new TestPublicKey()).build().parseEncryptedClaims(jwe)
+            Jwt.parser().decryptWith(new TestPublicKey()).build().parseEncryptedClaims(jwe)
             fail()
         } catch (IllegalArgumentException expected) {
             assertEquals DefaultJwtParser.PUB_KEY_DECRYPT_MSG, expected.getMessage()
@@ -130,7 +130,7 @@ class Issue365Test {
         def pub = TestKeys.RS256.pair.public
         String jwe = Jwts.builder().issuer('me').encryptWith(pub, Jwe.alg.RSA1_5, Jwe.enc.A256GCM).compact()
         try {
-            Jwts.parser().keyLocator(new Locator<Key>() {
+            Jwt.parser().keyLocator(new Locator<Key>() {
                 @Override
                 Key locate(Header header) {
                     return pub

--- a/impl/src/test/groovy/io/jsonwebtoken/issues/Issue438Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/issues/Issue438Test.groovy
@@ -16,7 +16,6 @@
 package io.jsonwebtoken.issues
 
 import io.jsonwebtoken.Jwt
-import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.UnsupportedJwtException
 import io.jsonwebtoken.impl.security.TestKeys
 import org.junit.Test
@@ -28,7 +27,7 @@ class Issue438Test {
 
     @Test(expected = UnsupportedJwtException /* not IllegalArgumentException */)
     void testIssue438() {
-        String jws = Jwts.builder().issuer('test').signWith(TestKeys.RS256.pair.private).compact()
+        String jws = Jwt.builder().issuer('test').signWith(TestKeys.RS256.pair.private).compact()
         Jwt.parser().verifyWith(TestKeys.HS256).build().parseSignedClaims(jws)
     }
 }

--- a/impl/src/test/groovy/io/jsonwebtoken/issues/Issue438Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/issues/Issue438Test.groovy
@@ -15,6 +15,7 @@
  */
 package io.jsonwebtoken.issues
 
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.UnsupportedJwtException
 import io.jsonwebtoken.impl.security.TestKeys
@@ -28,6 +29,6 @@ class Issue438Test {
     @Test(expected = UnsupportedJwtException /* not IllegalArgumentException */)
     void testIssue438() {
         String jws = Jwts.builder().issuer('test').signWith(TestKeys.RS256.pair.private).compact()
-        Jwts.parser().verifyWith(TestKeys.HS256).build().parseSignedClaims(jws)
+        Jwt.parser().verifyWith(TestKeys.HS256).build().parseSignedClaims(jws)
     }
 }

--- a/impl/src/test/groovy/io/jsonwebtoken/issues/Issue858Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/issues/Issue858Test.groovy
@@ -15,6 +15,7 @@
  */
 package io.jsonwebtoken.issues
 
+import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import org.junit.Test
 
@@ -32,7 +33,7 @@ class Issue858Test {
                 .claim('another', null) // null not allowed (same behavior since <= 0.11.5), won't be added
                 .compact()
 
-        def claims = Jwts.parser().unsecured().build().parseUnsecuredClaims(jwt).getPayload()
+        def claims = Jwt.parser().unsecured().build().parseUnsecuredClaims(jwt).getPayload()
         assertEquals 4, claims.size()
         assertEquals 'Joe', claims.getSubject()
         assertEquals '', claims.get('foo')

--- a/impl/src/test/groovy/io/jsonwebtoken/issues/Issue858Test.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/issues/Issue858Test.groovy
@@ -16,7 +16,6 @@
 package io.jsonwebtoken.issues
 
 import io.jsonwebtoken.Jwt
-import io.jsonwebtoken.Jwts
 import org.junit.Test
 
 import static org.junit.Assert.assertEquals
@@ -25,7 +24,7 @@ class Issue858Test {
 
     @Test
     void testEmptyAndNullEntries() {
-        def jwt = Jwts.builder()
+        def jwt = Jwt.builder()
                 .subject('Joe')
                 .claim('foo', '')       // empty allowed
                 .claim('list', [])            // empty allowed

--- a/impl/src/test/groovy/io/jsonwebtoken/security/KeysTest.groovy
+++ b/impl/src/test/groovy/io/jsonwebtoken/security/KeysTest.groovy
@@ -286,7 +286,7 @@ class KeysTest {
     void testAssociateWithECKey() {
         def priv = new TestPrivateKey(algorithm: 'EC')
         def pub = TestKeys.ES256.pair.public as ECPublicKey
-        def result = Keys.builder(priv).publicKey(pub).build()
+        def result = PrivateKeyBuilder.with(priv).publicKey(pub).build()
         assertTrue result instanceof PrivateECKey
         def key = result as PrivateECKey
         assertSame priv, key.getKey()
@@ -304,6 +304,7 @@ class KeysTest {
     @Test
     void testAssociateWithKeyThatDoesntNeedToBeWrapped() {
         def pair = TestKeys.RS256.pair
+        assertSame pair.private, PrivateKeyBuilder.with(pair.private).publicKey(pair.public).build()
         assertSame pair.private, Keys.builder(pair.private).publicKey(pair.public).build()
     }
 }

--- a/tdjar/src/test/groovy/io/jsonwebtoken/all/BasicTest.groovy
+++ b/tdjar/src/test/groovy/io/jsonwebtoken/all/BasicTest.groovy
@@ -16,7 +16,6 @@
 package io.jsonwebtoken.all
 
 import io.jsonwebtoken.*
-import io.jsonwebtoken.security.Keys
 import org.junit.Test
 
 import static org.hamcrest.CoreMatchers.equalTo
@@ -30,17 +29,16 @@ class BasicTest {
 
     @Test
     void basicUsageTest() {
-        def key = Keys.secretKeyFor(SignatureAlgorithm.HS256)
+        def alg = Jws.alg.HS256
+        def key = alg.key().build()
 
         String token = Jwts.builder()
-            .setSubject("test-user")
-            .claim("test", "basicUsageTest")
-            .signWith(key, SignatureAlgorithm.HS256)
-            .compact()
+                .subject("test-user")
+                .claim("test", "basicUsageTest")
+                .signWith(key, alg)
+                .compact()
 
-        JwtParser parser = Jwts.parser()
-            .setSigningKey(key)
-            .build()
+        JwtParser parser = Jwt.parser().verifyWith(key).build()
 
         Jwt<Header, Claims> result = parser.parseSignedClaims(token)
         assertThat result, notNullValue()

--- a/tdjar/src/test/groovy/io/jsonwebtoken/all/BasicTest.groovy
+++ b/tdjar/src/test/groovy/io/jsonwebtoken/all/BasicTest.groovy
@@ -32,7 +32,7 @@ class BasicTest {
         def alg = Jws.alg.HS256
         def key = alg.key().build()
 
-        String token = Jwts.builder()
+        String token = Jwt.builder()
                 .subject("test-user")
                 .claim("test", "basicUsageTest")
                 .signWith(key, alg)

--- a/tdjar/src/test/java/io/jsonwebtoken/all/JavaReadmeTest.java
+++ b/tdjar/src/test/java/io/jsonwebtoken/all/JavaReadmeTest.java
@@ -19,7 +19,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwe;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwt;
-import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.AeadAlgorithm;
 import io.jsonwebtoken.security.Curve;
 import io.jsonwebtoken.security.EcPrivateJwk;
@@ -68,7 +67,7 @@ public class JavaReadmeTest {
         String message = "Hello World. It's a Beautiful Day!";
         byte[] content = message.getBytes(StandardCharsets.UTF_8);
 
-        String jws = Jwts.builder().signWith(testKey) // #1
+        String jws = Jwt.builder().signWith(testKey) // #1
                 .content(content)                     // #2
                 .encodePayload(false)            // #3
                 .compact();
@@ -90,7 +89,7 @@ public class JavaReadmeTest {
 
         String claimsString = "{\"sub\":\"joe\",\"iss\":\"me\"}";
 
-        String jws = Jwts.builder().signWith(testKey) // #1
+        String jws = Jwt.builder().signWith(testKey) // #1
                 .content(claimsString)                // #2
                 .encodePayload(false)            // #3
                 .compact();
@@ -124,7 +123,7 @@ public class JavaReadmeTest {
         byte[] content = message.getBytes(StandardCharsets.UTF_8);
 
         // Create the compact JWS:
-        String jws = Jwts.builder().content(content, "text/plain").signWith(key, alg).compact();
+        String jws = Jwt.builder().content(content, "text/plain").signWith(key, alg).compact();
 
         // Parse the compact JWS:
         content = Jwt.parser().verifyWith(key).build().parseSignedContent(jws).getPayload();
@@ -142,7 +141,7 @@ public class JavaReadmeTest {
         KeyPair pair = alg.keyPair().build();
 
         // Bob creates the compact JWS with his RSA private key:
-        String jws = Jwts.builder().subject("Alice")
+        String jws = Jwt.builder().subject("Alice")
                 .signWith(pair.getPrivate(), alg) // <-- Bob's RSA private key
                 .compact();
 
@@ -164,7 +163,7 @@ public class JavaReadmeTest {
         KeyPair pair = alg.keyPair().build();
 
         // Bob creates the compact JWS with his EC private key:
-        String jws = Jwts.builder().subject("Alice")
+        String jws = Jwt.builder().subject("Alice")
                 .signWith(pair.getPrivate(), alg) // <-- Bob's EC private key
                 .compact();
 
@@ -186,7 +185,7 @@ public class JavaReadmeTest {
         KeyPair pair = curve.keyPair().build();
 
         // Bob creates the compact JWS with his Edwards Curve private key:
-        String jws = Jwts.builder().subject("Alice")
+        String jws = Jwt.builder().subject("Alice")
                 .signWith(pair.getPrivate(), Jws.alg.EdDSA) // <-- Bob's Edwards Curve private key w/ EdDSA
                 .compact();
 
@@ -212,7 +211,7 @@ public class JavaReadmeTest {
         byte[] content = message.getBytes(StandardCharsets.UTF_8);
 
         // Create the compact JWE:
-        String jwe = Jwts.builder().content(content, "text/plain").encryptWith(key, enc).compact();
+        String jwe = Jwt.builder().content(content, "text/plain").encryptWith(key, enc).compact();
 
         // Parse the compact JWE:
         content = Jwt.parser().decryptWith(key).build().parseEncryptedContent(jwe).getPayload();
@@ -234,7 +233,7 @@ public class JavaReadmeTest {
         AeadAlgorithm enc = Jwe.enc.A256GCM; //or A192GCM, A128GCM, A256CBC-HS512, etc...
 
         // Bob creates the compact JWE with Alice's RSA public key so only she may read it:
-        String jwe = Jwts.builder().audience().add("Alice").and()
+        String jwe = Jwt.builder().audience().add("Alice").and()
                 .encryptWith(pair.getPublic(), alg, enc) // <-- Alice's RSA public key
                 .compact();
 
@@ -259,7 +258,7 @@ public class JavaReadmeTest {
         AeadAlgorithm enc = Jwe.enc.A256GCM; //or A192GCM, A128GCM, A256CBC-HS512, etc...
 
         // Create the compact JWE:
-        String jwe = Jwts.builder().issuer("me").encryptWith(key, alg, enc).compact();
+        String jwe = Jwt.builder().issuer("me").encryptWith(key, alg, enc).compact();
 
         // Parse the compact JWE:
         String issuer = Jwt.parser().decryptWith(key).build()
@@ -282,7 +281,7 @@ public class JavaReadmeTest {
         AeadAlgorithm enc = Jwe.enc.A256GCM; //or A192GCM, A128GCM, A256CBC-HS512, etc...
 
         // Bob creates the compact JWE with Alice's EC public key so only she may read it:
-        String jwe = Jwts.builder().audience().add("Alice").and()
+        String jwe = Jwt.builder().audience().add("Alice").and()
                 .encryptWith(pair.getPublic(), alg, enc) // <-- Alice's EC public key
                 .compact();
 
@@ -318,7 +317,7 @@ public class JavaReadmeTest {
         AeadAlgorithm enc = Jwe.enc.A256GCM; //or A192GCM, A128GCM, A256CBC-HS512, etc...
 
         // Create the compact JWE:
-        String jwe = Jwts.builder().issuer("me")
+        String jwe = Jwt.builder().issuer("me")
                 // Optional work factor is specified in the header:
                 //.header().pbes2Count(pbkdf2Iterations).and()
                 .encryptWith(password, alg, enc)

--- a/tdjar/src/test/java/io/jsonwebtoken/all/JavaReadmeTest.java
+++ b/tdjar/src/test/java/io/jsonwebtoken/all/JavaReadmeTest.java
@@ -18,6 +18,7 @@ package io.jsonwebtoken.all;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwe;
 import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.AeadAlgorithm;
 import io.jsonwebtoken.security.Curve;
@@ -72,7 +73,7 @@ public class JavaReadmeTest {
                 .encodePayload(false)            // #3
                 .compact();
 
-        Jws<byte[]> parsed = Jwts.parser().verifyWith(testKey) // 1
+        Jws<byte[]> parsed = Jwt.parser().verifyWith(testKey) // 1
                 .build()
                 .parseSignedContent(jws, content);             // 2
 
@@ -94,7 +95,7 @@ public class JavaReadmeTest {
                 .encodePayload(false)            // #3
                 .compact();
 
-        Jws<Claims> parsed = Jwts.parser().verifyWith(testKey) // 1
+        Jws<Claims> parsed = Jwt.parser().verifyWith(testKey) // 1
                 .critical().add("b64").and()                   // 2
                 .build()
                 .parseSignedClaims(jws);                          // 3
@@ -102,7 +103,7 @@ public class JavaReadmeTest {
         assert "joe".equals(parsed.getPayload().getSubject());
         assert "me".equals(parsed.getPayload().getIssuer());
 
-        parsed = Jwts.parser().verifyWith(testKey)
+        parsed = Jwt.parser().verifyWith(testKey)
                 .build()
                 .parseSignedClaims(jws, claimsString.getBytes(StandardCharsets.UTF_8)); // <---
 
@@ -126,7 +127,7 @@ public class JavaReadmeTest {
         String jws = Jwts.builder().content(content, "text/plain").signWith(key, alg).compact();
 
         // Parse the compact JWS:
-        content = Jwts.parser().verifyWith(key).build().parseSignedContent(jws).getPayload();
+        content = Jwt.parser().verifyWith(key).build().parseSignedContent(jws).getPayload();
 
         assert message.equals(new String(content, StandardCharsets.UTF_8));
     }
@@ -146,7 +147,7 @@ public class JavaReadmeTest {
                 .compact();
 
         // Alice receives and verifies the compact JWS came from Bob:
-        String subject = Jwts.parser()
+        String subject = Jwt.parser()
                 .verifyWith(pair.getPublic()) // <-- Bob's RSA public key
                 .build().parseSignedClaims(jws).getPayload().getSubject();
 
@@ -168,7 +169,7 @@ public class JavaReadmeTest {
                 .compact();
 
         // Alice receives and verifies the compact JWS came from Bob:
-        String subject = Jwts.parser()
+        String subject = Jwt.parser()
                 .verifyWith(pair.getPublic()) // <-- Bob's EC public key
                 .build().parseSignedClaims(jws).getPayload().getSubject();
 
@@ -190,7 +191,7 @@ public class JavaReadmeTest {
                 .compact();
 
         // Alice receives and verifies the compact JWS came from Bob:
-        String subject = Jwts.parser()
+        String subject = Jwt.parser()
                 .verifyWith(pair.getPublic()) // <-- Bob's Edwards Curve public key
                 .build().parseSignedClaims(jws).getPayload().getSubject();
 
@@ -214,7 +215,7 @@ public class JavaReadmeTest {
         String jwe = Jwts.builder().content(content, "text/plain").encryptWith(key, enc).compact();
 
         // Parse the compact JWE:
-        content = Jwts.parser().decryptWith(key).build().parseEncryptedContent(jwe).getPayload();
+        content = Jwt.parser().decryptWith(key).build().parseEncryptedContent(jwe).getPayload();
 
         assert message.equals(new String(content, StandardCharsets.UTF_8));
     }
@@ -238,7 +239,7 @@ public class JavaReadmeTest {
                 .compact();
 
         // Alice receives and decrypts the compact JWE:
-        Set<String> audience = Jwts.parser()
+        Set<String> audience = Jwt.parser()
                 .decryptWith(pair.getPrivate()) // <-- Alice's RSA private key
                 .build().parseEncryptedClaims(jwe).getPayload().getAudience();
 
@@ -261,7 +262,7 @@ public class JavaReadmeTest {
         String jwe = Jwts.builder().issuer("me").encryptWith(key, alg, enc).compact();
 
         // Parse the compact JWE:
-        String issuer = Jwts.parser().decryptWith(key).build()
+        String issuer = Jwt.parser().decryptWith(key).build()
                 .parseEncryptedClaims(jwe).getPayload().getIssuer();
 
         assert "me".equals(issuer);
@@ -286,7 +287,7 @@ public class JavaReadmeTest {
                 .compact();
 
         // Alice receives and decrypts the compact JWE:
-        Set<String> audience = Jwts.parser()
+        Set<String> audience = Jwt.parser()
                 .decryptWith(pair.getPrivate()) // <-- Alice's EC private key
                 .build().parseEncryptedClaims(jwe).getPayload().getAudience();
 
@@ -324,7 +325,7 @@ public class JavaReadmeTest {
                 .compact();
 
         // Parse the compact JWE:
-        String issuer = Jwts.parser().decryptWith(password)
+        String issuer = Jwt.parser().decryptWith(password)
                 .build().parseEncryptedClaims(jwe).getPayload().getIssuer();
 
         assert "me".equals(issuer);


### PR DESCRIPTION
Continued work to adopt Java 8 interface static factory methods and deprecate corresponding `Jwts.*` and `Jwks.*` concepts.